### PR TITLE
let Julia start GAP without -r option

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -106,7 +106,7 @@ run_it = function(gapdir::String, error_handler_func::Ptr{Nothing})
     gaproots = abspath(joinpath(@__DIR__, "..")) * ";" * sysinfo["GAP_LIB_DIR"]
     initialize( [ ""
                        , "-l", gaproots
-                       , "-T", "-r", "-A", "--nointeract"
+                       , "-T", "-A", "--nointeract"
                        , "-m", "1000m" ], [""], error_handler_func )
     gap_is_initialized = true
 end


### PR DESCRIPTION
but keep the -A option.

This means that only the packages claimed as needed by GAP
(hopefully this selection will be reduced in the future)
are actually loaded on startup,
but users can easily load the packages in their `~/.gap/pkg`
directory on demand.