### PR TITLE
Travis: stop using ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ julia:
   - 1.3
   - nightly
 
-cache: ccache
-
 env:
   global:
     - MAKEFLAGS="-j4"


### PR DESCRIPTION
Since AbstractAlgebra and Nemo now have BinaryBuilder support, we don't need
this anymore, and it gets rid of all kind of potential glitches and other
annoyances.