### PR TITLE
First version of scoping

### DIFF
--- a/pkg/GAPJulia/JuliaInterface/julia/gap.jl
+++ b/pkg/GAPJulia/JuliaInterface/julia/gap.jl
@@ -68,3 +68,29 @@ for (left, right) in typecombinations
         end
     end
 end
+
+
+"""
+    @gap <obj>
+    @gap(<obj>)
+
+Executes <obj> directly in GAP, as if `GAP.EvalString("<obj>")` was called.
+Can be used for creating GAP literals directly from Julia.
+
+    julia> @gap (1,2,3)
+    GAP: (1,2,3)
+    julia> @gap SymmetricGroup(3)
+    GAP: SymmetricGroup( [ 1 .. 3 ] )
+    julia> @gap(SymmetricGroup)(3)
+    GAP: SymmetricGroup( [ 1 .. 3 ] )
+
+Note that the last two examples have a slight syntactical, and therefore also
+a semantical difference. The first one executes the string `SymmetricGroup(3)`
+directly inside GAP. The second example returns the function `SymmetricGroup`
+via `@gap(SymmetricGroup)`, then calls that function with the argument `3`.
+"""
+macro gap(str)
+    return EvalString(string(str))
+end
+
+export @gap

--- a/pkg/GAPJulia/JuliaInterface/julia/gap.jl
+++ b/pkg/GAPJulia/JuliaInterface/julia/gap.jl
@@ -94,3 +94,63 @@ macro gap(str)
 end
 
 export @gap
+
+"""
+    LoadPackageAndExposeGlobals(package::String, mod::String; all_globals::Bool = false)
+    LoadPackageAndExposeGlobals(package::String, mod::Module = Main; all_globals::Bool = false)
+
+`LoadPackageAndExposeGlobals` loads `package` into GAP via `LoadPackage`,
+and stores all newly defined GAP globals as globals in the module `mod`. If `mod` is
+a string, the function creates a new module, if `mod` is a Module, it uses `mod` directly.
+
+The function is intended to be used for creating mock modules for GAP packages.
+If you load the package `CAP` via
+
+    LoadPackageAndExposeGlobals( "CAP", "CAP" )
+
+you can use CAP commands via
+
+    CAP.PreCompose( a, b )
+
+"""
+function LoadPackageAndExposeGlobals(package::String, mod::String; all_globals::Bool = false)
+    mod_sym = Symbol(mod)
+    Base.MainInclude.eval(:(
+        module $(mod_sym)
+            import GAP
+        end
+    ))
+    ## Adds the new module to the Main module, so it is directly accessible in the julia REPL
+    mod_mod = Base.MainInclude.eval(:(Main.$(mod_sym)))
+
+    ## We need to call `invokelatest` as the module `mod_mod` was only created during the
+    ## call of this function in a different module, so its world age is higher than the
+    ## function calls world age.
+    Base.invokelatest(LoadPackageAndExposeGlobals, package, mod_mod; all_globals = all_globals)
+end
+
+function LoadPackageAndExposeGlobals(package::String, mod::Module; all_globals::Bool = false)
+    current_gvar_list = EvalString("ShallowCopy(NamesGVars())")
+    load_package = EvalString("LoadPackage(\"$package\")")
+    if load_package == Globals.fail
+        error("cannot load package $package")
+    end
+    new_gvar_list = nothing
+    if all_globals
+        new_gvar_list = Globals.NamesGVars()
+    else
+        new_gvar_list = Globals.Difference(Globals.NamesGVars(),current_gvar_list)
+    end
+    new_symbols = gap_to_julia(Array{Symbol,1},new_gvar_list)
+    for sym in new_symbols
+        try
+            mod.eval(:(
+                $(sym)=GAP.Globals.$(sym)
+            ))
+        catch
+        end
+    end
+end
+
+export LoadPackageAndExposeGlobals
+

--- a/test/compat.jl
+++ b/test/compat.jl
@@ -1,0 +1,12 @@
+@testset "compat" begin
+
+    x = @gap (1,2,3)
+    @test x == GAP.EvalString("(1,2,3)")
+    x = @gap((1,2,3))
+    @test x == GAP.EvalString("(1,2,3)")
+    x = @gap [1,2,3]
+    @test x == GAP.EvalString("[1,2,3]")
+    x = @gap(SymmetricGroup)(3)
+    @test GAP.Globals.Size(x) == 6
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,3 +5,4 @@ using GAP
 include("basics.jl")
 include("convenience.jl")
 include("conversion.jl")
+include("compat.jl")


### PR DESCRIPTION
Which leaks memory and is generally a bad choice. We should just use "import/export/using" instead:

```
julia> using GAP
Adding path /home/sebastian/Software/GAPJulia/gap/.libs to DL_LOAD_PATH
 ┌───────┐   GAP 4.dev of today
 │  GAP  │   https://www.gap-system.org
 └───────┘   Architecture: x86_64-pc-linux-gnu-julia64-kv6
 Configuration:  gmp 6.1.2, Julia GC, Julia 1.1.0, readline
 Loading the library and packages ...
 Packages:   GAPDoc 1.6.2.dev, PrimGrp 3.3.1, SmallGrp 1.3, TransGrp 2.0.4
 Try '??help' for help. See also '?copyright', '?cite' and '?authors'

julia> import Polymake
polymake version 3.4
Copyright (c) 1997-2019
Ewgenij Gawrilow, Michael Joswig (TU Berlin)
https://polymake.org

This is free software licensed under GPL; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


julia> GAP.@gap_scope Polymake begin
           x = Polytope.cube(4)
       end

julia> x
type: Polytope<Rational>
description: cube of dimension 4
```