### PR TITLE
Use ccache on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ branches:
 before_script:
   - unset JULIA_PROJECT
   - printenv | sort
+  - which gcc
+  - which g++
+  - which cc
+  - which c++
   - git show --pretty=fuller -s
   - mkdir -p coverage
   - export CFLAGS=--coverage; export LDFLAGS=--coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,13 @@ julia:
   - 1.1
   - nightly
 
+cache: ccache
+
 env:
   global:
     - MAKEFLAGS="-j4"
     - JULIA_TRACK_COVERAGE=yes
+    - PATH="/usr/lib/ccache:$PATH"
   matrix:
     - GAP=$HOME/.julia/gap.sh
       GAP_INSTALL_PACKAGES=debug


### PR DESCRIPTION
I am not sure whether this is actually useful, though, as we spend very little time compiling stuff (mostly GAP), and far more with downloading GAP, and running the tests.

It's a bit difficult to measure the benefit of this without merging it, though, as of course it only helps once the cache has been filled. As it is, I am not even fully sure this works as intended... 