### PR TITLE
catch GAP error messages in a Julia session

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 julia = "1.1"
 
 [extras]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,7 @@ makedocs(
          sitename = "GAP.jl",
          modules = [GAP],
          clean = true,
-         doctest = true,
+         doctest = false,
          strict = false,
          checkdocs = :none,
          pages    = [
@@ -13,7 +13,7 @@ makedocs(
          ]
 )
 
-deploydocs(
-   repo   = "github.com/oscar-system/GAP.jl.git",
-   target = "build",
-)
+#deploydocs(
+#   repo   = "github.com/oscar-system/GAP.jl.git",
+#   target = "build",
+#)

--- a/pkg/GAPJulia/JuliaInterface/gap/convert.gi
+++ b/pkg/GAPJulia/JuliaInterface/gap/convert.gi
@@ -14,7 +14,12 @@ function(filter, obj)
 end);
 
 # handle immediate integers as well
-InstallMethod(JuliaToGAP, ["IsInt", "IsInt"],
+InstallMethod(JuliaToGAP, ["IsInt", "IsInt and IsSmallIntRep"],
+function(filter, obj)
+    return obj;
+end);
+
+InstallMethod(JuliaToGAP, ["IsRat", "IsInt and IsSmallIntRep"],
 function(filter, obj)
     return obj;
 end);

--- a/pkg/GAPJulia/JuliaInterface/tst/adapter.tst
+++ b/pkg/GAPJulia/JuliaInterface/tst/adapter.tst
@@ -18,6 +18,8 @@ gap> zero := Zero(N);
 <Julia: 0>
 gap> one := One(N);
 <Julia: 1>
+gap> JuliaToGAP( IsInt, Zero(N) );
+0
 
 #
 gap> -N;

--- a/pkg/GAPJulia/JuliaInterface/tst/convert.tst
+++ b/pkg/GAPJulia/JuliaInterface/tst/convert.tst
@@ -1,82 +1,141 @@
 ##
 gap> START_TEST( "convert.tst" );
 
-##
-gap> typeof := Julia.Base.typeof;;
+## convert Julia booleans to GAP booleans (automatic conversion)
+gap> JuliaEvalString( "true" );
+true
+gap> GAPToJulia( true );
+true
+gap> JuliaEvalString( "false" );
+false
+gap> GAPToJulia( false );
+false
+gap> GAPToJulia( fail );  # do we really want this?
+fail
 
-###
-### Integers
-###
+## convert Julia integers to GAP integers and rationals
+
+## - for immediate integers
+gap> x:= 123;;  xstr:= String( x );;
+gap> IsSmallIntRep( x );
+true
+gap> l:= List( Cartesian( [ [ "", "U" ],
+>                           [ "Int" ],
+>                           [ "8", "16", "32", "64", "128" ],
+>                           [ Concatenation( "(", xstr, ")" ) ] ] ),
+>              Concatenation );;
+gap> Add( l, Concatenation( "BigInt(", xstr, ")" ) );
+gap> ForAll( l, obj -> JuliaToGAP( IsInt, JuliaEvalString( obj ) ) = x );
+true
+gap> ForAll( l, obj -> JuliaToGAP( IsRat, JuliaEvalString( obj ) ) = x );
+true
+
+## - for not immediate integers (only Int64, Int128, BigInt)
+gap> x:= 2^60;;  xstr:= String( x );;
+gap> IsSmallIntRep( x );
+false
+gap> l:= List( Cartesian( [ [ "", "U" ],
+>                           [ "Int" ],
+>                           [ "64", "128" ],
+>                           [ Concatenation( "(", xstr, ")" ) ] ] ),
+>              Concatenation );;
+gap> Add( l, Concatenation( "BigInt(", xstr, ")" ) );
+gap> ForAll( l, obj -> JuliaToGAP( IsInt, JuliaEvalString( obj ) ) = x );
+true
+gap> ForAll( l, obj -> JuliaToGAP( IsRat, JuliaEvalString( obj ) ) = x );
+true
+gap> x:= 2^70;;  xstr:= String( x );;
+gap> IsSmallIntRep( x );
+false
+gap> l:= List( Cartesian( [ [ "", "U" ],
+>                           [ "Int" ],
+>                           [ "128" ],
+>                           [ Concatenation( "(", xstr, ")" ) ] ] ),
+>              Concatenation );;
+gap> Add( l, Concatenation( "BigInt(", xstr, ")" ) );
+gap> ForAll( l, obj -> JuliaToGAP( IsInt, JuliaEvalString( obj ) ) = x );
+true
+gap> ForAll( l, obj -> JuliaToGAP( IsRat, JuliaEvalString( obj ) ) = x );
+true
+
+## convert Julia rationals to GAP rationals
+gap> x:= 1/3;;  xstr:= "1//3";;
+gap> l:= List( Cartesian( [ [ "Rational{" ],
+>                           [ "", "U" ],
+>                           [ "Int" ],
+>                           [ "8", "16", "32", "64", "128" ],
+>                           [ Concatenation( "}(", xstr, ")" ) ] ] ),
+>              Concatenation );;
+gap> Add( l, Concatenation( "Rational{BigInt}(", xstr, ")" ) );
+gap> ForAll( l, obj -> JuliaToGAP( IsInt, JuliaEvalString( obj ) ) = x );
+true
+gap> ForAll( l, obj -> JuliaToGAP( IsRat, JuliaEvalString( obj ) ) = x );
+true
+gap> x:= 1/2^60;;  xstr:= "1//2^60";;
+gap> l:= List( Cartesian( [ [ "Rational{" ],
+>                           [ "", "U" ],
+>                           [ "Int" ],
+>                           [ "64", "128" ],
+>                           [ Concatenation( "}(", xstr, ")" ) ] ] ),
+>              Concatenation );;
+gap> Add( l, Concatenation( "Rational{BigInt}(", xstr, ")" ) );
+gap> ForAll( l, obj -> JuliaToGAP( IsInt, JuliaEvalString( obj ) ) = x );
+true
+gap> ForAll( l, obj -> JuliaToGAP( IsRat, JuliaEvalString( obj ) ) = x );
+true
+gap> x:= 1/2^70;;  xstr:= "1//2^70";;
+gap> l:= List( Cartesian( [ [ "Rational{" ],
+>                           [ "", "U" ],
+>                           [ "Int" ],
+>                           [ "128" ],
+>                           [ Concatenation( "}(", xstr, ")" ) ] ] ),
+>              Concatenation );;
+gap> Add( l, Concatenation( "Rational{BigInt}(", xstr, ")" ) );
+gap> ForAll( l, obj -> JuliaToGAP( IsInt, JuliaEvalString( obj ) ) = x );
+true
+gap> ForAll( l, obj -> JuliaToGAP( IsRat, JuliaEvalString( obj ) ) = x );
+true
+
+## convert Julia FFEs to GAP FFEs
+
+
+## convert Julia floats to GAP floats
+gap> x:= 1.;;
+gap> IsFloat( x );
+true
+gap> l:= List( Cartesian( [ [ "Float" ],
+>                           [ "16", "32", "64" ],
+>                           [ Concatenation( "(", String( x ), ")" ) ] ] ),
+>              Concatenation );;
+gap> ForAll( l, obj -> JuliaToGAP( IsFloat, JuliaEvalString( obj ) ) = x );
+true
+
+## convert Julia chars to GAP chars
+gap> ForAll( [ 0 .. 255 ],
+>            i -> CharInt( i ) =
+>                 JuliaToGAP( IsChar, JuliaEvalString( Concatenation(
+>                   "Char(", String( i ), ")" ) ) ) );
+true
+gap> ForAll( [ 0 .. 255 ],
+>            i -> CharInt( i ) =
+>                 JuliaToGAP( IsChar, JuliaEvalString( Concatenation(
+>                   "Cuchar(", String( i ), ")" ) ) ) );
+true
+
+## convert Julia strings to GAP strings
 
 #
-gap> x := JuliaEvalString("Int128(123)");;
-gap> typeof(x);
-<Julia: Int128>
-gap> JuliaToGAP(IsInt, x);
-123
+gap> string := GAPToJulia( Julia.Base.AbstractString, "bla" );
+<Julia: "bla">
+gap> JuliaToGAP( IsString, string );
+"bla"
 
-#
-gap> x := JuliaEvalString("Int64(123)");;
-gap> typeof(x);
-<Julia: Int64>
-gap> JuliaToGAP(IsInt, x);
-123
 
-#
-gap> x := JuliaEvalString("Int32(123)");;
-gap> typeof(x);
-<Julia: Int32>
-gap> JuliaToGAP(IsInt, x);
-123
+## convert Julia symbols to GAP strings
 
-#
-gap> x := JuliaEvalString("Int16(123)");;
-gap> typeof(x);
-<Julia: Int16>
-gap> JuliaToGAP(IsInt, x);
-123
 
-#
-gap> x := JuliaEvalString("Int8(123)");;
-gap> typeof(x);
-<Julia: Int8>
-gap> JuliaToGAP(IsInt, x);
-123
+--------------------------------------
 
-#
-gap> x := JuliaEvalString("UInt128(123)");;
-gap> typeof(x);
-<Julia: UInt128>
-gap> JuliaToGAP(IsInt, x);
-123
-
-#
-gap> x := JuliaEvalString("UInt64(123)");;
-gap> typeof(x);
-<Julia: UInt64>
-gap> JuliaToGAP(IsInt, x);
-123
-
-#
-gap> x := JuliaEvalString("UInt32(123)");;
-gap> typeof(x);
-<Julia: UInt32>
-gap> JuliaToGAP(IsInt, x);
-123
-
-#
-gap> x := JuliaEvalString("UInt16(123)");;
-gap> typeof(x);
-<Julia: UInt16>
-gap> JuliaToGAP(IsInt, x);
-123
-
-#
-gap> x := JuliaEvalString("UInt8(123)");;
-gap> typeof(x);
-<Julia: UInt8>
-gap> JuliaToGAP(IsInt, x);
-123
 
 #
 gap> int := GAPToJulia( Julia.Base.Int64, 11 );
@@ -84,63 +143,15 @@ gap> int := GAPToJulia( Julia.Base.Int64, 11 );
 gap> JuliaToGAP(IsInt,  int );
 11
 
-#
-gap> x := JuliaEvalString("BigInt(123)");;
-gap> typeof(x);
-<Julia: BigInt>
-gap> JuliaToGAP(IsInt, x);
-123
-
-###
-### Floats
-###
-
-#
-gap> x := JuliaEvalString("Float64(1.0)");;
-gap> typeof(x);
-<Julia: Float64>
-gap> JuliaToGAP(IsFloat, x);
-1.
-
-#
-gap> x := JuliaEvalString("Float32(1.0)");;
-gap> typeof(x);
-<Julia: Float32>
-gap> JuliaToGAP(IsFloat, x);
-1.
-
-#
-gap> x := JuliaEvalString("Float16(1.0)");;
-gap> typeof(x);
-<Julia: Float16>
-gap> JuliaToGAP(IsFloat, x);
-1.
-
 ###
 ###
 ###
 
 #
-gap> big2 := JuliaEvalString("big(2)");
-<Julia: 2>
-gap> Zero(big2);
-<Julia: 0>
-gap> JuliaToGAP( IsInt, Zero(big2) );
-0
 gap> ForAll([0..64], n -> JuliaToGAP( IsInt, big2^n) = 2^n);
 true
 gap> ForAll([0..64], n -> JuliaToGAP( IsInt, -big2^n) = -2^n);
 true
-
-#
-gap> string := GAPToJulia( Julia.Base.AbstractString, "bla" );
-<Julia: "bla">
-gap> JuliaToGAP( IsString, string );
-"bla"
-gap> GAPToJulia( true );
-true
-gap> GAPToJulia( false );
-false
 
 ##
 gap> list:= GAPToJulia( [ 1, 2, 3 ] );
@@ -170,21 +181,27 @@ gap> xx := JuliaEvalString("GAP.Globals.PROD(2^59,2^59)");;
 gap> JuliaToGAP( IsInt, xx );
 332306998946228968225951765070086144
 
-###
-###  Records/Dictionaries
-###
+###  -------------------------------------------------------
 
-##  empty record
-gap> dict:= GAPToJulia( rec() );
-<Julia: Dict{Symbol,Any}()>
+## convert Julia dictionaries to GAP records
+## (non-recursively and recursively)
+
+gap> dict:= JuliaEvalString( "Dict{Symbol,Any}()" );
 gap> JuliaToGAP( IsRecord, dict );
 rec(  )
+gap> JuliaToGAP( IsRecord, dict, true );
+rec(  )
+gap> dict:= JuliaEvalString(
+>      "Dict( :bool => true, :string => \"abc\", :list => [ 1, 2, 3 ] )" );
+gap> JuliaToGAP( IsRecord, dict );
+gap> JuliaToGAP( IsRecord, dict, true );
+gap> dict.list[1]:= dict;;  # circular reference
+gap> JuliaToGAP( IsRecord, dict );
+gap> JuliaToGAP( IsRecord, dict, true );
 
-##  nested record: non-recursive vs. recursive
-gap> dict:= GAPToJulia( rec( bool:= true,
->                            string:= "abc",
->                            list:= [ 1, 2, 3 ],
->                          ) );;
+hier!
+
+
 gap> JuliaToGAP( IsRecord, dict );
 rec( bool := true, list := <Julia: Any[1, 2, 3]>, string := <Julia: "abc"> )
 gap> JuliaToGAP( IsRecord, dict, true );
@@ -198,4 +215,4 @@ gap> JuliaToGAP( IsRecord, dict );
 rec( juliafunc := <Julia: map> )
 
 ##
-gap> STOP_TEST( "convert.tst", 1 );
+gap> STOP_TEST( "convert.tst" );

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -159,7 +159,7 @@ function gap_to_julia( ::Type{BitArray{1}}, obj :: GapObj )
 end
 
 ## Arrays
-function gap_to_julia( ::Type{Array{Obj,1}}, obj :: GapObj , recursion_dict = IdDict() )
+function gap_to_julia( ::Type{Array{Obj,1}}, obj :: GapObj, recursion_dict = IdDict() )
     if ! Globals.IsList( obj )
         throw(ArgumentError("<obj> is not a list"))
     end

--- a/src/help.jl
+++ b/src/help.jl
@@ -1,10 +1,21 @@
-## enable access to GAP help system from Julia
+## enable access to GAP help system from Julia, via ?GAP.<topic>
 
 function GAP_help_string(topic::String, onlyexact::Bool = false)
     return GAP.gap_to_julia(GAP.Globals.HelpString(GAP.julia_to_gap(topic), onlyexact))
 end
 
-function show_GAP_help(topic::String, onlyexact::Bool = false)
+"""
+    show_help(topic::String, onlyexact::Bool = false)
+
+Print the documentation about `topic` from the GAP manuals.
+If `onlyexact` is `true` then only exact matches are shown,
+otherwise all entries with prefix `topic` are shown.
+
+If `topic` is the name of a global variable <var> in GAP then
+the latter variant corresponds to entering `?GAP.Globals.<var>`
+at the Julia prompt.
+"""
+function show_help(topic::String, onlyexact::Bool = false)
     print(GAP_help_string(topic, onlyexact))
 end
 

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -19,7 +19,7 @@ julia_to_gap(x::Bool) = x
 
 ## Integers
 julia_to_gap(x::Int128) = MakeObjInt(BigInt(x)) # FIXME: inefficient hack
-julia_to_gap(x::Int64)  = x
+julia_to_gap(x::Int64)  = x  # requires automatic conversion of x >= 2^60
 julia_to_gap(x::Int32)  = Int64(x)
 julia_to_gap(x::Int16)  = Int64(x)
 julia_to_gap(x::Int8)   = Int64(x)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -35,7 +35,7 @@ julia> @gap (1,2,3)
 GAP: (1,2,3)
 
 julia> @gap (1,2)(3,4)
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+ERROR: LoadError: Error thrown by GAP: Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 [...]
 
 julia> @gap [ 1,, 2 ]

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -19,7 +19,6 @@ you can use CAP commands via
 
 If `overwrite` is true, Symbols already in the `Main` module will be overloaded.
 Be aware that this flag only works in `Main`.
-
 """
 function LoadPackageAndExposeGlobals(package::String, mod::String; all_globals::Bool = false)
     mod_sym = Symbol(mod)
@@ -41,6 +40,7 @@ function LoadPackageAndExposeGlobals(package::String, mod::Module; all_globals::
     current_gvar_list = nothing
     if !all_globals
         current_gvar_list = Globals.ShallowCopy(Globals.NamesGVars())
+#T Why ShallowCopy? NamesGVars always creates a new list.
     end
     load_package = EvalString("LoadPackage(\"$package\")")
     if load_package == Globals.fail

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,8 @@ import Base: show
 """
     get_symbols_in_module(module_t::Module) :: Array{Symbol,1}
 
-> Returns all symbols in the module `module_t`.
+Return all symbols in the module `module_t`.
+This is used in the GAP function `ImportJuliaModuleIntoGAP`.
 """
 function get_symbols_in_module(module_t)
     module_name = string(nameof(module_t))
@@ -20,11 +21,11 @@ end
 """
     call_with_catch( juliafunc, arguments )
 
-> Returns a tuple `( ok, val )`
-> where `ok` is either `true`, meaning that calling the function `juliafunc`
-> with `arguments` returns the value `val`,
-> or `false`, meaning that the function call runs into an error;
-> in the latter case, `val` is set to the string of the error message.
+Return a tuple `( ok, val )`
+where `ok` is either `true`, meaning that calling the function `juliafunc`
+with `arguments` returns the value `val`,
+or `false`, meaning that the function call runs into an error;
+in the latter case, `val` is set to the string of the error message.
 """
 function call_with_catch( juliafunc, arguments )
     try

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,10 @@
-using Test
+using Test, Documenter, GAP
 
-using GAP
+DocMeta.setdocmeta!( GAP, :DocTestSetup, :( using GAP ); recursive = true )
 
 include("basics.jl")
 include("convenience.jl")
 include("conversion.jl")
 include("macros.jl")
 include("help.jl")
+include("testmanual.jl")


### PR DESCRIPTION
Up to now, GAP (running in a Julia session) printed its error messages
to the screen.
Now GAP's `ERROR_OUTPUT` gets redirected to a separate stream,
which is read and reset by the `error_handler` function in Julia.

(One effect is that the GAP error messages disappear when Julia tests for these errors are processed.)