### PR TITLE
Fix compilation with GAP master on macOS

### DIFF
--- a/pkg/GAPJulia/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/GAPJulia/JuliaInterface/src/JuliaInterface.c
@@ -1,5 +1,5 @@
 /*
- * JuliaInterface: Test interface to julia
+ * JuliaInterface: Interface to julia
  */
 
 #include "JuliaInterface.h"
@@ -7,7 +7,6 @@
 #include "calls.h"
 #include "convert.h"
 
-#include <src/compiled.h>    // GAP headers
 #include <src/julia_gc.h>
 
 #include <julia_gcext.h>

--- a/pkg/GAPJulia/JuliaInterface/src/JuliaInterface.h
+++ b/pkg/GAPJulia/JuliaInterface/src/JuliaInterface.h
@@ -1,6 +1,7 @@
 #ifndef JULIAINTERFACE_H_
 #define JULIAINTERFACE_H_
 
+#include <src/compiled.h>    // GAP headers
 #include <julia.h>
 #include <libgap-api.h>
 

--- a/pkg/GAPJulia/JuliaInterface/src/calls.c
+++ b/pkg/GAPJulia/JuliaInterface/src/calls.c
@@ -2,7 +2,6 @@
 #include "convert.h"
 #include "JuliaInterface.h"
 
-#include <src/compiled.h>    // GAP headers
 
 static Obj DoCallJuliaFunc0Arg(Obj func);
 

--- a/pkg/GAPJulia/JuliaInterface/src/calls.h
+++ b/pkg/GAPJulia/JuliaInterface/src/calls.h
@@ -1,6 +1,7 @@
 #ifndef JULIAINTERFACE_CALLS_H
 #define JULIAINTERFACE_CALLS_H
 
+#include <src/compiled.h>    // GAP headers
 #include <julia.h>
 #include <libgap-api.h>
 

--- a/pkg/GAPJulia/JuliaInterface/src/convert.c
+++ b/pkg/GAPJulia/JuliaInterface/src/convert.c
@@ -3,8 +3,6 @@
 #include "calls.h"
 #include "JuliaInterface.h"
 
-#include <src/compiled.h>    // GAP headers
-
 // This function is used by GAP.jl
 jl_value_t * julia_gap(Obj obj)
 {

--- a/pkg/GAPJulia/JuliaInterface/src/convert.h
+++ b/pkg/GAPJulia/JuliaInterface/src/convert.h
@@ -1,6 +1,7 @@
 #ifndef JULIAINTERFACE_CONVERT_H
 #define JULIAINTERFACE_CONVERT_H
 
+#include <src/compiled.h>    // GAP headers
 #include <julia.h>
 #include <libgap-api.h>
 


### PR DESCRIPTION
The GAP master branch has two new enum values TRUE and FALSE, which clash with
always included first.