### PR TITLE
suppress the GAP banner when importing GAP.jl

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -168,8 +168,11 @@ function __init__()
         (func::$MPtr)(args...; kwargs...) = $(GAP.call_gap_func)(func, args...; kwargs...)
     ))
 
-    if ! haskey( ENV, "GAP_SHOW_BANNER" ) || ENV[ "GAP_SHOW_BANNER" ] != "true"
-      # Show package banners by default when LoadPackage is called.
+    if get( ENV, "GAP_SHOW_BANNER", "false" ) != "true"
+      # Leave it to GAP's `LoadPackage` whether package banners are shown.
+      # Note that a second argument `false` of this function suppresses the
+      # package banner,
+      # but no package banners can be shown if the `-b` option is `true`.
       Base.MainInclude.eval(:(
         begin
           record = $gap_module.Globals.GAPInfo


### PR DESCRIPTION
This pull request addresses issue #334.

- By default, `using GAP` will not show the banner.
- If Julia's `ENV[ "GAP_SHOW_BANNER" ]` is set to `"true"` then
  the GAP banner is shown on `using GAP`.
- When the user loads GAP packages, it depends on the `LoadPackage` call
  whether a package banner is shown.
  This is the standard GAP behaviour in the situation that banners are
  in principle enabled:
  If there is a second argument `false` then the banner is not shown,
  otherwise it is shown.

(The idea is to set the command line option `-b` when GAP shall be started
without banner, and to reset this option after the start of GAP.)

I think we should wait until issue #333 gets resolved
before switching off the GAP banner by default.