### PR TITLE
Remove GAP name argument from JuliaBindCFunction

### DIFF
--- a/JuliaInterface/example/gap_function_call.gi
+++ b/JuliaInterface/example/gap_function_call.gi
@@ -4,10 +4,10 @@ dirs:= DirectoriesPackageLibrary( "JuliaInterface", "example" );
 
 JuliaIncludeFile( Filename( dirs, "gap_function_call.jl" ) );
 
-IsPrime_jl := JuliaBindCFunction( "IsPrimeInt", "IsPrime_jl", 1, [ "n" ] );
+IsPrime_jl := JuliaBindCFunction( "IsPrimeInt", 1, [ "n" ] );
 
 IsPrime_jl( 10 );
 
-Power2 := JuliaBindCFunction( "Power2", "Power2", 1, ["n"] );
+Power2 := JuliaBindCFunction( "Power2", 1, ["n"] );
 
 Power2( 10 );

--- a/JuliaInterface/example/orbits.gi
+++ b/JuliaInterface/example/orbits.gi
@@ -20,7 +20,7 @@ end;
 example_dirs := DirectoriesPackageLibrary( "JuliaInterface", "example" );
 JuliaIncludeFile( Filename( example_dirs, "orbits.jl" ) );
 
-bahn_jl := JuliaBindCFunction( "bahn", "bahn_jl", 3, [ "elem","gens","oper" ] );
+bahn_jl := JuliaBindCFunction( "bahn", 3, [ "elem","gens","oper" ] );
 
 grp := GeneratorsOfGroup( SymmetricGroup( 10000 ) );
 elem := 1;

--- a/JuliaInterface/gap/BindCFunction.gi
+++ b/JuliaInterface/gap/BindCFunction.gi
@@ -9,7 +9,7 @@
 #############################################################################
 
 InstallGlobalFunction( JuliaBindCFunction,
-  function( julia_name, gap_name, nr_args, arg_names )
+  function( julia_name, nr_args, arg_names )
     local cfunction_call_string, i, cfunc;
 
     if not IsString( julia_name ) then
@@ -17,18 +17,13 @@ InstallGlobalFunction( JuliaBindCFunction,
         return;
     fi;
 
-    if not IsString( gap_name ) then
-        Error( "second argument must be a string" );
-        return;
-    fi;
-
     if not IsInt( nr_args ) or not nr_args >= 0 then
-        Error( "third argument must be an non-negative integer" );
+        Error( "second argument must be an non-negative integer" );
         return;
     fi;
 
     if not IsList( arg_names ) then
-        Error( "fourth argument must be a list of strings" );
+        Error( "third argument must be a list of strings" );
         return;
     fi;
 
@@ -40,7 +35,7 @@ InstallGlobalFunction( JuliaBindCFunction,
     Remove( cfunction_call_string );
     cfunction_call_string := Concatenation( cfunction_call_string, "))" );
 
-    return __JuliaBindCFunction( gap_name, cfunction_call_string, nr_args, arg_names );
+    return __JuliaBindCFunction( cfunction_call_string, nr_args, arg_names );
 
 end );
 

--- a/JuliaInterface/src/JuliaInterface.c
+++ b/JuliaInterface/src/JuliaInterface.c
@@ -571,19 +571,12 @@ typedef Obj (* GVarFunc)(/*arguments*/);
 // FIXME: Provide better name
 
 
-Obj __JuliaBindCFunction( Obj self, Obj string_name, Obj cfunction_string,
+Obj __JuliaBindCFunction( Obj self, Obj cfunction_string,
                                            Obj number_args_gap, Obj arg_names_gap )
 {
     void* ccall_pointer = jl_unbox_voidpointer( jl_eval_string( CSTR_STRING( cfunction_string ) ) );
     size_t number_args = INT_INTOBJ( number_args_gap );
-    // char* arg_names = CSTR_STRING( arg_names_gap );
-    // StructGVarFunc current_function[] = {
-    //     GVAR_FUNC_TABLE_ENTRY_WITH_NAME( "JuliaInterface.c", ccall_pointer,
-    //                                      number_args, arg_names, CSTR_STRING( string_name ) ),
-    //     { 0 } };
-    // InitHdlrFuncsFromTable( current_function );
-    // InitGVarFuncsFromTable( current_function );
-    return NewFunction(string_name, number_args, arg_names_gap, ccall_pointer );
+    return NewFunction(0, number_args, arg_names_gap, ccall_pointer );
 }
 
 #define GVAR_FUNC_TABLE_ENTRY(srcfile, name, nparam, params) \
@@ -608,7 +601,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC_TABLE_ENTRY("JuliaInterface.c", __JuliaGetGlobalVariable, 1, "name" ),
     GVAR_FUNC_TABLE_ENTRY("JuliaInterface.c", __JuliaGetGlobalVariableByModule, 2, "name,module" ),
     GVAR_FUNC_TABLE_ENTRY("JuliaInterface.c", JuliaGetFieldOfObject, 2, "obj,name" ),
-    GVAR_FUNC_TABLE_ENTRY("JuliaInterface.c", __JuliaBindCFunction, 4, "string_name,cfunction_string,number_args_gap,arg_names_gap" ),
+    GVAR_FUNC_TABLE_ENTRY("JuliaInterface.c", __JuliaBindCFunction, 3, "cfunction_string,number_args_gap,arg_names_gap" ),
     GVAR_FUNC_TABLE_ENTRY("JuliaInterface.c", __JuliaSetGAPFuncAsJuliaObjFunc, 2, "func,name"),
     GVAR_FUNC_TABLE_ENTRY("JuliaInterface.c", JuliaTuple, 1, "list"),
     GVAR_FUNC_TABLE_ENTRY("JuliaInterface.c", JuliaSymbol, 1, "name"),

--- a/JuliaInterface/src/JuliaInterface.h
+++ b/JuliaInterface/src/JuliaInterface.h
@@ -96,7 +96,7 @@ Obj JuliaGetFieldOfObject( Obj self, Obj super_obj, Obj field_name );
 
 Obj __JuliaSetGAPFuncAsJuliaObjFunc( Obj self, Obj func, Obj name, Obj number_args );
 
-Obj __JuliaBindCFunction( Obj self, Obj string_name, Obj cfunction_string,
+Obj __JuliaBindCFunction( Obj self, Obj cfunction_string,
                                            Obj number_args_gap, Obj arg_names_gap );
 
 // From julia_macros.c


### PR DESCRIPTION
It is not needed, a GAP function may have an empty name. Once
you assign it to a global variable, it will get get the name of that
gvar.