### PR TITLE
access to Julia variables from GAP

### DIFF
--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -104,9 +104,9 @@ DeclareAttribute( "JuliaPointer", IsJuliaWrapper );
 #! gap> IsJuliaModule( Julia.GAP );
 #! true
 #! gap> Julia.GAP.julia_to_gap;
-#! function( arg... ) ... end
+#! <Julia: julia_to_gap>
 #! gap> JuliaFunction( "julia_to_gap", "GAP" );  # the same function
-#! function( arg... ) ... end
+#! <Julia: julia_to_gap>
 #! @EndExampleSession
 DeclareCategory( "IsJuliaModule", IsJuliaWrapper  );
 
@@ -212,7 +212,7 @@ BindGlobal( "_JuliaFunctions", rec( ) );
 #!      DoCallJuliaFunc0Arg and eventually to jl_call. -->
 #! @BeginExampleSession
 #! gap> fun:= JuliaFunction( "sqrt" );
-#! function( arg... ) ... end
+#! <Julia: sqrt>
 #! gap> Print( fun );
 #! function ( arg... )
 #!     <<kernel code>> from Julia:sqrt
@@ -223,17 +223,13 @@ DeclareGlobalFunction( "JuliaFunction" );
 #! @Arguments variable_name[, module_name]
 #! @Returns a &Julia; object
 #! @Description
-#!  Returns the &Julia; object assigned to the variable with name
+#!  Returns the object assigned to the &Julia; variable with name
 #!  <A>variable_name</A> in the &Julia; module <A>module_name</A>.
 #!  Both arguments must be strings. If <A>module_name</A> is not given,
-#!  the variable is taken from the <C>Main</C> module.
+#!  the variable is taken from &Julia;'s <C>Main</C> module.
 #!  <P/>
 #!  If the variable with name <A>variable_name</A> is not bound in the
 #!  &Julia; module then <K>fail</K> is returned.
-#!  Otherwise the result of this function is in
-#!  <Ref Func="IsArgumentForJuliaFunction"/>,
-#!  <!-- but never in IsJuliaWrapper -->
-#!  thus it can be passed as an argument to &Julia; functions.
 #! @BeginExampleSession
 #! gap> JuliaEvalString( "x = 17" );
 #! 17
@@ -241,6 +237,20 @@ DeclareGlobalFunction( "JuliaFunction" );
 #! 17
 #! gap> JuliaGetGlobalVariable( "unbound_variable", "GAP" );
 #! fail
+#! @EndExampleSession
+#! Note that the value of a &Julia; variable may be a &GAP; object,
+#! thus the value <K>fail</K> can be returned in a situation where the
+#! &Julia; variable in question is bound.
+#! In order to decide whether a &Julia; variable is bound,
+#! one can use the &Julia; function <C>isdefined</C>.
+#! @BeginExampleSession
+#! gap> JuliaEvalString( "julia_x = GAP.Globals.fail" );;
+#! gap> JuliaGetGlobalVariable( "julia_x" );
+#! fail
+#! gap> Julia.isdefined( Julia.Main, JuliaSymbol( "julia_x" ) );
+#! true
+#! gap> Julia.isdefined( Julia.Main, JuliaSymbol( "julia_y" ) );
+#! false
 #! @EndExampleSession
 DeclareGlobalFunction( "JuliaGetGlobalVariable" );
 

--- a/pkg/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/JuliaInterface/src/JuliaInterface.c
@@ -199,6 +199,12 @@ static Obj Func_JuliaFunctionByModule(Obj self, Obj funcName, Obj moduleName)
     return NewJuliaFunc(f);
 }
 
+// Export 'IS_JULIA_FUNC' to the GAP level.
+static Obj FuncIS_JULIA_FUNC(Obj self, Obj obj)
+{
+    return IS_JULIA_FUNC(obj) ? True : False;
+}
+
 // Executes the string <string> in the current julia session.
 static Obj FuncJuliaEvalString(Obj self, Obj string)
 {
@@ -348,6 +354,7 @@ static void MarkJuliaObject(Bag bag)
 static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(_JuliaFunction, 1, "string"),
     GVAR_FUNC(_JuliaFunctionByModule, 2, "funcName, moduleName"),
+    GVAR_FUNC(IS_JULIA_FUNC, 1, "obj"),
     GVAR_FUNC(JuliaEvalString, 1, "string"),
     GVAR_FUNC(JuliaSetVal, 2, "name,val"),
     GVAR_FUNC(_JuliaGetGlobalVariable, 1, "name"),

--- a/pkg/JuliaInterface/tst/import.tst
+++ b/pkg/JuliaInterface/tst/import.tst
@@ -31,7 +31,7 @@ gap> Julia.Base;
 gap> IsBound( Julia.Base );
 true
 gap> Julia.Base.sqrt;
-function( arg... ) ... end
+<Julia: sqrt>
 gap> IsBound( Julia.Base.foo_bar_quux_not_defined );
 false
 gap> Julia.Base.foo_bar_quux_not_defined;
@@ -47,8 +47,7 @@ gap> Julia.Base.C_NULL;
 gap> IsBound( Julia.Base.C_NULL );
 true
 gap> Unbind( Julia.Base.C_NULL );
-gap> IsBound( Julia.Base.C_NULL );
-true
+Error, cannot unbind Julia variables
 
 ##
 gap> STOP_TEST( "import.tst", 1 );


### PR DESCRIPTION
(This deals with parts of #390.)
- made `IS_JULIA_FUNC` accessible from GAP
- added a `ViewString` method for GAP functions created by `_JuliaFunction`
- fixed the documentation of `JuliaGetGlobalVariable`,
  the returned value can be a GAP object as well
- set also the `String` attribute in `IsJuliaModule` objects
  (`String( Julia )` yields `"<object>"` otherwise)
- removed the caching of arbitrary Julia variables in `IsJuliaModule` objects,
  because the value may change on the Julia side;
  caching for Julia modules is kept
- forbid `Unbind\.` in `IsJuliaModule` objects