### PR TITLE
keyword arguments: something that had been missing

### DIFF
--- a/pkg/JuliaExperimental/gap/singular.g
+++ b/pkg/JuliaExperimental/gap/singular.g
@@ -212,16 +212,13 @@ InstallMethod( ContextGAPSingular,
       degree_bound:= 0;
     fi;
 
-    # Create the Singular ring.
-    # If we would be able to deal with keyword arguments
-    # then wrapping would not be needed here.
-    dict:= GAPToJulia( rec( ring:= FContext!.JuliaDomainPointer,
-                          indeterminates:= names,
-                          cached:= true,
-                          ordering:= JuliaSymbol( ordering ),
-                          ordering2:= JuliaSymbol( ordering2 ),
-                          degree_bound:= degree_bound ) );
-    juliaRing:= Julia.GAPSingularModule.SingularPolynomialRingWrapper( dict );
+    juliaRing:= CallJuliaFunctionWithKeywordArguments(
+                    Julia.Singular.PolynomialRing,
+                    [ FContext!.JuliaDomainPointer, names ],
+                    rec( cached:= true,
+                         ordering:= JuliaSymbol( ordering ),
+                         ordering2:= JuliaSymbol( ordering2 ),
+                         degree_bound:= degree_bound ) );
 
     # Create the GAP wrappers.
     # Create a new family.

--- a/pkg/JuliaExperimental/julia/singular.jl
+++ b/pkg/JuliaExperimental/julia/singular.jl
@@ -7,31 +7,6 @@ module GAPSingularModule
 
 import Singular
 
-""" 
-    SingularPolynomialRingWrapper( dict::Dict{Any,Any} )
-> The purpose of this function is just to handle *keyword arguments*.
-> The following works in a Julia session:
-> 
->   # keyword argument
->   Singular.PolynomialRing( Singular.QQ, [ "x", "y" ], ordering = :lex )
-> 
->   # (key, value) pairs after ';' (apparently no longer in Julia 1.0 ...)
->   Singular.PolynomialRing( Singular.QQ, [ "x", "y" ]; (:ordering, :lex) )
-> 
->   # iterable expression after ';'
->   Singular.PolynomialRing( Singular.QQ, [ "x", "y" ]; :ordering => :lex )
-> 
->   But none of these has a suitable syntax for 'jl_call'.
->   (Note the semicolon in the last two cases above.)
-"""
-function SingularPolynomialRingWrapper( dict::Dict{Symbol,Any} )
-    return Singular.PolynomialRing( dict[ :ring ], dict[ :indeterminates ];
-               cached = dict[ :cached ],
-               ordering = dict[ :ordering ],
-               ordering2 = dict[ :ordering2 ],
-               degree_bound = dict[ :degree_bound ] )
-end
-
 function GAPExtRepOfSingularPolynomial( poly )
     coeffs = []
     exps = []

--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -357,6 +357,15 @@ DeclareGlobalFunction( "CallJuliaFunctionWithCatch" );
 #! gap> CallJuliaFunctionWithKeywordArguments(
 #! >        Julia.Base.reverse, [ m ], rec( dims:= 2 ) );
 #! <Julia: [2 1; 4 3]>
+#! gap> tuptyp:= JuliaEvalString( "Tuple{Int,Int}" );;
+#! gap> t1:= GAPToJulia( tuptyp, [ 2, 1 ] );
+#! <Julia: (2, 1)>
+#! gap> t2:= GAPToJulia( tuptyp, [ 1, 3 ] );
+#! <Julia: (1, 3)>
+#! gap> CallJuliaFunctionWithKeywordArguments(
+#! >        Julia.Base.( "repeat" ), [ m ],
+#! >        rec( inner:= t1, outer:= t2 ) );
+#! <Julia: [1 2 1 2 1 2; 1 2 1 2 1 2; 3 4 3 4 3 4; 3 4 3 4 3 4]>
 #! @EndExampleSession
 DeclareGlobalFunction( "CallJuliaFunctionWithKeywordArguments" );
 


### PR DESCRIPTION
- ~~added a `gap_to_julia` method for the non-recursive conversion
  of GAP records to Julia dictionaries~~
- added an example of `CallJuliaFunctionWithKeywordArguments` where
  the keyword arguments are proper Julia objects
- ~~added comments (in the code) about the current meaning of the
  first arguments `::Type{Array{Obj,1}}` and `::Type{Dict{Symbol,Obj}}`
  for `gap_to_julia`~~
- replaced the individual Julia code for creating polynomial rings
  by the use of `CallJuliaFunctionWithKeywordArguments`

(The removals are due to a better solution which is meanwhile available by #430.)