### PR TITLE
Replace GAP orbit implementation

### DIFF
--- a/JuliaInterface/example/orbits.gi
+++ b/JuliaInterface/example/orbits.gi
@@ -1,30 +1,29 @@
 LoadPackage( "JuliaInterface" );
 
 bahn := function( element, generators, action )
-  local return_set, work_set, current_element, current_generator, current_result;
-    work_set := [ element ];
-    return_set := [ element ];
-    while not IsEmpty( work_set ) do
-        current_element := Remove( work_set );
-        for current_generator in generators do
-            current_result := action( current_element, current_generator );
-            if not ForAny( return_set, i -> i = current_result ) then
-                Add( work_set, current_result );
-                Add( return_set, current_result );
-            fi;
-        od;
+  local orb, dict, b, g, c;
+  orb := [ element ];
+  dict := NewDictionary(element, true);
+  AddDictionary(dict, element, 1);
+  for b in orb do
+    for g in generators do
+      c := action(b, g);
+      if not KnowsDictionary(dict, c) then
+        Add(orb, c);
+        AddDictionary(dict, c, Length(orb));
+      fi;
     od;
-    return return_set;
+  od;
+  return orb;
 end;
 
 example_dirs := DirectoriesPackageLibrary( "JuliaInterface", "example" );
 JuliaIncludeFile( Filename( example_dirs, "orbits.jl" ) );
 
-bahn_jl := JuliaBindCFunction( "bahn", 3, [ "elem","gens","oper" ] );
+bahn_jl := JuliaFunction( "bahn" );
 
-grp := GeneratorsOfGroup( SymmetricGroup( 10000 ) );
-elem := 1;
-action := function( elem, grp_elem ) return elem^grp_elem; end;
+grp := SymmetricGroup( 10000 );
+gens := GeneratorsOfGroup( grp );;
 
-bahn(elem,grp,action);;time;
-bahn_jl(elem,grp,action);;time;
+bahn(1, gens, OnPoints);;time;
+bahn_jl(1, gens, OnPoints);;time;

--- a/JuliaInterface/example/orbits.jl
+++ b/JuliaInterface/example/orbits.jl
@@ -1,25 +1,15 @@
 function bahn( element, generators, action )
-    work_set = [element]
-    return_set = [element]
-    action_func = GAP.GapFunc( action )
-    generator_length = length(generators)
-    while length(work_set) != 0
-        current_element = pop!(work_set)
-        for current_generator_number = 1:generator_length
-            current_generator = generators[current_generator_number]
-            current_result = action(current_element,current_generator)
-            is_in_set = false
-            for i in return_set
-                if i.ptr == current_result.ptr
-                    is_in_set = true
-                    break
-                end
-            end
-            if ! is_in_set
-                push!( work_set, current_result )
-                push!( return_set, current_result )
+    orb = [ element ]
+    dict = Dict(element=>1)
+    for b in orb
+        for g in generators
+            c = action(b, g)
+            x = get(dict, c, nothing)
+            if x == nothing
+                push!( orb, c )
+                dict[c] = length(orb)
             end
         end
     end
-    return ccall(:NewJuliaObj,Ptr{CVoid},(Ptr{CVoid},),pointer_from_objref(return_set))
+    return orb
 end


### PR DESCRIPTION
The new one is much faster. Indeed, for me it is faster than the Julia
version. However, that also could be optimized; the main reason I did not yet
do that is that one needs to access a hash function for the orbit elements
(here: GAP integers), and I did not yet bother to figure out how to do that.