### PR TITLE
remove the horrible hack for Display

### DIFF
--- a/pkg/GAPJulia/JuliaInterface/gap/utils.gi
+++ b/pkg/GAPJulia/JuliaInterface/gap/utils.gi
@@ -15,6 +15,16 @@ BindGlobal( "CreateRecFromKeyValuePairList",
     return return_rec;
 end );
 
+BindGlobal( "StringDisplayObj",
+function(obj)
+  local str, out;
+  str := "";
+  out := OutputTextString(str, false);
+  STREAM_DISPLAYOBJ(out, obj);
+  CloseStream(out);
+  return str;
+end );
+
 BindGlobal( "StringViewObj",
 function(obj)
   local str, out;

--- a/pkg/GAPJulia/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/GAPJulia/JuliaInterface/src/JuliaInterface.c
@@ -25,6 +25,7 @@ jl_datatype_t * gap_datatype_mptr;
 Obj  TheTypeJuliaObject;
 UInt T_JULIA_OBJ;
 
+Obj JULIAINTERFACE_Display;
 Obj JULIAINTERFACE_IsJuliaWrapper;
 Obj JULIAINTERFACE_JuliaPointer;
 
@@ -332,6 +333,38 @@ static Obj FuncJuliaGetFieldOfObject(Obj self, Obj super_obj, Obj field_name)
 
 static Obj IsOutputStream;
 
+static Obj FuncSTREAM_DISPLAYOBJ(Obj self, Obj stream, Obj obj)
+{
+    syJmp_buf readJmpError;
+
+    if (CALL_1ARGS(IsOutputStream, stream) != True) {
+        ErrorQuit("STREAM_DISPLAYOBJ: <outstream> must be an output stream",
+                  0, 0);
+    }
+    if (!OpenOutputStream(stream)) {
+        ErrorQuit("STREAM_DISPLAYOBJ: cannot open stream for output", 0, 0);
+    }
+
+    // if an error occurs stop printing
+    memcpy(readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf));
+    TRY_IF_NO_ERROR
+    {
+        CALL_1ARGS(JULIAINTERFACE_Display, obj);
+    }
+    CATCH_ERROR
+    {
+        // TODO: signal failure somehow?
+    }
+    memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
+
+    // close the output file again, and return nothing
+    if (!CloseOutput()) {
+        ErrorQuit("STREAM_DISPLAYOBJ: cannot close output", 0, 0);
+    }
+
+    return 0;
+}
+
 static Obj FuncSTREAM_VIEWOBJ(Obj self, Obj stream, Obj obj)
 {
     syJmp_buf readJmpError;
@@ -386,6 +419,7 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(JuliaSymbol, 1, "name"),
     GVAR_FUNC(_NewJuliaCFunc, 2, "ptr,arg_names"),
     GVAR_FUNC(_JULIAINTERFACE_INTERNAL_INIT, 0, ""),
+    GVAR_FUNC(STREAM_DISPLAYOBJ, 2, "stream, obj"),
     GVAR_FUNC(STREAM_VIEWOBJ, 2, "stream, obj"),
     { 0 } /* Finish with an empty entry */
 
@@ -447,6 +481,7 @@ static Int InitKernel(StructInitInfo * module)
         (jl_datatype_t *)jl_get_global(gap_module, jl_symbol("MPtr"));
     GAP_ASSERT(gap_datatype_mptr);
 
+    ImportFuncFromLibrary("Display", &JULIAINTERFACE_Display);
     ImportFuncFromLibrary("IsJuliaWrapper", &JULIAINTERFACE_IsJuliaWrapper);
     ImportFuncFromLibrary("JuliaPointer", &JULIAINTERFACE_JuliaPointer);
     ImportFuncFromLibrary("IsOutputStream", &IsOutputStream);

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -49,15 +49,5 @@ end
 ## convenience function
 
 function Display(x::GapObj)
-    ## FIXME: Get rid of this horrible hack
-    ##        once GAP offers a consistent
-    ##        DisplayString function
-    local_var = "julia_gap_display_tmp"
-    AssignGlobalVariable(local_var, x)
-    xx = EvalStringEx("Display($local_var);")[1]
-    if xx[1] == true
-        println(GAP.gap_to_julia(AbstractString, xx[5]))
-    else
-        error("variable was not correctly evaluated")
-    end
+    println(GAP.gap_to_julia(AbstractString, Globals.StringDisplayObj(x)))
 end


### PR DESCRIPTION
(intended to resolve #380)

- added the C function `STREAM_DISPLAYOBJ`, analogous to `STREAM_VIEWOBJ`,
- added the GAP function `StringDisplayObj` analogous to `StringViewObj`,
- in the Julia function `Display`, use `StringDisplayObj` instead of the horrible hack.