### PR TITLE
proposed fix for a conversion inconsistency

### DIFF
--- a/pkg/JuliaInterface/src/convert.c
+++ b/pkg/JuliaInterface/src/convert.c
@@ -54,7 +54,7 @@ Obj gap_julia(jl_value_t * julia_obj)
         if (INT_INTOBJ_MIN <= v && v <= INT_INTOBJ_MAX) {
             return INTOBJ_INT(v);
         }
-        return ObjInt_Int8(v);
+        return NewJuliaObj(julia_obj);
     }
     if (is_gapobj(julia_obj)) {
         return (Obj)julia_obj;

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -29,7 +29,6 @@ end
 
 ## Small integers types always fit into GAP immediate integers, and thus are
 ## represented by Int64 on the Julia side.
-julia_to_gap(x::Int64)  = x
 julia_to_gap(x::Int32)  = Int64(x)
 julia_to_gap(x::Int16)  = Int64(x)
 julia_to_gap(x::Int8)   = Int64(x)


### PR DESCRIPTION
Currently the following happens.
```
gap> x:= JuliaEvalString( "2^60" );
1152921504606846976
gap> GAPToJulia( 2^60 );
<Julia: 1152921504606846976>
```
The number `x` is not an immediate integer, and `Julia.Base.sqrt( x )` yields an error.
The result of `GAPToJulia` (computed using `gap_to_julia`) looks correct.
`JuliaEvalString` calls `gap_julia`, which calls `ObjInt_Int8` in this case;
I propose to use `NewJuliaObj` instead.

After this change, the tests exhibit a problem with the method
```
julia_to_gap(x::Int64)  = x
```
which is simply wrong.

Perhaps this proposal is not a good idea.
Converting `Int64` to GAP becomes more expensive because the argument has to be checked.
For the moment, I have no good idea to improve this.