### PR TITLE
changed the installation of JuliaSymbolsInModule

### DIFF
--- a/pkg/GAPJulia/JuliaInterface/gap/JuliaInterface.gi
+++ b/pkg/GAPJulia/JuliaInterface/gap/JuliaInterface.gi
@@ -94,7 +94,6 @@ end );
 
 
 InstallGlobalFunction( JuliaSymbolsInModule,
-                       [ IsJuliaModule ],
   module -> RecNames( module!.storage ) );
 
 InstallValue( Julia, _WrapJuliaModule( "Main", _JuliaGetGlobalVariable( "Main" ) ) );


### PR DESCRIPTION
Apparently the (unused) second argument of `InstallGlobalFunction` is going to be deprecated.