### PR TITLE
Setup ctags, add global Makefile

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -1,0 +1,24 @@
+--langdef=GAP
+--langmap=GAP:.g.gd.gi.gap
+--regex-GAP=/([a-zA-Z0-9_]+) *:= *function/\1/f,function/
+--regex-GAP=/InstallMethod *\( *([a-zA-Z0-9_]+) *,/\1/m,method/
+--regex-GAP=/InstallOtherMethod *\( *([a-zA-Z0-9_]+) *,/\1/m,method/
+--regex-GAP=/InstallGlobalFunction *\( *([a-zA-Z0-9_]+) *,/\1/g,gfunction/
+--regex-GAP=/InstallValue *\( *([a-zA-Z0-9_]+) *,/\1/v,value/
+--regex-GAP=/InstallTrueMethod *\( *([a-zA-Z0-9_]+) *,/\1/t,truemethod/
+--regex-GAP=/<#GAPDoc *Label *= *"([a-zA-Z0-9_]+) *"/\1/d,documentation/
+--regex-GAP=/#Include *Label *= *"([a-zA-Z0-9_]+)"/\1/d,documentation/
+--regex-GAP=/DeclareCategory *\( *"([a-zA-Z0-9_]+)"/\1/c,category/
+--regex-GAP=/DeclareRepresentation *\( *"([a-zA-Z0-9_]+)"/\1/r,representation/
+--regex-GAP=/DeclareInfoClass *\( *"([a-zA-Z0-9_]+)"/\1/i,infoclass/
+--regex-GAP=/DeclareAttribute *\( *"([a-zA-Z0-9_]+)"/\1/a,attribute/
+--regex-GAP=/DeclareProperty *\( *"([a-zA-Z0-9_]+)"/\1/p,property/
+--regex-GAP=/DeclareSynonym *\( *"([a-zA-Z0-9_]+)"/\1/s,synonym/
+--regex-GAP=/DeclareGlobalFunction *\( *"([a-zA-Z0-9_]+)"/\1/g,gfunction/
+--regex-GAP=/DeclareOperation *\( *"([a-zA-Z0-9_]+)"/\1/o,operation/
+
+--langdef=julia
+--langmap=julia:.jl
+--regex-julia=/^[ \t]*(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*(function|macro|abstract type|primitive type|struct|mutable struct|module)[ \t]+([^ \t({[]+).*$/\4/f,function/
+--regex-julia=/^[ \t]*(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*(([^@#$ \t({[]+)|\(([^@#$ \t({[]+)\))[ \t]*[ \t]*\([^#]*\)([ \t]+where[ \t]+\{.*\})?[ \t]*=([^=].*)?$/\4\5/f,function/
+--regex-julia=/^(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*(const[ \t]+)?(([^ \t.({[]+\.)*@[^ \t({[]+[ \t]+)*([^@#$ \t({[]+)[ \t]*=([^=].*)?$/\6/v,variable/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/Makefile
 /gap/
 /gh-pages/
 /Manifest.toml
@@ -7,3 +6,4 @@
 /deps/build.log
 /gap.sh
 /pkg/GAPJulia/Makefile
+/tags

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+# TODO: ensure JulieInterface is up-to-date
+default:
+	@echo "Use 'make doc' or 'make check' or 'make tags'""
+
+check:
+	julia --color=yes test/runtests.jl
+
+doc:
+	julia --color=yes docs/make.jl
+
+tags:
+	etc/tags.sh --recurse pkg src
+
+.PHONY: default check doc tags

--- a/etc/tags.sh
+++ b/etc/tags.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -ex
+
+#
+# This little script tries guessing which executable
+# in the system is exuberant ctags. It first checks whether
+# the environment variable $GAP_CTAGS is set, and if so, executes
+# the command given by it, otherwise it first tries locating
+# `exctags`, and then `ctags`.
+#
+
+for tags in "$GAP_CTAGS" exctags ctags-exuberant ctags
+do
+    command -v "$tags" >/dev/null 2>&1 || continue
+    echo "$tags" "$@"
+    exec "$tags" "$@"
+done
+
+echo "error, exuberant ctags not found"
+exit 1


### PR DESCRIPTION
The global makefile for now makes it convenient run tests, build the
Julia manual, and generate tags.

In the future it could also build the GAP package manuals; (re)compile the
GAP packages; (re)compile the bundled