### PR TITLE
in show, use StringView not String

### DIFF
--- a/src/gap2.jl
+++ b/src/gap2.jl
@@ -1,7 +1,7 @@
 import Base: convert, getindex, setindex!, length, show
 
 function Base.show( io::IO, obj::Union{GapObj,FFE} )
-    str = Globals.String( obj )
+    str = Globals.StringView( obj )
     stri = CSTR_STRING( str )
     print(io,"GAP: $stri")
 end


### PR DESCRIPTION
I think that the `show` method for GAP objects fits better to GAP's `ViewObj` than to `String`.
Ideally, `ViewString` should be called but this is not (yet) supported for enough GAP objects.
Thus `StringView` is a reasonable temporary alternative.
(Cf. https://github.com/gap-packages/JupyterKernel/pull/104.)