### PR TITLE
GAP.AssignGlobalVariable: allow non-mptr arguments

### DIFF
--- a/pkg/GAPJulia/JuliaInterface/julia/ccalls.jl
+++ b/pkg/GAPJulia/JuliaInterface/julia/ccalls.jl
@@ -2,7 +2,7 @@
 
 import Base: getproperty, propertynames
 
-function GET_FROM_GAP(ptr::Ptr{Cvoid})::Any
+function RAW_GAP_TO_JULIA(ptr::Ptr{Cvoid})::Any
     return ccall(:julia_gap,Any,(Ptr{Cvoid},),ptr)
 end
 
@@ -21,7 +21,7 @@ end
 function ValueGlobalVariable( name :: String )
     gvar = ccall( :GAP_ValueGlobalVariable, Ptr{Cvoid},
                       (Ptr{UInt8},),name)
-    return GET_FROM_GAP(gvar)
+    return RAW_GAP_TO_JULIA(gvar)
 end
 
 function CanAssignGlobalVariable(name::String)
@@ -75,7 +75,7 @@ function MakeObjInt(x::BigInt)
                Ptr{Cvoid},
                (Ptr{UInt64},Cint),
                x.d, x.size )
-    return GET_FROM_GAP( o )
+    return RAW_GAP_TO_JULIA( o )
 end
 
 function NEW_MACFLOAT(x::Float64)
@@ -107,7 +107,7 @@ function ElmList(x::MPtr,position)
                Ptr{Cvoid},
                (Any,Culong),
                x,Culong(position))
-    return GET_FROM_GAP(o)
+    return RAW_GAP_TO_JULIA(o)
 end
 
 function NewJuliaFunc(x::Function)
@@ -168,7 +168,7 @@ function getproperty(funcobj::GlobalsType, name::Symbol)
     end
 
     v = ccall(:ValGVar, Ptr{Cvoid}, (Cuint,), gvar)
-    v = GET_FROM_GAP(v)
+    v = RAW_GAP_TO_JULIA(v)
     if v == nothing
         error("GAP variable ", name, " not bound")
     end
@@ -177,6 +177,6 @@ end
 
 function propertynames(funcobj::GlobalsType,private)
     list = Globals.NamesGVars()
-    list_converted = gap_to_julia( Array{Symbol,1}, list )
+    list_converted = RAW_GAP_TO_JULIA( Array{Symbol,1}, list )
     return tuple(list_converted...)
 end

--- a/pkg/GAPJulia/JuliaInterface/julia/ccalls.jl
+++ b/pkg/GAPJulia/JuliaInterface/julia/ccalls.jl
@@ -6,6 +6,10 @@ function RAW_GAP_TO_JULIA(ptr::Ptr{Cvoid})::Any
     return ccall(:julia_gap,Any,(Ptr{Cvoid},),ptr)
 end
 
+function RAW_JULIA_TO_GAP(val::Any)::Ptr{Cvoid}
+    return ccall(:gap_julia,Ptr{Cvoid},(Any,),val)
+end
+
 function EvalStringEx( cmd :: String )
     res = ccall( :GAP_EvalString, Any, 
                  (Ptr{UInt8},),
@@ -29,12 +33,13 @@ function CanAssignGlobalVariable(name::String)
              (Ptr{UInt8},), name)
 end
 
-function AssignGlobalVariable(name::String, value::MPtr)
+function AssignGlobalVariable(name::String, value::Obj)
     if ! CanAssignGlobalVariable(name)
         error("cannot assing to $name in GAP")
     end
+    tmp = RAW_JULIA_TO_GAP(value)
     ccall(:GAP_AssignGlobalVariable, Cvoid,
-             (Ptr{UInt8}, Any), name, value)
+             (Ptr{UInt8}, Ptr{Cvoid}), name, tmp)
 end
 
 function MakeString( val::String )::MPtr

--- a/pkg/GAPJulia/JuliaInterface/julia/gap.jl
+++ b/pkg/GAPJulia/JuliaInterface/julia/gap.jl
@@ -1,7 +1,5 @@
 import Base: convert, getindex, setindex!, length, show
 
-const Obj = Union{MPtr,FFE,Int64,Bool,Nothing}
-
 function Base.show( io::IO, obj::Union{MPtr,FFE} )
     str = Globals.String( obj )
     stri = CSTR_STRING( str )

--- a/pkg/GAPJulia/JuliaInterface/julia/libgap.jl
+++ b/pkg/GAPJulia/JuliaInterface/julia/libgap.jl
@@ -11,6 +11,8 @@ import Base: length, convert
 
 const MPtr = Main.ForeignGAP.MPtr
 
+const Obj = Union{MPtr,FFE,Int64,Bool,Nothing}
+
 
 include( "ccalls.jl" )
 include( "gap.jl" )

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -23,6 +23,18 @@
     str = GAP.gap_to_julia(AbstractString, GAP.ValueGlobalVariable("IdentifierLetters"));
     @test str == "0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"
 
+    @test GAP.CanAssignGlobalVariable("Read") == false
+    @test GAP.CanAssignGlobalVariable("foobar")
+
+    GAP.AssignGlobalVariable("foobar", 42)
+    @test GAP.ValueGlobalVariable("foobar") == 42
+
+    GAP.AssignGlobalVariable("foobar", false)
+    @test GAP.ValueGlobalVariable("foobar") == false
+
+    GAP.AssignGlobalVariable("foobar", "julia_string")
+    @test GAP.ValueGlobalVariable("foobar") == "julia_string"
+
     @test string(GAP.Globals) == "\"table of global GAP objects\""
 
     @test string(GAP.julia_to_gap("x")) == "x"


### PR DESCRIPTION
It turns out that just changing the argument type to `Obj` is not quite enough...

This PR is based on PR #255. Once #255 is merged, it can be rebased.