### PR TITLE
Only compile GAP once for each Julia major.minor pair

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,8 @@ using BinaryProvider
 using Pkg.Artifacts
 
 # Remove deps.jl now, so that we can recognize an aborted build by its absence
-deps_jl = abspath(joinpath(@__DIR__, "deps-$(VERSION).jl"))
+const julia_version = "$(VERSION.major).$(VERSION.minor)"
+deps_jl = abspath(joinpath(@__DIR__, "deps-$(julia_version).jl"))
 rm(deps_jl, force = true)
 
 # Reference the Julia artifact containing the GAP source code
@@ -21,7 +22,7 @@ gap_src_root = abspath(joinpath(artifact_dir, "$(gapdirname)"))
 extra_gap_root = abspath(joinpath(@__DIR__, ".."))
 
 # the location in which we initiate GAP's "out of tree build"
-gap_bin_root = abspath(joinpath(@__DIR__, "build", "$(gapdirname)-julia-$(VERSION)"))
+gap_bin_root = abspath(joinpath(@__DIR__, "build", "$(gapdirname)-julia-$(julia_version)"))
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
@@ -58,7 +59,7 @@ cd(gap_bin_root) do
                 --with-zlib=$(deps_prefix)
                 --disable-maintainer-mode
                 LIBS="-Wl,-rpath -Wl,$(deps_prefix)/lib"
-                ARCHEXT=v$(VERSION)
+                ARCHEXT=v$(julia_version)
                 `)
     run(`make -j$(Sys.CPU_THREADS)`)
 end

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -6,9 +6,10 @@
 module GAP
 
 # In order to locate the GAP installation, 'deps/build.jl' generate a file
-# 'deps/deps-$(VERSION).jl' for us which sets the variable GAPROOT. We read
-# this file here.
-deps_jl = abspath(joinpath(@__DIR__, "..", "deps", "deps-$(VERSION).jl"))
+# 'deps/deps-$(julia_version).jl' for us which sets the variable GAPROOT. We
+# read this file here.
+const julia_version = "$(VERSION.major).$(VERSION.minor)"
+deps_jl = abspath(joinpath(@__DIR__, "..", "deps", "deps-$(julia_version).jl"))
 if !isfile(deps_jl)
     # HACK: we need to compile GAP once for each Julia version, but Julia only
     # builds it for us once; so we need to check if the package was actually


### PR DESCRIPTION
Don't compile it again when e.g. upgrading from 1.4.0 to 1.4.1.
Doing that shouldn't be necessary (famous last words).