### PR TITLE
Improve InstallMethod calls

### DIFF
--- a/pkg/GAPJulia/JuliaInterface/gap/JuliaInterface.gi
+++ b/pkg/GAPJulia/JuliaInterface/gap/JuliaInterface.gi
@@ -43,7 +43,7 @@ BindGlobal( "_WrapJuliaModule",
 end );
 
 InstallMethod( \.,
-              [ IsJuliaModule, IsPosInt ],
+              [ "IsJuliaModule", "IsPosInt" ],
   function( module, rnum )
     local rnam, global_variable;
 
@@ -70,14 +70,14 @@ InstallMethod( \.,
 end );
 
 InstallMethod( \.\:\=,
-               [ IsJuliaModule, IsPosInt, IsObject ],
+               [ "IsJuliaModule", "IsPosInt", "IsObject" ],
   function( module, rnum, obj )
     Error( "Manual assignment to module is not allowed" );
 end );
 
 
 InstallMethod( IsBound\.,
-               [ IsJuliaModule, IsPosInt ],
+               [ "IsJuliaModule", "IsPosInt" ],
   function( module, rnum )
     if IsBound\.( module!.storage, rnum ) then
         return true;
@@ -87,7 +87,7 @@ end );
 
 
 InstallMethod( Unbind\.,
-               [ IsJuliaModule, IsPosInt ],
+               [ "IsJuliaModule", "IsPosInt" ],
   function( module, rnum )
     Unbind\.( module!.storage, rnum );
 end );
@@ -123,7 +123,7 @@ function( filename )
 end );
 
 InstallMethod( ViewString,
-               [ IsJuliaObject ],
+               [ "IsJuliaObject" ],
 
   function( julia_obj )
     return Concatenation( "<Julia: ", String( julia_obj ), ">" );
@@ -131,7 +131,7 @@ InstallMethod( ViewString,
 end );
 
 InstallMethod( String,
-               [ IsJuliaObject ],
+               [ "IsJuliaObject" ],
 
   function( julia_obj )
     return JuliaToGAP( IsString, Julia.Base.repr( julia_obj ) );

--- a/pkg/GAPJulia/JuliaInterface/gap/convert.gi
+++ b/pkg/GAPJulia/JuliaInterface/gap/convert.gi
@@ -5,7 +5,7 @@
 #############################################################################
 
 # convert Julia Integer subtypes like Int8, Int16, ... UInt64, BigInt
-InstallMethod(JuliaToGAP, [IsInt, IsJuliaObject],
+InstallMethod(JuliaToGAP, ["IsInt", "IsJuliaObject"],
 function(filter, obj)
     if Julia.isa(obj, Julia.Base.Integer) then
         return Julia.GAP.julia_to_gap(obj);
@@ -14,12 +14,12 @@ function(filter, obj)
 end);
 
 # handle immediate integers as well
-InstallMethod(JuliaToGAP, [IsInt, IsInt],
+InstallMethod(JuliaToGAP, ["IsInt", "IsInt"],
 function(filter, obj)
     return obj;
 end);
 
-InstallMethod(JuliaToGAP, [IsRat, IsJuliaObject],
+InstallMethod(JuliaToGAP, ["IsRat", "IsJuliaObject"],
 function(filter, obj)
     if Julia.isa(obj, Julia.Base.Integer) or Julia.isa(obj, Julia.Base.Rational) then
         return Julia.GAP.julia_to_gap(obj);
@@ -30,12 +30,12 @@ end);
 # No default conversion for IsCyc
 
 # immediate FFEs are auto-converted, so nothing to do here
-InstallMethod(JuliaToGAP, [IsFFE, IsFFE],
+InstallMethod(JuliaToGAP, ["IsFFE", "IsFFE"],
 function(filter, obj)
     return obj;
 end);
 
-InstallMethod(JuliaToGAP, [IsFloat, IsJuliaObject],
+InstallMethod(JuliaToGAP, ["IsFloat", "IsJuliaObject"],
 function(filter, obj)
     if Julia.isa(obj, Julia.Base.AbstractFloat) then
         return Julia.GAP.julia_to_gap(obj);
@@ -46,12 +46,12 @@ end);
 # No default conversion for T_PERM, T_TRANS, T_PPERM
 
 # Julia booleans true and false are auto-converted to GAP true and false, so nothing to do here
-InstallMethod(JuliaToGAP, [IsBool, IsBool],
+InstallMethod(JuliaToGAP, ["IsBool", "IsBool"],
 function(filter, obj)
     return obj;
 end);
 
-InstallMethod(JuliaToGAP, [IsChar, IsJuliaObject],
+InstallMethod(JuliaToGAP, ["IsChar", "IsJuliaObject"],
 function(filter, obj)
     # TODO: support Julia Int8 and UInt8, but *not* Char (which is a 32bit type)
     # convert to GAP using CHAR_SINT resp. CHAR_INT
@@ -62,10 +62,10 @@ BindGlobal("_JL_Dict_Symbol", JuliaEvalString("Dict{Symbol}"));
 BindGlobal("_JL_Dict_AbstractString", JuliaEvalString("Dict{AbstractString}"));
 BindGlobal("_JL_VAL_TRUE", JuliaEvalString("Val(true)"));
 
-InstallMethod(JuliaToGAP, [IsRecord, IsJuliaObject],
+InstallMethod(JuliaToGAP, ["IsRecord", "IsJuliaObject"],
     {filter,obj} -> JuliaToGAP(filter,obj,false) );
 
-InstallMethod(JuliaToGAP, [IsRecord, IsJuliaObject, IsBool],
+InstallMethod(JuliaToGAP, ["IsRecord", "IsJuliaObject", "IsBool"],
 function(filter, obj, recursive)
     if Julia.isa(obj, _JL_Dict_Symbol) or Julia.isa(obj, _JL_Dict_AbstractString) then
         if recursive then
@@ -77,10 +77,10 @@ function(filter, obj, recursive)
     Error("<obj> must be a Julia Dict{Symbol} or Dict{AbstractString}");
 end);
 
-InstallMethod(JuliaToGAP, [IsList, IsJuliaObject],
+InstallMethod(JuliaToGAP, ["IsList", "IsJuliaObject"],
     {filter,obj} -> JuliaToGAP(filter,obj,false) );
 
-InstallMethod(JuliaToGAP, [IsList, IsJuliaObject, IsBool],
+InstallMethod(JuliaToGAP, ["IsList", "IsJuliaObject", "IsBool"],
 function(filter, obj, recursive)
     if Julia.isa(obj, Julia.Base.Array) or Julia.isa(obj, Julia.Base.Tuple) then
         if recursive then
@@ -93,10 +93,10 @@ function(filter, obj, recursive)
 end);
 
 
-InstallMethod(JuliaToGAP, [IsRange, IsJuliaObject],
+InstallMethod(JuliaToGAP, ["IsRange", "IsJuliaObject"],
     {filter,obj} -> JuliaToGAP(filter,obj,false) );
 
-InstallMethod(JuliaToGAP, [IsRange, IsJuliaObject, IsBool],
+InstallMethod(JuliaToGAP, ["IsRange", "IsJuliaObject", "IsBool"],
 function(filter, obj, recursive)
     if Julia.isa(obj, Julia.Base.AbstractRange) then
         if recursive then
@@ -111,10 +111,10 @@ end);
 BindGlobal("_JL_Array_Bool_1", JuliaEvalString("Array{Bool,1}"));
 BindGlobal("_JL_BitArray_1", JuliaEvalString("BitArray{1}"));
 
-InstallMethod(JuliaToGAP, [IsBlist, IsJuliaObject],
+InstallMethod(JuliaToGAP, ["IsBlist", "IsJuliaObject"],
     {filter,obj} -> JuliaToGAP(filter,obj,false) );
 
-InstallMethod(JuliaToGAP, [IsBlist, IsJuliaObject, IsBool],
+InstallMethod(JuliaToGAP, ["IsBlist", "IsJuliaObject", "IsBool"],
 function(filter, obj, recursive)
     if Julia.isa(obj, _JL_Array_Bool_1) or Julia.isa(obj, _JL_BitArray_1) then
         if recursive then
@@ -126,7 +126,7 @@ function(filter, obj, recursive)
     Error("<obj> must be a Julia Array{Bool,1} or BitArray{1}");
 end);
 
-InstallMethod(JuliaToGAP, [IsString, IsJuliaObject],
+InstallMethod(JuliaToGAP, ["IsString", "IsJuliaObject"],
 function(filter, obj)
     # TODO: also accept Symbol?
     if Julia.isa(obj, Julia.Base.AbstractString) then


### PR DESCRIPTION
Use strings not the filters themselves in the argument descriptions,
in order to get nicer output from `ApplicableMethod`,
and for the sake of consistency.