### PR TITLE
Add basic wrappers for GAP PackageManager

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -46,6 +46,16 @@ TODO: Describe access to arbitrary GAP variables and functions via `GAP.Globals.
 TODO: describe Help system integration
 
 
+## Managing GAP packages
+
+```@docs
+GAP.Packages.load
+GAP.Packages.install
+GAP.Packages.update
+GAP.Packages.remove
+```
+
+
 
 ## Index
 

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -178,11 +178,11 @@ end
 
 include( "ccalls.jl" )
 include( "adapter.jl" )
-include( "packages.jl" )
 include( "macros.jl" )
 include( "gap_to_julia.jl" )
 include( "julia_to_gap.jl" )
 include( "utils.jl" )
 include( "help.jl" )
+include( "packages.jl" )
 
 end

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -64,3 +64,59 @@ function LoadPackageAndExposeGlobals(package::String, mod::Module; all_globals::
 end
 
 export LoadPackageAndExposeGlobals
+
+
+module Packages
+
+import ...GAP: Globals, julia_to_gap
+
+"""
+    load(desc)
+
+TODO: write text, link to GAP's LoadPackage
+
+TODO: support version qualifier?
+"""
+function load(desc::String)
+    return Globals.LoadPackage(julia_to_gap(desc), false)
+    # TODO: can we provide more information in case of a failure?
+    # GAP unfortunately only gives us info messages...
+end
+
+"""
+    install(desc)
+
+TODO: copy text from <https://gap-packages.github.io/PackageManager/doc/chap2.html> resp.
+link to that
+"""
+function install(desc::String, interactive::Bool = true)
+    res = Globals.LoadPackage(julia_to_gap("PackageManager"), false)
+    @assert res
+    return Globals.InstallPackage(julia_to_gap(desc), interactive)
+end
+
+"""
+    update(desc)
+
+TODO: copy text from <https://gap-packages.github.io/PackageManager/doc/chap2.html> resp.
+link to that
+"""
+function update(desc::String, interactive::Bool = true)
+    res = Globals.LoadPackage(julia_to_gap("PackageManager"), false)
+    @assert res
+    return Globals.UpdatePackage(julia_to_gap(desc), interactive)
+end
+
+"""
+    remove(desc)
+
+TODO: copy text from <https://gap-packages.github.io/PackageManager/doc/chap2.html> resp.
+link to that
+"""
+function remove(desc::String, interactive::Bool = true)
+    res = Globals.LoadPackage(julia_to_gap("PackageManager"), false)
+    @assert res
+    return Globals.RemovePackage(julia_to_gap(desc), interactive)
+end
+
+end


### PR DESCRIPTION
This was part of PR #365 but is of independent interest, and the discussion on PR #365 might go one for some more time.

One thing we still might want to change (or could change after merging this) is to add an (optional?) argument to `GAP.Packages.install` to specify an alternate installation location (see discussion on #365 for some reasons for this). And perhaps similar such arguments for `load`, `remove`, `update` would be useful?

Moreover, we could add `GAP.Packages.build` which for now might invoke `PKGMAN_CompileDir` (see also https://github.com/gap-packages/PackageManager/issues/50)

Resolves #367