### PR TITLE
on the GAP side, support Julia's keyword arguments

### DIFF
--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -316,6 +316,36 @@ DeclareGlobalFunction( "JuliaTypeInfo" );
 #! @EndExampleSession
 DeclareGlobalFunction( "CallJuliaFunctionWithCatch" );
 
+#! @Arguments juliafunc, arguments, arec
+#! @Returns the result of the &Julia; function call.
+#! @Description
+#!  The function calls the &Julia; function <A>juliafunc</A>
+#!  with ordinary arguments in the &GAP; list <A>arguments</A>
+#!  and keyword arguments given by the component names (keys) and values
+#!  of the record <A>arec</A>,
+#!  and returns the function value.
+#!  <P/>
+#!  Note that the entries of <A>arguments</A> and the components of
+#!  <A>arec</A> are not implicitly converted to &Julia;.
+#! @BeginExampleSession
+#! gap> CallJuliaFunctionWithKeywordArguments( Julia.Base.round,
+#! >        [ GAPToJulia( Float( 1/3 ) ) ], rec( digits:= 5 ) );
+#! <Julia: 0.33333>
+#! gap> CallJuliaFunctionWithKeywordArguments(
+#! >        Julia.Base.range, [ 2 ], rec( length:= 5, step:= 2 ) );
+#! <Julia: 2:2:10>
+#! gap> m:= GAPToJulia( JuliaEvalString( "Array{Int,2}" ),
+#! >            [ [ 1, 2 ], [ 3, 4 ] ] );
+#! <Julia: [1 2; 3 4]>
+#! gap> CallJuliaFunctionWithKeywordArguments(
+#! >        Julia.Base.reverse, [ m ], rec( dims:= 1 ) );
+#! <Julia: [3 4; 1 2]>
+#! gap> CallJuliaFunctionWithKeywordArguments(
+#! >        Julia.Base.reverse, [ m ], rec( dims:= 2 ) );
+#! <Julia: [2 1; 4 3]>
+#! @EndExampleSession
+DeclareGlobalFunction( "CallJuliaFunctionWithKeywordArguments" );
+
 #! @Section Calling &Julia; functions
 #!  The simplest way to execute &Julia; code from &GAP; is to call
 #!  <Ref Func="JuliaEvalString"/> with a string that contains

--- a/pkg/JuliaInterface/gap/calls.gi
+++ b/pkg/JuliaInterface/gap/calls.gi
@@ -5,6 +5,8 @@
 ##
 BindGlobal("_JL_Array_GAPObj_1", JuliaEvalString("Array{__JULIAGAPMODULE.Obj,1}"));
 
+BindGlobal("_JL_Dict_GAPObj", JuliaEvalString("Dict{Symbol,__JULIAGAPMODULE.Obj}"));
+
 ##
 ##  We want to use &GAP's function call syntax also for certain Julia objects
 ##  that are <E>not</E> functions, for example for types such as <C>fmpz</C>.
@@ -35,3 +37,9 @@ InstallGlobalFunction( CallJuliaFunctionWithCatch,
       return rec( ok:= false, value:= JuliaToGAP( IsString, res[2] ) );
     fi;
 end );
+
+InstallGlobalFunction( CallJuliaFunctionWithKeywordArguments,
+    { julia_obj, args, arec } -> Julia.GAP.kwarg_wrapper( julia_obj,
+                                     # non-recursive conversions
+                                     GAPToJulia( _JL_Array_GAPObj_1, args ),
+                                     GAPToJulia( _JL_Dict_GAPObj, arec ) ) );

--- a/pkg/JuliaInterface/gap/convert.gd
+++ b/pkg/JuliaInterface/gap/convert.gd
@@ -482,10 +482,6 @@ DeclareGlobalFunction("GAPToJulia");
 #!   Why is <Ref Func="GAPToJulia"/> always recursive?
 #! </Item>
 #! <Item>
-#!   Is there a way to call &Julia; functions with named arguments
-#!   from &GAP; via the interface?
-#! </Item>
-#! <Item>
 #!   Should we allow the three argument case of <C>JuliaToGAP</C> in all
 #!   cases, e.g., <C>JuliaToGAP( IsInt, 1, true )</C>?
 #! </Item>

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -45,6 +45,29 @@ function call_with_catch(juliafunc, arguments)
     end
 end
 
+"""
+    function kwarg_wrapper(func, args::Array{T1,1}, kwargs::Dict{Symbol,T2}) where {T1, T2}
+
+Call the function `func` with arguments `args` and keyword arguments
+given by the keys and values of `kwargs`.
+
+This function is used on the GAP side, in calls of Julia functions that
+require keyword arguments.
+Note that `jl_call` and `Core._apply` do not support keyword arguments.
+
+# Examples
+```jldoctest
+julia> range( 2, length = 5, step = 2 )
+2:2:10
+
+julia> GAP.kwarg_wrapper( range, [ 2 ], Dict( :length => 5, :step => 2 ) )
+2:2:10
+
+```
+"""
+function kwarg_wrapper(func, args::Array{T1,1}, kwargs::Dict{Symbol,T2}) where {T1, T2}
+    return func( args...; [ k => kwargs[k] for k in keys( kwargs ) ]... )
+end
 
 ## convenience function
 


### PR DESCRIPTION
- added Julia function `kwarg_wrapper`,
- added GAP function `CallJuliaFunctionWithKeywordArguments`,
- removed the corresp. item from the list of open items

intended to resolve #381