### PR TITLE
Place `call_gap_func` in the main module to ensure it is accessible

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -120,7 +120,7 @@ function __init__()
     ## corresponding function call in in ccalls.jl (func::GapObj)(...)
     MPtr = Base.MainInclude.eval(:(ForeignGAP.MPtr))
     Base.MainInclude.eval(:(
-        (func::$MPtr)(args...; kwargs...) = GAP.call_gap_func(func, args...; kwargs...)
+        (func::$MPtr)(args...; kwargs...) = $(GAP.call_gap_func)(func, args...; kwargs...)
     ))
 end
 


### PR DESCRIPTION
even when the GAP module is not loaded into main (e.g., if loaded
from another module)