### PR TITLE
two list issues brought up by Mohamed

### DIFF
--- a/pkg/JuliaInterface/gap/convert.gi
+++ b/pkg/JuliaInterface/gap/convert.gi
@@ -87,14 +87,15 @@ InstallMethod(JuliaToGAP, ["IsList", "IsJuliaObject"],
 
 InstallMethod(JuliaToGAP, ["IsList", "IsJuliaObject", "IsBool"],
 function(filter, obj, recursive)
-    if Julia.isa(obj, Julia.Base.Array) or Julia.isa(obj, Julia.Base.Tuple) then
+    if Julia.isa(obj, Julia.Base.Array) or Julia.isa(obj, Julia.Base.Tuple)
+       or Julia.isa(obj, Julia.Base.AbstractRange) then
         if recursive then
             return Julia.GAP.julia_to_gap(obj,_JL_VAL_TRUE);
         else
             return Julia.GAP.julia_to_gap(obj);
         fi;
     fi;
-    Error("<obj> must be a Julia array or tuple");
+    Error("<obj> must be a Julia array or tuple or range");
 end);
 
 

--- a/pkg/JuliaInterface/tst/convert.tst
+++ b/pkg/JuliaInterface/tst/convert.tst
@@ -148,6 +148,30 @@ gap> list:= GAPToJulia( [ 1, 2, 3 ] );
 gap> JuliaToGAP( IsList, list );
 [ 1, 2, 3 ]
 
+##  ranges
+gap> Julia.GAP.julia_to_gap( JuliaEvalString( "1:3" ) );
+[ 1 .. 3 ]
+gap> Julia.GAP.julia_to_gap( JuliaEvalString( "1:2:5" ) );
+[ 1, 3 .. 5 ]
+gap> Julia.GAP.julia_to_gap( JuliaEvalString( "3:2" ) );
+[  ]
+gap> JuliaToGAP( IsList, JuliaEvalString( "1:3" ) );
+[ 1 .. 3 ]
+gap> JuliaToGAP( IsList, JuliaEvalString( "1:2:5" ) );
+[ 1, 3 .. 5 ]
+gap> JuliaToGAP( IsList, JuliaEvalString( "3:2" ) );
+[  ]
+gap> JuliaToGAP( IsRange, JuliaEvalString( "1:3" ) );
+[ 1 .. 3 ]
+gap> JuliaToGAP( IsRange, JuliaEvalString( "1:2:5" ) );
+[ 1, 3 .. 5 ]
+gap> JuliaToGAP( IsRange, JuliaEvalString( "3:2" ) );
+[  ]
+gap> JuliaToGAP( IsRange, JuliaEvalString( "[ 1, 2, 3 ]" ) );
+Error, <obj> must be a Julia range
+gap> JuliaToGAP( IsRange, JuliaEvalString( "[ 1, 2, 4 ]" ) );
+Error, <obj> must be a Julia range
+
 ##  empty list vs. empty string
 gap> emptylist:= GAPToJulia( JuliaEvalString( "Array{Any,1}"), [] );
 <Julia: Any[]>

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -16,7 +16,15 @@ end
 
 ## implement indexing interface
 Base.getindex(x::GapObj, i::Int64) = Globals.ELM_LIST(x, i)
+Base.getindex(x::GapObj, l::Union{Vector{T},AbstractRange{T}}) where T <: Integer = GAP.Globals.ELMS_LIST(x, GAP.julia_to_gap(l))
+# The following would make sense but could not be installed just for the case
+# that the second argument is a positions list;
+# also large integers (element access) or strings (component access) would have
+# to be handled.
+# Base.getindex(x::GapObj, l::GapObj) = GAP.Globals.ELMS_LIST(x, l)
 Base.setindex!(x::GapObj, v::Any, i::Int64) = Globals.ASS_LIST(x, i, v)
+Base.setindex!(x::GapObj, v::Any, l::Union{Vector{T},AbstractRange{T}}) where T <: Integer = GAP.Globals.ASSS_LIST(x, GAP.julia_to_gap(l), GAP.julia_to_gap(v))
+
 Base.length(x::GapObj) = Globals.Length(x)
 Base.firstindex(x::GapObj) = 1
 Base.lastindex(x::GapObj) = Globals.Length(x)

--- a/test/convenience.jl
+++ b/test/convenience.jl
@@ -79,6 +79,25 @@ end
     @test length(list) == 4
     @test list[4] == 4
 
+    @test list[ 1:2 ] == GAP.EvalString( "[1,2]" )
+    @test list[ 1:2:3 ] == GAP.EvalString( "[1,3]" )
+    @test list[ [1,2] ] == GAP.EvalString( "[1,2]" )
+    list[ [1,2] ] = [ 0, 1 ]
+    @test list[ [1,2] ] == GAP.EvalString( "[0,1]" )
+    list[ 1:2 ] = [ 2, 3 ]
+    @test list[ 1:2 ] == GAP.EvalString( "[2,3]" )
+    list[ 1:2:3 ] = [ 3, 4 ]
+    @test list[ 1:2:3 ] == GAP.EvalString( "[3,4]" )
+    @test list[ 1:1 ] == GAP.EvalString( "[3]" )
+    list[ 1:1 ] = [ 5 ]
+    @test list[ 1:1 ] == GAP.EvalString( "[5]" )
+    @test list[ [1] ] == GAP.EvalString( "[5]" )
+    list[ [1] ] = [ 6 ]
+    @test list[ [1] ] == GAP.EvalString( "[6]" )
+    @test list[ Int[] ] == GAP.EvalString( "[]" )
+    list[ Int[] ] = [  ]
+    @test list[ Int[] ] == GAP.EvalString( "[]" )
+
     @test matrix[1,1] == 1
     @test matrix[2,1] == 3
     matrix[1,2] = 5


### PR DESCRIPTION
- added `getindex` and `setindex!` methods for GAP objects,
  which yield sublist access and assignment;
  this should solve #438

- support `JuliaToGAP( IsList, obj )` where `obj` is a Julia `AbstractRange`;
  this should solve #439

- added tests for the new methods