### PR TITLE
Switch to using GAP 4.11

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -22,17 +22,17 @@ julia_binary = get(ENV, "JULIA_BINARY", Sys.BINDIR)
 ## Install GAP
 if install_gap
     println("Installing GAP ...")
+    gap_branch = "stable-4.11"
     cd(extra_gap_root)
     ## check if gap already exists
     if isdir("gap")
         ### Update the GAP clone
         cd("gap")
-        run(`git pull origin master`)
+        run(`git fetch origin`)
+        run(`git checkout $(gap_branch)`)
+        run(`git pull origin $(gap_branch)`)
     else
-        ## TODO: We currently use the GAP master branch.
-        ##       Once all issues of using GAP with the julia
-        ##       GC are resolved, we switch to a stable version.
-        run(`git clone https://github.com/gap-system/gap`)
+        run(`git clone -b $(gap_branch) https://github.com/gap-system/gap`)
         cd("gap")
     end
     run(`./autogen.sh`)

--- a/etc/travis_install_gap.sh
+++ b/etc/travis_install_gap.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Download and install GAP
-git clone --depth=1 https://github.com/gap-system/gap
+git clone --depth=1 -b stable-4.11 https://github.com/gap-system/gap
 cd gap
 ./autogen.sh
 ./configure --with-gc=julia --with-julia


### PR DESCRIPTION
For now, we use the stable-4.11 branch; once GAP 4.11.0 is released, we could switch to that.