### PR TITLE
Remove GAPInputType

### DIFF
--- a/pkg/GAPJulia/JuliaInterface/julia/gap.jl
+++ b/pkg/GAPJulia/JuliaInterface/julia/gap.jl
@@ -3,10 +3,7 @@ import Base: convert, getindex, setindex!, length, show
 const True = Globals.ReturnTrue()
 const False = Globals.ReturnFalse()
 
-const GAPInputType_internal = Union{MPtr,FFE}
-const GAPInputType = Union{GAPInputType_internal,Int64,Bool}
-
-const Obj = Union{GAPInputType,Nothing}
+const Obj = Union{MPtr,FFE,Int64,Bool,Nothing}
 
 function Base.show( io::IO, obj::Union{MPtr,FFE} )
     str = Globals.String( obj )
@@ -41,16 +38,23 @@ Base.setproperty!(x::MPtr, f::Symbol, v) = Globals.ASS_REC(x, RNamObj(f), v)
 Base.setproperty!(x::MPtr, f::Union{AbstractString,Int64}, v) = Globals.ASS_REC(x, RNamObj(f), v)
 
 #
-Base.zero(x::GAPInputType_internal) = Globals.ZERO(x)
-Base.one(x::GAPInputType_internal) = Globals.ONE(x)
-Base.:-(x::GAPInputType_internal) = Globals.AINV(x)
+Base.zero(x::Union{MPtr,FFE}) = Globals.ZERO(x)
+Base.one(x::Union{MPtr,FFE}) = Globals.ONE(x)
+Base.:-(x::Union{MPtr,FFE}) = Globals.AINV(x)
 
 #
-typecombinations = ((:GAPInputType_internal,:GAPInputType_internal),
-                    (:GAPInputType_internal,:Int64),
-                    (:Int64,:GAPInputType_internal),
-                    (:GAPInputType_internal,:Bool),
-                    (:Bool,:GAPInputType_internal))
+typecombinations = ((:MPtr,:MPtr),
+                    (:FFE,:FFE),
+                    (:MPtr,:FFE),
+                    (:FFE,:MPtr),
+                    (:MPtr,:Int64),
+                    (:Int64,:MPtr),
+                    (:FFE,:Int64),
+                    (:Int64,:FFE),
+                    (:MPtr,:Bool),
+                    (:Bool,:MPtr),
+                    (:FFE,:Bool),
+                    (:Bool,:FFE))
 function_combinations = ((:+,:SUM),
                          (:-,:DIFF),
                          (:*,:PROD),

--- a/pkg/GAPJulia/JuliaInterface/julia/gap_to_julia.jl
+++ b/pkg/GAPJulia/JuliaInterface/julia/gap_to_julia.jl
@@ -30,10 +30,10 @@ function gap_to_julia(t::T, x::Any) where T <: Type
 end
 
 ## Default
-gap_to_julia(::Type{Any},         x::GAPInputType) = gap_to_julia(x)
-gap_to_julia(::Type{Any},         x::Any         ) = x
-gap_to_julia(::T,                 x::Nothing     ) where T <: Type = nothing
-gap_to_julia(::Type{Any},         x::Nothing     ) = nothing
+gap_to_julia(::Type{Any}, x::MPtr) = gap_to_julia(x)
+gap_to_julia(::Type{Any}, x::Any) = x
+gap_to_julia(::T,         x::Nothing) where T <: Type = nothing
+gap_to_julia(::Type{Any}, x::Nothing) = nothing
 
 ## Integers
 gap_to_julia(::Type{Int128} ,x::Int64) = trunc(Int128 ,x)

--- a/pkg/GAPJulia/JuliaInterface/julia/julia_to_gap.jl
+++ b/pkg/GAPJulia/JuliaInterface/julia/julia_to_gap.jl
@@ -12,12 +12,14 @@ of input data, by converting egal data to identical objects in GAP.
 
 
 ## Default
-julia_to_gap(x::GAPInputType) = x
+julia_to_gap(x::MPtr) = x
+julia_to_gap(x::FFE) = x
+julia_to_gap(x::Bool) = x
 
 
 ## Integers
 julia_to_gap(x::Int128) = MakeObjInt(BigInt(x)) # FIXME: inefficient hack
-#julia_to_gap(x::Int64)  = x
+julia_to_gap(x::Int64)  = x
 julia_to_gap(x::Int32)  = Int64(x)
 julia_to_gap(x::Int16)  = Int64(x)
 julia_to_gap(x::Int8)   = Int64(x)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -1,7 +1,8 @@
 @testset "conversion from GAP" begin
 
     ## Defaults
-    @test GAP.gap_to_julia(GAP.GAPInputType, true )
+    @test GAP.gap_to_julia(Any, true ) == true
+    @test GAP.gap_to_julia(GAP.Obj, true ) == true
     @test GAP.gap_to_julia(Any, "foo" ) == "foo"
     
     ## Integers


### PR DESCRIPTION
As a next step, we might want to rename `GAPInputType_internal` or even remove it as well (e.g. by using `Union{MPtr,FFE}` everywhere instead).