### PR TITLE
fix access to matrix entries for the GAP master branch

### DIFF
--- a/pkg/GAPJulia/JuliaInterface/gap/adapter.gi
+++ b/pkg/GAPJulia/JuliaInterface/gap/adapter.gi
@@ -55,19 +55,39 @@ InstallOtherMethod( \[\]\:\=,
 #
 # "matrices" / lists of lists
 #
+#TODO:  Remove the installations for '\[\]' and '\[\]\:\='
+#       as soon as a released GAP version supports '\[\,\]' and '\[\,\]\:\='.
+if IsBound( \[\,\] ) then
+InstallOtherMethod( \[\,\],
+    [ "IsJuliaObject", "IsPosInt and IsSmallIntRep",
+                       "IsPosInt and IsSmallIntRep" ],
+    function( obj, i, j )
+      return Julia.Base.getindex( obj, i, j );
+    end );
+else
 InstallOtherMethod( \[\],
     [ "IsJuliaObject", "IsPosInt and IsSmallIntRep",
                        "IsPosInt and IsSmallIntRep" ],
     function( obj, i, j )
       return Julia.Base.getindex( obj, i, j );
     end );
+fi;
 
+if IsBound( \[\,\]\:\= ) then
+InstallOtherMethod( \[\,\]\:\=,
+    [ "IsJuliaObject", "IsPosInt and IsSmallIntRep",
+                       "IsPosInt and IsSmallIntRep", "IsObject" ],
+    function( obj, i, j, val )
+      return Julia.Base.setindex\!( obj, val, i, j );
+    end );
+else
 InstallOtherMethod( \[\]\:\=,
     [ "IsJuliaObject", "IsPosInt and IsSmallIntRep",
                        "IsPosInt and IsSmallIntRep", "IsObject" ],
     function( obj, i, j, val )
       return Julia.Base.setindex\!( obj, val, i, j );
     end );
+fi;
 
 #
 # access to fields and properties


### PR DESCRIPTION
GAP 4.10 calls the operation `\[\]` with 3 arguments,
the master branch calls the new operation `\[\,\]`.

Note that the default delegation from `\[\,\]` to `\[\]`
does not apply in the given situation because the GAP objects
are just Julia objects, without type information about `IsMatrixObj`.

(After this change, the tests that were broken after merging #276 should pass again.)