### PR TITLE
extend the documentation of GAP.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,6 @@ makedocs(
 )
 
 # Compute the links to GAP manuals.
-GAP.compute_links_to_GAP_manuals()
+GAP.compute_links_to_GAP_manuals(@__DIR__)
 
 deploydocs(repo = "github.com/oscar-system/GAP.jl.git", target = "build")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,4 +13,7 @@ makedocs(
     pages = ["index.md"],
 )
 
+# Compute the links to GAP manuals.
+GAP.compute_links_to_GAP_manuals()
+
 deploydocs(repo = "github.com/oscar-system/GAP.jl.git", target = "build")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,6 @@ makedocs(
 )
 
 # Compute the links to GAP manuals.
-GAP.compute_links_to_GAP_manuals(@__DIR__)
+GAP.compute_links_to_gap_manuals(@__DIR__)
 
 deploydocs(repo = "github.com/oscar-system/GAP.jl.git", target = "build")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -63,7 +63,7 @@ using Julia syntax features.
 ```@docs
 Globals
 call_gap_func
-EvalString
+evalstr
 getindex
 setindex!
 getproperty

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,10 +9,30 @@ CurrentModule = GAP
 
 ## Introduction
 
-TODO: describe the goals and non-goals of this package
+GAP.jl is a low level interface from Julia to
+[the computer algebra system GAP](https://www.gap-system.org).
+The term "low level" means that the aim is
+to give Julia access to all GAP objects,
+to let Julia call GAP functions,
+and to provide conversions of low level data
+(integers, Booleans, strings, arrays/lists, dictionaries/records)
+between the two systems.
 
-TODO: also link to JuliaInterface docs (also JuliaExperimental?)
+In particular, it is *not* the aim of GAP.jl to provide Julia types
+for higher level GAP objects that represent algebraic structures,
+such as groups, rings, fields, etc.,
+and mappings between such structures.
 
+The connection between GAP and Julia is in fact bidirectional, that is,
+GAP can access all Julia objects,
+call Julia functions,
+and perform conversions of low level data.
+This direction will become interesting on the Julia side
+as soon as GAP packages provide functionality that is based on
+using Julia code from the GAP side.
+
+The viewpoint of an interface from GAP to Julia is described in
+[the manual of the GAP package JuliaInterface](GAP_ref(JuliaInterface:Title page)).
 
 ## Types
 
@@ -37,16 +57,125 @@ julia_to_gap
 
 ## Convenience adapters
 
-TODO: describe the various convenience / adapter methods we install, e.g. for
-basic arithmetic, accessing GAP list and record entries, calling GAP function, etc.
+This section describes how one can manipulate GAP objects from the Julia side,
+using Julia syntax features.
 
+```@docs
+Globals
+call_gap_func
+EvalString
+getindex
+setindex!
+getproperty
+setproperty!
+hasproperty
+```
 
-TODO: Describe access to arbitrary GAP variables and functions via `GAP.Globals.IDENTIFIER_NAME`
+For the following Julia functions, methods are provided that deal with the
+case that the arguments are GAP objects; they delegate to the corresponding
+GAP operations.
 
-TODO: describe Help system integration
+| Julia        | GAP      |
+|--------------|----------|
+| `length`     | `Length` |
+| `in`         | `\in`    |
+| `zero`       | `ZERO`   |
+| `one`        | `ONE`    |
+| `-` (unary)  | `AINV`   |
+| `+`          | `SUM`    |
+| `-` (binary) | `DIFF`   |
+| `*`          | `PROD`   |
+| `/`          | `QUO`    |
+| `\`          | `LQUO`   |
+| `^`          | `POW`    |
+| `mod`        | `MOD`    |
+| `<`          | `LT`     |
+| `==`         | `EQ`     |
 
+```julia
+julia> l = GAP.julia_to_gap( [ 1, 3, 7, 15 ] )
+GAP: [ 1, 3, 7, 15 ]
+
+julia> m = GAP.julia_to_gap( [ 1 2; 3 4 ] )
+GAP: [ [ 1, 2 ], [ 3, 4 ] ]
+
+julia> length( l )
+4
+
+julia> length( m )  # different from Julia's behaviour
+2
+
+julia> 1 in l
+true
+
+julia> 2 in l
+false
+
+julia> zero( l )
+GAP: [ 0, 0, 0, 0 ]
+
+julia> one( m )
+GAP: [ [ 1, 0 ], [ 0, 1 ] ]
+
+julia> - l
+GAP: [ -1, -3, -7, -15 ]
+
+julia> l + 1
+GAP: [ 2, 4, 8, 16 ]
+
+julia> l + l
+GAP: [ 2, 6, 14, 30 ]
+
+julia> m + m
+GAP: [ [ 2, 4 ], [ 6, 8 ] ]
+
+julia> 1 - m
+GAP: [ [ 0, -1 ], [ -2, -3 ] ]
+
+julia> l * l
+284
+
+julia> l * m
+GAP: [ 10, 14 ]
+
+julia> m * m
+GAP: [ [ 7, 10 ], [ 15, 22 ] ]
+
+julia> 1 / m
+GAP: [ [ -2, 1 ], [ 3/2, -1/2 ] ]
+
+julia> m / 2
+GAP: [ [ 1/2, 1 ], [ 3/2, 2 ] ]
+
+julia> 2 \ m
+GAP: [ [ 1/2, 1 ], [ 3/2, 2 ] ]
+
+julia> m ^ 2
+GAP: [ [ 7, 10 ], [ 15, 22 ] ]
+
+julia> m ^ -1
+GAP: [ [ -2, 1 ], [ 3/2, -1/2 ] ]
+
+julia> mod( l, 3 )
+GAP: [ 1, 0, 1, 0 ]
+
+julia> m < 2 * m
+true
+
+julia> m^2 - 5 * m == 2 * one( m )
+true
+
+```
+
+## Access to the GAP help system
+
+```@docs
+show_GAP_help
+```
 
 ## Managing GAP packages
+
+The following functions allow one to load/install/update/remove GAP packages.
 
 ```@docs
 GAP.Packages.load

--- a/pkg/JuliaInterface/gap/utils.gi
+++ b/pkg/JuliaInterface/gap/utils.gi
@@ -34,3 +34,94 @@ function(obj)
   CloseStream(out);
   return str;
 end );
+
+##  Compute the URL of a manual entry in the current &GAP; online manuals.
+##  (This should eventually be moved to GAPDoc.)
+##
+##  <A>reference</A> must be a string of the form <C>pkgname:label</C>,
+##  for example <C>ref:Size</C> or <C>atlasrep:InfoAtlasRep</C>.
+##
+##  <A>prefix</A>, if given, must be the URL to a directory containing the
+##  HTML versions of &GAP; manuals;
+##  the default is the current address at <C>www.gap-system.org</C>.
+##
+BindGlobal( "UrlOfManualEntry", function( reference, prefix... )
+    local pos, pkgname, label, ref, test, localurl, middle, nextpos, suffix;
+
+    # Deal with the optional argument.
+    if Length( prefix ) = 0 then
+      prefix:= "https://www.gap-system.org/Manuals/";
+    elif Length( prefix ) = 1 and IsString( prefix[1] ) then
+      prefix:= prefix[1];
+    else
+      Error( "<prefix>, if given must be a string" );
+    fi;
+
+    # get package name and label
+    pos:= Position( reference, ':' );
+    if pos = fail then
+      return fail;
+    fi;
+    pkgname:= reference{ [ 1 .. pos-1 ] };
+    label:= reference{ [ pos+1 .. Length( reference ) ] };
+
+    # the anchor for the label
+    ref:= GAPDoc2HTMLProcs.ResolveExternalRef( pkgname, label, 1 );
+    if ref = fail then
+      return fail;
+    fi;
+    test:= ref[1];
+    if test{ [ PositionSublist( test, ": " ) + 2 .. Length( test ) ] }
+       <> label then
+      Info( InfoWarning, 1,
+            "UrlOfManualEntry for label '", label, "': found reference to '",
+            test, "'" );
+      return fail;
+    fi;
+    localurl:= ref[6];
+
+    # prescribe the substring where to cut off the suffix
+    if pkgname = "ref" then
+      middle:= "/doc/ref/";
+    elif pkgname = "tut" then
+      middle:= "/doc/tut/";
+    else
+      middle:= "/pkg/";
+    fi;
+
+    # compute the suffix
+    pos:= PositionSublist( localurl, middle );
+    if pos = fail then
+      return fail;
+    fi;
+    nextpos:= PositionSublist( localurl, middle, pos );
+    while nextpos <> fail do
+      pos:= nextpos;
+      nextpos:= PositionSublist( localurl, "/pkg/", pos );
+    od;
+    suffix:= localurl{ [ pos + 1 .. Length( localurl ) ] };
+
+    return Concatenation( prefix, suffix );
+end );
+
+BindGlobal( "ComputeLinksToGAPManuals", function( str )
+    local pos, pos2, reference, repl;
+
+    pos:= PositionSublist( str, "GAP_ref(" );
+    while pos <> fail do
+      pos2:= Position( str, ')', pos );
+      if pos2 = fail then
+        Info( InfoWarning, 1, "syntax/tagging problem" );
+        return "";
+      fi;
+      reference:= str{ [ pos + 8 .. pos2 - 1 ] };
+      repl:= UrlOfManualEntry( reference );
+      if repl = fail then
+        Info( InfoWarning, 1, "reference '", reference, "' not found" );
+        return "";
+      fi;
+      str:= ReplacedString( str, str{ [ pos .. pos2 ] }, repl );
+      pos:= PositionSublist( str, "GAP_ref(", pos );
+    od;
+    return str;
+end );

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -24,8 +24,18 @@ include(deps_jl)
 """
     FFE
 
-Wraps a pointer to a GAP FFE immediate object.
+Wrap a pointer to a GAP FFE immediate object.
 This type is defined in the JuliaInterface C code.
+
+# Examples
+```jldoctest
+julia> x = GAP.EvalString( "Z(3)" )
+GAP: Z(3)
+
+julia> typeof( x )
+FFE
+
+```
 """
 primitive type FFE 64 end
 
@@ -39,7 +49,48 @@ import Markdown
 """
     GapObj
 
-TODO
+This is the Julia type of all those GAP objects that are not
+"immediate" (Booleans, small integers, FFEs).
+
+# Examples
+```jldoctest
+julia> isa( GAP.EvalString( "[ 1, 2 ]" ), GAP.GapObj ) # a GAP list
+true
+
+julia> isa( GAP.EvalString( "rec()" ), GAP.GapObj )    # a GAP record
+true
+
+julia> isa( GAP.EvalString( "(1,2,3)" ), GAP.GapObj )  # a GAP permutation
+true
+
+julia> isa( GAP.EvalString( "2^64" ), GAP.GapObj )     # a large GAP integer
+true
+
+julia> isa( GAP.EvalString( "2^59" ), GAP.GapObj )     # a small GAP integer
+false
+
+julia> isa( GAP.EvalString( "Z(2)" ), GAP.GapObj )     # a GAP FFE
+false
+
+julia> isa( GAP.EvalString( "true" ), GAP.GapObj )     # a Boolean
+false
+
+```
+
+Note that this is Julia's viewpoint on GAP objects.
+From the viewpoint of GAP, also the pointers to Julia objects are
+implemented as "non-immediate GAP objects",
+but they appear as Julia objects to Julia, not "doubly wrapped".
+
+# Examples
+```jldoctest
+julia> GAP.EvalString( "Julia.Base" )
+Base
+
+julia> isa( GAP.EvalString( "Julia.Base" ), GAP.GapObj ) # native Julia object
+false
+
+```
 """
 abstract type GapObj end
 
@@ -265,7 +316,7 @@ end
 export gap_exe
 
 """
-    GAP.prompt()
+    prompt()
 
 Start a GAP prompt where you can enter GAP commands as in a regular GAP
 session. This prompt can be left as any GAP prompt by either entering `quit;`

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -24,7 +24,7 @@ include(deps_jl)
 """
     FFE
 
-Wrap a pointer to a GAP FFE immediate object.
+Wrap a pointer to a GAP FFE ("finite field element") immediate object.
 This type is defined in the JuliaInterface C code.
 
 # Examples
@@ -66,14 +66,14 @@ true
 julia> isa( GAP.evalstr( "2^64" ), GAP.GapObj )     # a large GAP integer
 true
 
-julia> isa( GAP.evalstr( "2^59" ), GAP.GapObj )     # a small GAP integer
-false
+julia> typeof( GAP.evalstr( "2^59" ) )              # a small GAP integer
+Int64
 
-julia> isa( GAP.evalstr( "Z(2)" ), GAP.GapObj )     # a GAP FFE
-false
+julia> typeof( GAP.evalstr( "Z(2)" ) )              # a GAP FFE
+FFE
 
-julia> isa( GAP.evalstr( "true" ), GAP.GapObj )     # a Boolean
-false
+julia> typeof( GAP.evalstr( "true" ) )              # a Boolean
+Bool
 
 ```
 
@@ -87,8 +87,8 @@ but they appear as Julia objects to Julia, not "doubly wrapped".
 julia> GAP.evalstr( "Julia.Base" )
 Base
 
-julia> isa( GAP.evalstr( "Julia.Base" ), GAP.GapObj ) # native Julia object
-false
+julia> typeof( GAP.evalstr( "Julia.Base" ) )        # native Julia object
+Module
 
 ```
 """

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -29,7 +29,7 @@ This type is defined in the JuliaInterface C code.
 
 # Examples
 ```jldoctest
-julia> x = GAP.EvalString( "Z(3)" )
+julia> x = GAP.evalstr( "Z(3)" )
 GAP: Z(3)
 
 julia> typeof( x )
@@ -54,25 +54,25 @@ This is the Julia type of all those GAP objects that are not
 
 # Examples
 ```jldoctest
-julia> isa( GAP.EvalString( "[ 1, 2 ]" ), GAP.GapObj ) # a GAP list
+julia> isa( GAP.evalstr( "[ 1, 2 ]" ), GAP.GapObj ) # a GAP list
 true
 
-julia> isa( GAP.EvalString( "rec()" ), GAP.GapObj )    # a GAP record
+julia> isa( GAP.evalstr( "rec()" ), GAP.GapObj )    # a GAP record
 true
 
-julia> isa( GAP.EvalString( "(1,2,3)" ), GAP.GapObj )  # a GAP permutation
+julia> isa( GAP.evalstr( "(1,2,3)" ), GAP.GapObj )  # a GAP permutation
 true
 
-julia> isa( GAP.EvalString( "2^64" ), GAP.GapObj )     # a large GAP integer
+julia> isa( GAP.evalstr( "2^64" ), GAP.GapObj )     # a large GAP integer
 true
 
-julia> isa( GAP.EvalString( "2^59" ), GAP.GapObj )     # a small GAP integer
+julia> isa( GAP.evalstr( "2^59" ), GAP.GapObj )     # a small GAP integer
 false
 
-julia> isa( GAP.EvalString( "Z(2)" ), GAP.GapObj )     # a GAP FFE
+julia> isa( GAP.evalstr( "Z(2)" ), GAP.GapObj )     # a GAP FFE
 false
 
-julia> isa( GAP.EvalString( "true" ), GAP.GapObj )     # a Boolean
+julia> isa( GAP.evalstr( "true" ), GAP.GapObj )     # a Boolean
 false
 
 ```
@@ -84,10 +84,10 @@ but they appear as Julia objects to Julia, not "doubly wrapped".
 
 # Examples
 ```jldoctest
-julia> GAP.EvalString( "Julia.Base" )
+julia> GAP.evalstr( "Julia.Base" )
 Base
 
-julia> isa( GAP.EvalString( "Julia.Base" ), GAP.GapObj ) # native Julia object
+julia> isa( GAP.evalstr( "Julia.Base" ), GAP.GapObj ) # native Julia object
 false
 
 ```
@@ -125,9 +125,9 @@ function reset_GAP_ERROR_OUTPUT()
     # a string stream, this does nothing. So we don't do it, which saves us
     # some hassle when calling reset_GAP_ERROR_OUTPUT from `initialize`
     #Globals.CloseStream(Globals.ERROR_OUTPUT)
-    EvalString("_JULIAINTERFACE_ERROR_OUTPUT:= \"\";")
+    evalstr("_JULIAINTERFACE_ERROR_OUTPUT:= \"\";")
     Globals.MakeReadWriteGlobal(julia_to_gap("ERROR_OUTPUT"))
-    EvalString("ERROR_OUTPUT:= OutputTextString( _JULIAINTERFACE_ERROR_OUTPUT, true );")
+    evalstr("ERROR_OUTPUT:= OutputTextString( _JULIAINTERFACE_ERROR_OUTPUT, true );")
     Globals.MakeReadOnlyGlobal(julia_to_gap("ERROR_OUTPUT"))
 end
 
@@ -339,7 +339,7 @@ function prompt()
     # restore GAP's error output
     disable_error_handler = true
     Globals.MakeReadWriteGlobal(julia_to_gap("ERROR_OUTPUT"))
-    EvalString("""ERROR_OUTPUT:= "*errout*";""")
+    evalstr("""ERROR_OUTPUT:= "*errout*";""")
     Globals.MakeReadOnlyGlobal(julia_to_gap("ERROR_OUTPUT"))
 
     # enable break loop
@@ -369,5 +369,6 @@ include("julia_to_gap.jl")
 include("utils.jl")
 include("help.jl")
 include("packages.jl")
+include("obsolete.jl")
 
 end

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -27,7 +27,7 @@ provided that `x` is a GAP list.
 
 # Examples
 ```jldoctest
-julia> l = GAP.EvalString( "[ 1, 2, 3, 5, 8, 13 ]" )
+julia> l = GAP.evalstr( "[ 1, 2, 3, 5, 8, 13 ]" )
 GAP: [ 1, 2, 3, 5, 8, 13 ]
 
 julia> l[4]
@@ -42,7 +42,7 @@ GAP: [ 2, 3, 5 ]
 julia> l[[1,4,4]]
 GAP: [ 1, 5, 5 ]
 
-julia> m = GAP.EvalString( "[ [ 1, 2 ], [ 3, 4 ] ]" )
+julia> m = GAP.evalstr( "[ [ 1, 2 ], [ 3, 4 ] ]" )
 GAP: [ [ 1, 2 ], [ 3, 4 ] ]
 
 julia> m[1,1]
@@ -76,7 +76,7 @@ to the entries in `v`, provided that `x` is a GAP list.
 
 # Examples
 ```jldoctest
-julia> l = GAP.EvalString( "[ 1, 2, 3, 5, 8, 13 ]" )
+julia> l = GAP.evalstr( "[ 1, 2, 3, 5, 8, 13 ]" )
 GAP: [ 1, 2, 3, 5, 8, 13 ]
 
 julia> l[1] = 0
@@ -94,7 +94,7 @@ julia> l[2:4] = [ 7, 7, 7 ]
 julia> l
 GAP: [ 0, 7, 7, 7, 8, 13,, -1 ]
 
-julia> m = GAP.EvalString( "[ [ 1, 2 ], [ 3, 4 ] ]" )
+julia> m = GAP.evalstr( "[ [ 1, 2 ], [ 3, 4 ] ]" )
 GAP: [ [ 1, 2 ], [ 3, 4 ] ]
 
 julia> m[1,2] = 0
@@ -131,7 +131,7 @@ Return the record component of the GAP record `x` that is described by `f`.
 
 # Examples
 ```jldoctest
-julia> r = GAP.EvalString( "rec( a:= 1 )" )
+julia> r = GAP.evalstr( "rec( a:= 1 )" )
 GAP: rec( a := 1 )
 
 julia> r.a
@@ -152,7 +152,7 @@ to the value `v`.
 
 # Examples
 ```jldoctest
-julia> r = GAP.EvalString( "rec( a:= 1 )" )
+julia> r = GAP.evalstr( "rec( a:= 1 )" )
 GAP: rec( a := 1 )
 
 julia> r.b = 0
@@ -176,7 +176,7 @@ and `false` otherwise.
 
 # Examples
 ```jldoctest
-julia> r = GAP.EvalString( "rec( a:= 1 )" )
+julia> r = GAP.evalstr( "rec( a:= 1 )" )
 GAP: rec( a := 1 )
 
 julia> hasproperty( r, :a )

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -15,6 +15,47 @@ function Base.string(obj::Union{GapObj,FFE})
 end
 
 ## implement indexing interface
+
+"""
+    getindex(x::GapObj, i::Int64)
+    getindex(x::GapObj, i::Int64, j::Int64)
+    getindex(x::GapObj, l::Union{Vector{T},AbstractRange{T}}) where {T<:Integer}
+
+Return the entry at position `i` or at position `(i,j)` in `x`,
+or the list of entries in `x` at the positions described by `l`,
+provided that `x` is a GAP list.
+
+# Examples
+```jldoctest
+julia> l = GAP.EvalString( "[ 1, 2, 3, 5, 8, 13 ]" )
+GAP: [ 1, 2, 3, 5, 8, 13 ]
+
+julia> l[4]
+5
+
+julia> l[end]
+13
+
+julia> l[2:4]
+GAP: [ 2, 3, 5 ]
+
+julia> l[[1,4,4]]
+GAP: [ 1, 5, 5 ]
+
+julia> m = GAP.EvalString( "[ [ 1, 2 ], [ 3, 4 ] ]" )
+GAP: [ [ 1, 2 ], [ 3, 4 ] ]
+
+julia> m[1,1]
+1
+
+julia> m[1,2]
+2
+
+julia> m[2,1]
+3
+
+```
+"""
 Base.getindex(x::GapObj, i::Int64) = Globals.ELM_LIST(x, i)
 Base.getindex(x::GapObj, l::Union{Vector{T},AbstractRange{T}}) where {T<:Integer} =
     GAP.Globals.ELMS_LIST(x, GAP.julia_to_gap(l))
@@ -23,6 +64,47 @@ Base.getindex(x::GapObj, l::Union{Vector{T},AbstractRange{T}}) where {T<:Integer
 # also large integers (element access) or strings (component access) would have
 # to be handled.
 # Base.getindex(x::GapObj, l::GapObj) = GAP.Globals.ELMS_LIST(x, l)
+
+"""
+    setindex!(x::GapObj, v::Any, i::Int64)
+    setindex!(x::GapObj, v::Any, i::Int64, j::Int64)
+    setindex!(x::GapObj, v::Any, l::Union{Vector{T},AbstractRange{T}}) where {T<:Integer}
+
+Set the entry at position `i` or `(i,j)` in `x` to `v`,
+or set the entries at the positions in `x` that are described by `l`
+to the entries in `v`, provided that `x` is a GAP list.
+
+# Examples
+```jldoctest
+julia> l = GAP.EvalString( "[ 1, 2, 3, 5, 8, 13 ]" )
+GAP: [ 1, 2, 3, 5, 8, 13 ]
+
+julia> l[1] = 0
+0
+
+julia> l[8] = -1
+-1
+
+julia> l[2:4] = [ 7, 7, 7 ]
+3-element Array{Int64,1}:
+ 7
+ 7
+ 7
+
+julia> l
+GAP: [ 0, 7, 7, 7, 8, 13,, -1 ]
+
+julia> m = GAP.EvalString( "[ [ 1, 2 ], [ 3, 4 ] ]" )
+GAP: [ [ 1, 2 ], [ 3, 4 ] ]
+
+julia> m[1,2] = 0
+0
+
+julia> m
+GAP: [ [ 1, 0 ], [ 3, 4 ] ]
+
+```
+"""
 Base.setindex!(x::GapObj, v::Any, i::Int64) = Globals.ASS_LIST(x, i, v)
 Base.setindex!(x::GapObj, v::Any, l::Union{Vector{T},AbstractRange{T}}) where {T<:Integer} =
     GAP.Globals.ASSS_LIST(x, GAP.julia_to_gap(l), GAP.julia_to_gap(v))
@@ -40,19 +122,92 @@ RNamObj(f::Union{Symbol,Int64,AbstractString}) = Globals.RNamObj(MakeString(stri
 # note: we don't use Union{Symbol,Int64,AbstractString} below to avoid
 # ambiguity between these methods and method `getproperty(x, f::Symbol)`
 # from Julia's Base module
+
+"""
+    getproperty(x::GapObj, f::Symbol)
+    getproperty(x::GapObj, f::Union{AbstractString,Int64})
+
+Return the record component of the GAP record `x` that is described by `f`.
+
+# Examples
+```jldoctest
+julia> r = GAP.EvalString( "rec( a:= 1 )" )
+GAP: rec( a := 1 )
+
+julia> r.a
+1
+
+```
+"""
 Base.getproperty(x::GapObj, f::Symbol) = Globals.ELM_REC(x, RNamObj(f))
 Base.getproperty(x::GapObj, f::Union{AbstractString,Int64}) = Globals.ELM_REC(x, RNamObj(f))
+
+
+"""
+    setproperty!(x::GapObj, f::Symbol, v)
+    setproperty!(x::GapObj, f::Union{AbstractString,Int64}, v)
+
+Set the record component of the GAP record `x` that is described by `f`
+to the value `v`.
+
+# Examples
+```jldoctest
+julia> r = GAP.EvalString( "rec( a:= 1 )" )
+GAP: rec( a := 1 )
+
+julia> r.b = 0
+0
+
+julia> r
+GAP: rec( a := 1, b := 0 )
+
+```
+"""
 Base.setproperty!(x::GapObj, f::Symbol, v) = Globals.ASS_REC(x, RNamObj(f), v)
 Base.setproperty!(x::GapObj, f::Union{AbstractString,Int64}, v) =
     Globals.ASS_REC(x, RNamObj(f), v)
 
-#
-Base.zero(x::Union{GapObj,FFE}) = Globals.ZERO(x)
-Base.one(x::Union{GapObj,FFE}) = Globals.ONE(x)
-Base.:-(x::Union{GapObj,FFE}) = Globals.AINV(x)
+"""
+    hasproperty(x::GapObj, f::Symbol)
+    hasproperty(x::GapObj, f::Union{AbstractString,Int64})
+
+Return `true` if the GAP record `x` has a component that is described by `f`,
+and `false` otherwise.
+
+# Examples
+```jldoctest
+julia> r = GAP.EvalString( "rec( a:= 1 )" )
+GAP: rec( a := 1 )
+
+julia> hasproperty( r, :a )
+true
+
+julia> hasproperty( r, :b )
+false
+
+julia> r.b = 2
+2
+
+julia> hasproperty( r, :b )
+true
+
+julia> r
+GAP: rec( a := 1, b := 2 )
+
+```
+"""
+Base.hasproperty(x::GapObj, f::Symbol) = Globals.ISB_REC(x, RNamObj(f))
+Base.hasproperty(x::GapObj, f::Union{AbstractString,Int64}) =
+    Globals.ISB_REC(x, RNamObj(f))
 
 #
-Base.in(x::Obj, y::GapObj) = Globals.in(x, y)
+Base.zero(x::Union{GapObj,FFE}) = Globals.ZERO(x)   # same mutability
+Base.one(x::Union{GapObj,FFE}) = Globals.ONE_MUT(x) # same mutability
+Base.inv(x::Union{GapObj,FFE}) = Globals.INV_MUT(x) # same mutability
+Base.:-(x::Union{GapObj,FFE}) = Globals.AINV(x)     # same mutability
+
+#
+Base.in(x::Any, y::GapObj) = Globals.in(x, y)
 
 #
 typecombinations = (

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -10,42 +10,42 @@ function RAW_JULIA_TO_GAP(val::Any)::Ptr{Cvoid}
     return ccall(:gap_julia, Ptr{Cvoid}, (Any,), val)
 end
 
-function EvalStringEx(cmd::String)
+function evalstr_ex(cmd::String)
     res = ccall(:GAP_EvalString, Any, (Ptr{UInt8},), cmd)
     return res
 end
 
 """
-    EvalString(cmd::String)
+    evalstr(cmd::String)
 
-Let GAP execute the command(s) given by `cmd` and returns the last result.
+Let GAP execute the command(s) given by `cmd` and return the last result.
 An error is thrown if no value is returned.
 
 # Examples
 ```jldoctest
-julia> GAP.EvalString( "1+2" )
+julia> GAP.evalstr( "1+2" )
 3
 
-julia> GAP.EvalString( "x:= []; y:= 0" )
+julia> GAP.evalstr( "x:= []; y:= 0" )
 0
 
-julia> GAP.EvalString( "Add( x, 1 )" )
+julia> GAP.evalstr( "Add( x, 1 )" )
 ERROR: Error thrown by GAP: Error, List Element: <list>[2] must have an assigned value
 [...]
 
-julia> GAP.EvalString( "x:= []" )
+julia> GAP.evalstr( "x:= []" )
 GAP: [  ]
 
-julia> GAP.EvalString( "Add( x, 1 ); 0" )
+julia> GAP.evalstr( "Add( x, 1 ); 0" )
 0
 
-julia> GAP.EvalString( "x;" )
+julia> GAP.evalstr( "x;" )
 GAP: [ 1 ]
 
 ```
 """
-function EvalString(cmd::String)
-    res = EvalStringEx(cmd * ";")
+function evalstr(cmd::String)
+    res = evalstr_ex(cmd * ";")
     return res[end][2]
 end
 

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -13,7 +13,7 @@ Base.showerror(io::IO, e::ConversionError) =
 """
     gap_to_julia(type, x, recursion_dict=nothing; recursive=true)
 
-Tries to convert the object `x` to a Julia object of type `type`.
+Try to convert the object `x` to a Julia object of type `type`.
 If `x` is a `GAP.GapObj` then the conversion rules are defined in the
 manual of the GAP package JuliaInterface.
 If `x` is another `GAP.Obj` (for example a `Int64`) then the result is

--- a/src/help.jl
+++ b/src/help.jl
@@ -4,9 +4,40 @@ function GAP_help_string(topic::String, onlyexact::Bool = false)
     return GAP.gap_to_julia(GAP.Globals.HelpString(GAP.julia_to_gap(topic), onlyexact))
 end
 
+"""
+    show_GAP_help(topic::String, onlyexact::Bool = false)
+
+Print the information from the GAP help system about `topic` to the screen.
+If `onlyexact` is `true` then only exact matches are shown,
+otherwise all matches.
+For example, `GAP.show_GAP_help("Size")` shows also documentation for
+`SizeScreen` and `SizesPerfectGroups`,
+whereas `GAP.show_GAP_help("Size", true)` shows only documentation for
+`Size`.
+
+For the variant showing all matches,
+one can also enter `?GAP.Globals.Size` at the Julia prompt
+instead of calling `show_GAP_help`.
+
+# Examples
+```
+julia> GAP.show_GAP_help( "Size" )
+[...]  # more than 50 entries from GAP manuals
+
+hepl?> GAP.Globals.Size
+[...]  # the same
+
+julia> GAP.show_GAP_help( "Size", true )
+[...]  # about 15 entries from GAP manuals
+
+```
+"""
 function show_GAP_help(topic::String, onlyexact::Bool = false)
     print(GAP_help_string(topic, onlyexact))
 end
+
+## If one enters `?GAP.Globals.Size` then the following dispatch mechanism
+## does the job.
 
 import Base.Docs: Binding, getdoc, docstr
 
@@ -24,4 +55,14 @@ end
 ## Set getdoc for GlobalsType to nothing,
 ## so it dispatches on the Binding.
 Base.Docs.getdoc(x::GlobalsType) = nothing
-Base.Docs.getdoc(x::GapObj) = Text(GAP_help_string(gap_to_julia(Globals.NameFunction(x))))
+
+## If one enters `?x` for a variable `x` pointing to a `GapObj`
+## then the following gets called.
+## (Note that this feature works for Julia objects as well.)
+function Base.Docs.getdoc(x::GapObj)
+    if Globals.HasNameFunction(x)
+      return Text(GAP_help_string(gap_to_julia(Globals.NameFunction(x))))
+    else
+      return nothing
+    end
+end

--- a/src/help.jl
+++ b/src/help.jl
@@ -1,38 +1,38 @@
 ## enable access to GAP help system from Julia
 
-function GAP_help_string(topic::String, onlyexact::Bool = false)
+function gap_help_string(topic::String, onlyexact::Bool = false)
     return GAP.gap_to_julia(GAP.Globals.HelpString(GAP.julia_to_gap(topic), onlyexact))
 end
 
 """
-    show_GAP_help(topic::String, onlyexact::Bool = false)
+    show_gap_help(topic::String, onlyexact::Bool = false)
 
 Print the information from the GAP help system about `topic` to the screen.
 If `onlyexact` is `true` then only exact matches are shown,
 otherwise all matches.
-For example, `GAP.show_GAP_help("Size")` shows also documentation for
+For example, `GAP.show_gap_help("Size")` shows also documentation for
 `SizeScreen` and `SizesPerfectGroups`,
-whereas `GAP.show_GAP_help("Size", true)` shows only documentation for
+whereas `GAP.show_gap_help("Size", true)` shows only documentation for
 `Size`.
 
 For the variant showing all matches,
 one can also enter `?GAP.Globals.Size` at the Julia prompt
-instead of calling `show_GAP_help`.
+instead of calling `show_gap_help`.
 
 # Examples
 ```
-julia> GAP.show_GAP_help( "Size" )
+julia> GAP.show_gap_help( "Size" )
 [...]  # more than 50 entries from GAP manuals
 
 hepl?> GAP.Globals.Size
 [...]  # the same
 
-julia> GAP.show_GAP_help( "Size", true )
+julia> GAP.show_gap_help( "Size", true )
 [...]  # about 15 entries from GAP manuals
 
 ```
 """
-function show_GAP_help(topic::String, onlyexact::Bool = false)
+function show_gap_help(topic::String, onlyexact::Bool = false)
     print(GAP_help_string(topic, onlyexact))
 end
 
@@ -49,7 +49,7 @@ end
 Base.Docs.Binding(x::GlobalsType, name::Symbol) = GAPHelpType(name)
 
 function Base.Docs.doc(x::GAPHelpType, typesig::Type = Union{})
-    return Text(GAP_help_string(string(x.name)))
+    return Text(gap_help_string(string(x.name)))
 end
 
 ## Set getdoc for GlobalsType to nothing,
@@ -61,7 +61,7 @@ Base.Docs.getdoc(x::GlobalsType) = nothing
 ## (Note that this feature works for Julia objects as well.)
 function Base.Docs.getdoc(x::GapObj)
     if Globals.HasNameFunction(x)
-      return Text(GAP_help_string(gap_to_julia(Globals.NameFunction(x))))
+      return Text(gap_help_string(gap_to_julia(Globals.NameFunction(x))))
     else
       return nothing
     end

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -2,7 +2,7 @@
 """
     julia_to_gap(input, recursive::Val{Recursive} = Val(false), recursion_dict = IdDict())
 
-Converts a julia object `input` to an appropriate GAP object.
+Convert a julia object `input` to an appropriate GAP object.
 If `recursive` is set to `Val(true)`, recursive conversions on
 arrays, tuples, and dictionaries is performed.
 

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -133,11 +133,11 @@ end
 ## Ranges
 # FIXME: eventually check that the values are valid for GAP ranges
 function julia_to_gap(range::UnitRange{T}) where {T<:Integer}
-    return EvalString("[" * string(range.start) * ".." * string(range.stop) * "]")
+    return evalstr("[" * string(range.start) * ".." * string(range.stop) * "]")
 end
 
 function julia_to_gap(range::StepRange{T1,T2}) where {T1<:Integer,T2<:Integer}
-    return EvalString(
+    return evalstr(
         "[" *
         string(range.start) *
         "," *
@@ -156,7 +156,7 @@ function julia_to_gap(
 ) where {Recursive} where {S} where {T<:Union{Symbol,AbstractString}}
 
     # FIXME: add a dedicated method for creating an empty GAP record
-    record = EvalString("rec()")
+    record = evalstr("rec()")
     if Recursive
         recursion_dict[obj] = record
     end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -4,7 +4,7 @@
     @gap <expr>
     @gap(<expr>)
 
-Execute <expr> directly in GAP, as if `GAP.EvalString("<expr>")` was called.
+Execute <expr> directly in GAP, as if `GAP.evalstr("<expr>")` was called.
 This can be used for creating GAP literals directly from Julia.
 
 # Examples
@@ -44,7 +44,7 @@ ERROR: syntax: unexpected ","
 
 ```
 
-Note also that a string argument gets evaluated with `GAP.EvalString`.
+Note also that a string argument gets evaluated with `GAP.evalstr`.
 
 ```jldoctest
 julia> @gap "\\"abc\\""
@@ -59,7 +59,7 @@ GAP: (1,2)(3,4)
 ```
 """
 macro gap(str)
-    return EvalString(string(str))
+    return evalstr(string(str))
 end
 
 export @gap

--- a/src/obsolete.jl
+++ b/src/obsolete.jl
@@ -1,0 +1,6 @@
+## Deprecated function names
+
+function EvalString(cmd::String)
+    @warn "Use GAP.evalstr instead of GAP.EvalString"
+    return evalstr(cmd)
+end

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -54,7 +54,7 @@ function LoadPackageAndExposeGlobals(
     if !all_globals
         current_gvar_list = Globals.ShallowCopy(Globals.NamesGVars())
     end
-    load_package = EvalString("LoadPackage(\"$package\")")
+    load_package = evalstr("LoadPackage(\"$package\")")
     if load_package == Globals.fail
         error("cannot load package $package")
     end

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -81,23 +81,35 @@ module Packages
 import ...GAP: Globals, julia_to_gap, GAPROOT
 
 """
-    load(desc)
+    load(desc::String, version::String = "")
 
-TODO: write text, link to GAP's LoadPackage
+Try to load the newest installed version of the GAP package with name `desc`.
+Return `true` if this is successful, and `false` otherwise.
 
-TODO: support version qualifier?
+The function calls [GAP's `LoadPackage` function](GAP_ref(ref:LoadPackage));
+the package banner is not printed.
 """
-function load(desc::String)
-    return Globals.LoadPackage(julia_to_gap(desc), false)
+function load(desc::String, version::String = "")
+    return Globals.LoadPackage(julia_to_gap(desc),
+                               julia_to_gap(version), false) == true
     # TODO: can we provide more information in case of a failure?
     # GAP unfortunately only gives us info messages...
 end
 
 """
-    install(desc)
+    install(desc::String, interactive::Bool = true)
 
-TODO: copy text from <https://gap-packages.github.io/PackageManager/doc/chap2.html> resp.
-link to that
+Download and install the newest released version of the GAP package
+given by `desc` in the `pkg` subdirectory of GAP's build directory
+(variable `GAP.GAPROOT`).
+Return `true` if the installation is successful or if the package
+was already installed, and `false` otherwise.
+
+`desc` can be either the package name or an URL of an archive or repository
+of the package, or an URL of its `PackageInfo.g` file.
+
+The function uses [the function `InstallPackage` from GAP's package
+`PackageManager`](GAP_ref(PackageManager:InstallPackage)).
 """
 function install(desc::String; interactive::Bool = true, pkgdir::AbstractString = GAPROOT * "/pkg")
     res = load("PackageManager")
@@ -114,10 +126,19 @@ function install(desc::String; interactive::Bool = true, pkgdir::AbstractString 
 end
 
 """
-    update(desc)
+    update(desc::String)
 
-TODO: copy text from <https://gap-packages.github.io/PackageManager/doc/chap2.html> resp.
-link to that
+Update the GAP package given by `desc` that is installed in the
+`pkg` subdirectory of GAP's build directory (variable `GAP.GAPROOT`),
+to the latest version.
+Return `true` if a newer version was installed successfully,
+or if no newer version is available, and `false` otherwise.
+
+`desc` can be either the package name or an URL of an archive or repository
+of the package, or an URL of its `PackageInfo.g` file.
+
+The function uses [the function `UpdatePackage` from GAP's package
+`PackageManager`](GAP_ref(PackageManager:UpdatePackage)).
 """
 function update(desc::String; interactive::Bool = true, pkgdir::AbstractString = GAPROOT * "/pkg")
     res = load("PackageManager")
@@ -128,12 +149,19 @@ function update(desc::String; interactive::Bool = true, pkgdir::AbstractString =
 
     return Globals.UpdatePackage(julia_to_gap(desc), interactive)
 end
+# note that the updated version cannot be used in the current GAP session,
+# because the older version is already loaded;
+# thus nec. to start Julia anew
 
 """
-    remove(desc)
+    remove(desc::String)
 
-TODO: copy text from <https://gap-packages.github.io/PackageManager/doc/chap2.html> resp.
-link to that
+Remove the GAP package with name `desc` that is installed in the
+`pkg` subdirectory of GAP's build directory (variable `GAP.GAPROOT`).
+Return `true` if the removal was successful, and `false` otherwise.
+
+The function uses [the function `RemovePackage` from GAP's package
+`PackageManager`](GAP_ref(PackageManager:RemovePackage)).
 """
 function remove(desc::String; interactive::Bool = true, pkgdir::AbstractString = GAPROOT * "/pkg")
     res = load("PackageManager")

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -81,37 +81,37 @@ module Packages
 import ...GAP: Globals, julia_to_gap, GAPROOT
 
 """
-    load(desc::String, version::String = "")
+    load(spec::String, version::String = "")
 
-Try to load the newest installed version of the GAP package with name `desc`.
+Try to load the newest installed version of the GAP package with name `spec`.
 Return `true` if this is successful, and `false` otherwise.
 
 The function calls [GAP's `LoadPackage` function](GAP_ref(ref:LoadPackage));
 the package banner is not printed.
 """
-function load(desc::String, version::String = "")
-    return Globals.LoadPackage(julia_to_gap(desc),
+function load(spec::String, version::String = "")
+    return Globals.LoadPackage(julia_to_gap(spec),
                                julia_to_gap(version), false) == true
     # TODO: can we provide more information in case of a failure?
     # GAP unfortunately only gives us info messages...
 end
 
 """
-    install(desc::String, interactive::Bool = true)
+    install(spec::String, interactive::Bool = true)
 
 Download and install the newest released version of the GAP package
-given by `desc` in the `pkg` subdirectory of GAP's build directory
+given by `spec` in the `pkg` subdirectory of GAP's build directory
 (variable `GAP.GAPROOT`).
 Return `true` if the installation is successful or if the package
 was already installed, and `false` otherwise.
 
-`desc` can be either the package name or an URL of an archive or repository
-of the package, or an URL of its `PackageInfo.g` file.
+`spec` can be either the name of a package or the URL of an archive or repository
+containing a package, or the URL of a `PackageInfo.g` file.
 
 The function uses [the function `InstallPackage` from GAP's package
 `PackageManager`](GAP_ref(PackageManager:InstallPackage)).
 """
-function install(desc::String; interactive::Bool = true, pkgdir::AbstractString = GAPROOT * "/pkg")
+function install(spec::String; interactive::Bool = true, pkgdir::AbstractString = GAPROOT * "/pkg")
     res = load("PackageManager")
     @assert res
     # FIXME: crude hack to allow PackageManager 1.0 shipped with GAP
@@ -122,55 +122,55 @@ function install(desc::String; interactive::Bool = true, pkgdir::AbstractString 
     # point PackageManager to our internal pkg dir
     Globals.PKGMAN_CustomPackageDir = julia_to_gap(pkgdir)
 
-    return Globals.InstallPackage(julia_to_gap(desc), interactive)
+    return Globals.InstallPackage(julia_to_gap(spec), interactive)
 end
 
 """
-    update(desc::String)
+    update(spec::String)
 
-Update the GAP package given by `desc` that is installed in the
+Update the GAP package given by `spec` that is installed in the
 `pkg` subdirectory of GAP's build directory (variable `GAP.GAPROOT`),
 to the latest version.
 Return `true` if a newer version was installed successfully,
 or if no newer version is available, and `false` otherwise.
 
-`desc` can be either the package name or an URL of an archive or repository
-of the package, or an URL of its `PackageInfo.g` file.
+`spec` can be either the name of a package or the URL of an archive or repository
+containing a package, or the URL of a `PackageInfo.g` file.
 
 The function uses [the function `UpdatePackage` from GAP's package
 `PackageManager`](GAP_ref(PackageManager:UpdatePackage)).
 """
-function update(desc::String; interactive::Bool = true, pkgdir::AbstractString = GAPROOT * "/pkg")
+function update(spec::String; interactive::Bool = true, pkgdir::AbstractString = GAPROOT * "/pkg")
     res = load("PackageManager")
     @assert res
 
     # point PackageManager to our internal pkg dir
     Globals.PKGMAN_CustomPackageDir = julia_to_gap(pkgdir)
 
-    return Globals.UpdatePackage(julia_to_gap(desc), interactive)
+    return Globals.UpdatePackage(julia_to_gap(spec), interactive)
 end
 # note that the updated version cannot be used in the current GAP session,
 # because the older version is already loaded;
 # thus nec. to start Julia anew
 
 """
-    remove(desc::String)
+    remove(spec::String)
 
-Remove the GAP package with name `desc` that is installed in the
+Remove the GAP package with name `spec` that is installed in the
 `pkg` subdirectory of GAP's build directory (variable `GAP.GAPROOT`).
 Return `true` if the removal was successful, and `false` otherwise.
 
 The function uses [the function `RemovePackage` from GAP's package
 `PackageManager`](GAP_ref(PackageManager:RemovePackage)).
 """
-function remove(desc::String; interactive::Bool = true, pkgdir::AbstractString = GAPROOT * "/pkg")
+function remove(spec::String; interactive::Bool = true, pkgdir::AbstractString = GAPROOT * "/pkg")
     res = load("PackageManager")
     @assert res
 
     # point PackageManager to our internal pkg dir
     Globals.PKGMAN_CustomPackageDir = julia_to_gap(pkgdir)
 
-    return Globals.RemovePackage(julia_to_gap(desc), interactive)
+    return Globals.RemovePackage(julia_to_gap(spec), interactive)
 end
 
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -72,5 +72,14 @@ end
 ## convenience function
 
 function Display(x::GapObj)
-    print(GAP.gap_to_julia(AbstractString, Globals.StringDisplayObj(x)))
+    print(gap_to_julia(AbstractString, Globals.StringDisplayObj(x)))
+end
+
+## Compute the links to GAP manuals in the HTML file created by Documenter.jl.
+function compute_links_to_GAP_manuals()
+    filename = abspath(joinpath(@__DIR__, "..", "docs", "build", "index.html"))
+    str = read(filename, String)
+    replstr = gap_to_julia( Globals.ComputeLinksToGAPManuals( julia_to_gap( str ) ) )
+    Base.Filesystem.mv( filename, filename * "~", force = true )
+    Base.write( filename, replstr )
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -76,7 +76,7 @@ function Display(x::GapObj)
 end
 
 ## Compute the links to GAP manuals in the HTML file created by Documenter.jl.
-function compute_links_to_GAP_manuals(docsdir)
+function compute_links_to_gap_manuals(docsdir)
     filename = abspath(joinpath(docsdir, "build", "index.html"))
     str = read(filename, String)
     replstr = gap_to_julia( Globals.ComputeLinksToGAPManuals( julia_to_gap( str ) ) )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -76,8 +76,8 @@ function Display(x::GapObj)
 end
 
 ## Compute the links to GAP manuals in the HTML file created by Documenter.jl.
-function compute_links_to_GAP_manuals()
-    filename = abspath(joinpath(@__DIR__, "..", "docs", "build", "index.html"))
+function compute_links_to_GAP_manuals(docsdir)
+    filename = abspath(joinpath(docsdir, "build", "index.html"))
     str = read(filename, String)
     replstr = gap_to_julia( Globals.ComputeLinksToGAPManuals( julia_to_gap( str ) ) )
     Base.Filesystem.mv( filename, filename * "~", force = true )

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -55,7 +55,7 @@ end
 end
 
 @testset "gapcalls" begin
-    f = GAP.EvalString("{x...} -> x")
+    f = GAP.evalstr("{x...} -> x")
 
     @test GAP.julia_to_gap([]) == f()
     @test GAP.julia_to_gap([1]) == f(1)
@@ -85,7 +85,7 @@ end
 
 @testset "bugfixes" begin
     # from issue #324:
-    l = GAP.EvalString("[1,~,3]")
+    l = GAP.evalstr("[1,~,3]")
     @test l[2] === l
     @test GAP.gap_to_julia(GAP.Globals.StringViewObj(l)) == "[ 1, ~, 3 ]"
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -4,88 +4,88 @@
     @test GAP.Obj(true) == true
 
     ## Conversion to GAP.Obj and GAP.GapObj.
-    x = GAP.EvalString("2^100")
+    x = GAP.evalstr("2^100")
     @test GAP.GapObj(x) == x
     @test GAP.Obj(true) == true
-    x = GAP.EvalString("Z(3)")
+    x = GAP.evalstr("Z(3)")
     @test GAP.Obj(x) == x
     @test GAP.Obj(0) == 0
 
     ## Border cases
-    x = GAP.EvalString("2^100")
+    x = GAP.evalstr("2^100")
     @test_throws InexactError Int64(x)
     @test Int128(x) == BigInt(2)^100
     @test BigInt(x) == BigInt(2)^100
-    x = GAP.EvalString("2^62")  # not an immediate integer
+    x = GAP.evalstr("2^62")  # not an immediate integer
     @test Int64(x) == 2^62
 
     ## BigInts
-    x = GAP.EvalString("2^100")
+    x = GAP.evalstr("2^100")
     @test BigInt(x) == BigInt(2)^100
-    x = GAP.EvalString("1/2")
+    x = GAP.evalstr("1/2")
     @test_throws GAP.ConversionError BigInt(x)
 
     ## Rationals
-    x = GAP.EvalString("2^100")
+    x = GAP.evalstr("2^100")
     @test Rational{BigInt}(x) == BigInt(2)^100 // 1
-    x = GAP.EvalString("2^100/3")
+    x = GAP.evalstr("2^100/3")
     @test Rational{BigInt}(x) == BigInt(2)^100 // 3
-    x = GAP.EvalString("(1,2,3)")
+    x = GAP.evalstr("(1,2,3)")
     @test_throws GAP.ConversionError Rational{BigInt}(x)
 
     ## Floats
-    x = GAP.EvalString("2.")
+    x = GAP.evalstr("2.")
     @test Float64(x) == 2.0
     @test Float32(x) == Float32(2.0)
     @test Float16(x) == Float16(2.0)
     @test BigFloat(x) == BigFloat(2.0)
-    x = GAP.EvalString("(1,2,3)")
+    x = GAP.evalstr("(1,2,3)")
     @test_throws GAP.ConversionError Float64(x)
 
     ## big
-    x = GAP.EvalString("2^100")
+    x = GAP.evalstr("2^100")
     @test big(x) == BigInt(2)^100
-    x = GAP.EvalString("2^100/3")
+    x = GAP.evalstr("2^100/3")
     @test big(x) == BigInt(2)^100 // 3
-    x = GAP.EvalString("2.")
+    x = GAP.evalstr("2.")
     @test big(x) == BigFloat(2.0)
-    x = GAP.EvalString("[]")
+    x = GAP.evalstr("[]")
     @test_throws GAP.ConversionError big(x)
 
     ## Chars
-    x = GAP.EvalString("'x'")
+    x = GAP.evalstr("'x'")
     @test Cuchar(x) == Cuchar('x')
-    x = GAP.EvalString("(1,2,3)")
+    x = GAP.evalstr("(1,2,3)")
     @test_throws GAP.ConversionError Cuchar(x)
 
     ## Strings
-    x = GAP.EvalString("[]")
+    x = GAP.evalstr("[]")
     @test GAP.Globals.IsString(x) == true
     @test GAP.Globals.IsStringRep(x) == false
     @test String(x) == ""
-    x = GAP.EvalString("[ 'a', 'b', 'c' ]")
+    x = GAP.evalstr("[ 'a', 'b', 'c' ]")
     @test GAP.Globals.IsString(x) == true
     @test GAP.Globals.IsStringRep(x) == false
     @test String(x) == "abc"
-    x = GAP.EvalString("\"foo\"")
+    x = GAP.evalstr("\"foo\"")
     @test String(x) == "foo"
     @test AbstractString(x) == "foo"
 
     ## Symbols
     @test Symbol(x) == :foo
-    x = GAP.EvalString("(1,2,3)")
+    x = GAP.evalstr("(1,2,3)")
     @test_throws GAP.ConversionError AbstractString(x)
 
     # Convert GAP string to Vector{UInt8} (==Array{UInt8,1})
-    x = GAP.EvalString("\"foo\"")
+    x = GAP.evalstr("\"foo\"")
     @test Vector{UInt8}(x) == UInt8[0x66, 0x6f, 0x6f]
-    x = GAP.EvalString("[1,2,3]")
+    x = GAP.evalstr("[1,2,3]")
     @test Vector{UInt8}(x) == UInt8[1, 2, 3]
 
     ## BitArrays
-    x = GAP.EvalString("[ true, false, false, true ]")
+    x = GAP.evalstr("[ true, false, false, true ]")
     @test BitArray{1}(x) == [true, false, false, true]
-    x = GAP.EvalString("[ 1, 0, 0, 1 ]")
+    x = GAP.evalstr("[ 1, 0, 0, 1 ]")
     @test_throws GAP.ConversionError BitArray{1}(x)
 
     ## Vectors
@@ -96,7 +96,7 @@
     n = GAP.julia_to_gap(big(2)^100)
     @test_throws GAP.ConversionError Vector{Int64}(n)
     @test_throws GAP.ConversionError Vector{BigInt}(n)
-    x = GAP.EvalString("[ [ 1, 2 ], [ 3, 4 ] ]")
+    x = GAP.evalstr("[ [ 1, 2 ], [ 3, 4 ] ]")
     nonrec1 = Vector{GAP.GapObj}(x)
     nonrec2 = Vector{Any}(x; recursive = false)
     rec = Vector{Any}(x; recursive = true)
@@ -110,14 +110,14 @@
     @test z[1] === z[2]
 
     ## Matrices
-    n = GAP.EvalString("[[1,2],[3,4]]")
+    n = GAP.evalstr("[[1,2],[3,4]]")
     @test Matrix{Int64}(n) == [1 2; 3 4]
     xt = [(1,) (2,); (3,) (4,)]
     n = GAP.julia_to_gap(xt, Val(false))
     @test Matrix{Tuple{Int64}}(n) == xt
     n = GAP.julia_to_gap(big(2)^100)
     @test_throws GAP.ConversionError Matrix{Int64}(n)
-    n = GAP.EvalString("[[1,2],[,4]]")
+    n = GAP.evalstr("[[1,2],[,4]]")
     @test Matrix{Union{Int64,Nothing}}(n) == [1 2; nothing 4]
     x = [1, 2]
     m = Any[1 2; 3 4]
@@ -138,7 +138,7 @@
     @test_throws ArgumentError Tuple{Any,Any,Any,Any}(x)
     n = GAP.julia_to_gap(big(2)^100)
     @test_throws GAP.ConversionError Tuple{Int64,Any,Int32}(n)
-    x = GAP.EvalString("[ [ 1, 2 ], [ 3, [ 4, 5 ] ] ]")
+    x = GAP.evalstr("[ [ 1, 2 ], [ 3, [ 4, 5 ] ] ]")
     y = Tuple{GAP.Obj,Any}(x)
     @test isa(y, Tuple)
     @test isa(y[1], GAP.Obj)
@@ -151,32 +151,32 @@
     @test isa(y[2][2], GAP.Obj)
 
     ## Ranges
-    r = GAP.EvalString("[]")
+    r = GAP.evalstr("[]")
     @test UnitRange{Int64}(r) == 1:0
     @test StepRange{Int64,Int64}(r) == 1:1:0
-    r = GAP.EvalString("[ 1 ]")
+    r = GAP.evalstr("[ 1 ]")
     @test UnitRange{Int64}(r) == 1:1
     @test StepRange{Int64,Int64}(r) == 1:1:1
-    r = GAP.EvalString("[ 4 .. 13 ]")
+    r = GAP.evalstr("[ 4 .. 13 ]")
     @test UnitRange{Int64}(r) == 4:13
     @test StepRange{Int64,Int64}(r) == 4:1:13
-    r = GAP.EvalString("[ 1, 4 .. 10 ]")
+    r = GAP.evalstr("[ 1, 4 .. 10 ]")
     @test_throws ArgumentError UnitRange{Int64}(r)
     @test StepRange{Int64,Int64}(r) == 1:3:10
-    r = GAP.EvalString("[ 1, 2, 4 ]")
+    r = GAP.evalstr("[ 1, 2, 4 ]")
     @test_throws GAP.ConversionError UnitRange{Int64}(r)
     @test_throws GAP.ConversionError StepRange{Int64,Int64}(r)
-    r = GAP.EvalString("rec()")
+    r = GAP.evalstr("rec()")
     @test_throws GAP.ConversionError UnitRange{Int64}(r)
     @test_throws GAP.ConversionError StepRange{Int64,Int64}(r)
 
     ## Dictionaries
-    x = GAP.EvalString("rec( foo := 1, bar := \"foo\" )")
+    x = GAP.evalstr("rec( foo := 1, bar := \"foo\" )")
     y = Dict{Symbol,Any}(:foo => 1, :bar => "foo")
     @test Dict{Symbol,Any}(x) == y
     n = GAP.julia_to_gap(big(2)^100)
     @test_throws GAP.ConversionError Dict{Symbol,Any}(n)
-    x = GAP.EvalString("rec( a:= [ 1, 2 ], b:= [ 3, [ 4, 5 ] ] )")
+    x = GAP.evalstr("rec( a:= [ 1, 2 ], b:= [ 3, [ 4, 5 ] ] )")
     y = Dict{Symbol,Any}(x)
     @test isa(y, Dict)
     @test isa(y[:a], Array)
@@ -187,12 +187,12 @@
     @test isa(y[:b], GAP.Obj)
 
     ## Conversions involving circular references
-    xx = GAP.EvalString("l:=[1];x:=[l,l];")
+    xx = GAP.evalstr("l:=[1];x:=[l,l];")
     conv = Tuple{Tuple{Int64},Tuple{Int64}}(xx)
     @test conv[1] === conv[2]
 
     ## Test converting GAP lists with holes in them
-    xx = GAP.EvalString("[1,,1]")
+    xx = GAP.evalstr("[1,,1]")
     @test Vector{Any}(xx) == Any[1, nothing, 1]
     @test_throws MethodError Vector{Int64}(xx)
     @test Vector{Union{Nothing,Int64}}(xx) == Union{Nothing,Int64}[1, nothing, 1]

--- a/test/convenience.jl
+++ b/test/convenience.jl
@@ -2,11 +2,11 @@
 @testset "integer_arithmetics" begin
 
     # Create some large integers
-    large_int = GAP.EvalString("2^100")
-    large_int_p1 = GAP.EvalString("2^100 + 1")
-    large_int_m1 = GAP.EvalString("2^100 - 1")
-    large_int_squared = GAP.EvalString("2^200")
-    large_int_t2 = GAP.EvalString("2^101")
+    large_int = GAP.evalstr("2^100")
+    large_int_p1 = GAP.evalstr("2^100 + 1")
+    large_int_m1 = GAP.evalstr("2^100 - 1")
+    large_int_squared = GAP.evalstr("2^200")
+    large_int_t2 = GAP.evalstr("2^101")
 
     @test zero(large_int) == 0
     @test one(large_int) == 1
@@ -42,9 +42,9 @@ end
 
 @testset "ffe_arithmetics" begin
 
-    z3_gen = GAP.EvalString("Z(3)")
-    z3_one = GAP.EvalString("Z(3)^0")
-    z3_zero = GAP.EvalString("0 * Z(3)")
+    z3_gen = GAP.evalstr("Z(3)")
+    z3_one = GAP.evalstr("Z(3)^0")
+    z3_zero = GAP.evalstr("0 * Z(3)")
 
     z3 = GAP.Globals.Z(3)
 
@@ -73,9 +73,9 @@ end
 end
 
 @testset "object_access" begin
-    list = GAP.EvalString("[1,2,3]")
-    matrix = GAP.EvalString("[[1,2],[3,4]]")
-    record = GAP.EvalString("rec( one := 1 )")
+    list = GAP.evalstr("[1,2,3]")
+    matrix = GAP.evalstr("[[1,2],[3,4]]")
+    record = GAP.evalstr("rec( one := 1 )")
 
     @test length(list) == 3
     @test list[1] == 1
@@ -85,24 +85,24 @@ end
     @test length(list) == 4
     @test list[4] == 4
 
-    @test list[1:2] == GAP.EvalString("[1,2]")
-    @test list[1:2:3] == GAP.EvalString("[1,3]")
-    @test list[[1, 2]] == GAP.EvalString("[1,2]")
+    @test list[1:2] == GAP.evalstr("[1,2]")
+    @test list[1:2:3] == GAP.evalstr("[1,3]")
+    @test list[[1, 2]] == GAP.evalstr("[1,2]")
     list[[1, 2]] = [0, 1]
-    @test list[[1, 2]] == GAP.EvalString("[0,1]")
+    @test list[[1, 2]] == GAP.evalstr("[0,1]")
     list[1:2] = [2, 3]
-    @test list[1:2] == GAP.EvalString("[2,3]")
+    @test list[1:2] == GAP.evalstr("[2,3]")
     list[1:2:3] = [3, 4]
-    @test list[1:2:3] == GAP.EvalString("[3,4]")
-    @test list[1:1] == GAP.EvalString("[3]")
+    @test list[1:2:3] == GAP.evalstr("[3,4]")
+    @test list[1:1] == GAP.evalstr("[3]")
     list[1:1] = [5]
-    @test list[1:1] == GAP.EvalString("[5]")
-    @test list[[1]] == GAP.EvalString("[5]")
+    @test list[1:1] == GAP.evalstr("[5]")
+    @test list[[1]] == GAP.evalstr("[5]")
     list[[1]] = [6]
-    @test list[[1]] == GAP.EvalString("[6]")
-    @test list[Int[]] == GAP.EvalString("[]")
+    @test list[[1]] == GAP.evalstr("[6]")
+    @test list[Int[]] == GAP.evalstr("[]")
     list[Int[]] = []
-    @test list[Int[]] == GAP.EvalString("[]")
+    @test list[Int[]] == GAP.evalstr("[]")
 
     @test matrix[1, 1] == 1
     @test matrix[2, 1] == 3

--- a/test/convenience.jl
+++ b/test/convenience.jl
@@ -64,6 +64,12 @@ end
     pi = @gap "(1,2,3)(4,17)"
     @test !(pi in sym5)
     @test pi^2 in sym5
+
+    # Julia object in GAP list
+    l = [ [ 1 2 ], [ 3 4 ] ]
+    gaplist = GAP.julia_to_gap( l )  # list of Julia arrays
+    @test l[1] in gaplist
+    @test !([ 5 6 ] in gaplist)
 end
 
 @testset "object_access" begin

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -6,10 +6,10 @@
     @test GAP.gap_to_julia(Any, "foo") == "foo"
 
     ## Conversion to GAP.Obj and GAP.GapObj.
-    x = GAP.EvalString("2^100")
+    x = GAP.evalstr("2^100")
     @test GAP.gap_to_julia(GAP.GapObj, x) == x
     @test GAP.gap_to_julia(GAP.Obj, true) == true
-    x = GAP.EvalString("Z(3)")
+    x = GAP.evalstr("Z(3)")
     @test GAP.gap_to_julia(GAP.Obj, x) == x
     @test GAP.gap_to_julia(GAP.Obj, 0) == 0
 
@@ -28,77 +28,77 @@
     @test GAP.gap_to_julia(UInt8, 1) == UInt8(1)
 
     ## Border cases
-    x = GAP.EvalString("2^100")
+    x = GAP.evalstr("2^100")
     @test_throws InexactError GAP.gap_to_julia(Int64, x)
     @test GAP.gap_to_julia(Int128, x) == BigInt(2)^100
     @test GAP.gap_to_julia(BigInt, x) == BigInt(2)^100
-    x = GAP.EvalString("2^62")  # not an immediate integer
+    x = GAP.evalstr("2^62")  # not an immediate integer
     @test GAP.gap_to_julia(Int64, x) == 2^62
 
     ## BigInts
     @test GAP.gap_to_julia(BigInt, 1) == BigInt(1)
-    x = GAP.EvalString("2^100")
+    x = GAP.evalstr("2^100")
     @test GAP.gap_to_julia(BigInt, x) == BigInt(2)^100
     @test GAP.gap_to_julia(x) == BigInt(2)^100
-    x = GAP.EvalString("1/2")
+    x = GAP.evalstr("1/2")
     @test_throws GAP.ConversionError GAP.gap_to_julia(BigInt, x)
 
     ## Rationals
     @test GAP.gap_to_julia(Rational{Int64}, 1) == 1 // 1
-    x = GAP.EvalString("2^100")
+    x = GAP.evalstr("2^100")
     @test GAP.gap_to_julia(Rational{BigInt}, x) == BigInt(2)^100 // 1
-    x = GAP.EvalString("2^100/3")
+    x = GAP.evalstr("2^100/3")
     @test GAP.gap_to_julia(Rational{BigInt}, x) == BigInt(2)^100 // 3
     @test GAP.gap_to_julia(x) == BigInt(2)^100 // 3
-    x = GAP.EvalString("(1,2,3)")
+    x = GAP.evalstr("(1,2,3)")
     @test_throws GAP.ConversionError GAP.gap_to_julia(Rational{BigInt}, x)
 
     ## Floats
-    x = GAP.EvalString("2.")
+    x = GAP.evalstr("2.")
     @test GAP.gap_to_julia(Float64, x) == 2.0
     @test GAP.gap_to_julia(x) == 2.0
     @test GAP.gap_to_julia(Float32, x) == Float32(2.0)
     @test GAP.gap_to_julia(Float16, x) == Float16(2.0)
     @test GAP.gap_to_julia(BigFloat, x) == BigFloat(2.0)
-    x = GAP.EvalString("(1,2,3)")
+    x = GAP.evalstr("(1,2,3)")
     @test_throws GAP.ConversionError GAP.gap_to_julia(Float64, x)
 
     ## Chars
-    x = GAP.EvalString("'x'")
+    x = GAP.evalstr("'x'")
     @test GAP.gap_to_julia(Cuchar, x) == Cuchar('x')
     @test GAP.gap_to_julia(x) == Cuchar('x')
-    x = GAP.EvalString("(1,2,3)")
+    x = GAP.evalstr("(1,2,3)")
     @test_throws GAP.ConversionError GAP.gap_to_julia(Cuchar, x)
 
     ## Strings
-    x = GAP.EvalString("[]")
+    x = GAP.evalstr("[]")
     @test GAP.Globals.IsString(x) == true
     @test GAP.Globals.IsStringRep(x) == false
     @test GAP.gap_to_julia(String, x) == ""
-    x = GAP.EvalString("[ 'a', 'b', 'c' ]")
+    x = GAP.evalstr("[ 'a', 'b', 'c' ]")
     @test GAP.Globals.IsString(x) == true
     @test GAP.Globals.IsStringRep(x) == false
     @test GAP.gap_to_julia(String, x) == "abc"
-    x = GAP.EvalString("\"foo\"")
+    x = GAP.evalstr("\"foo\"")
     @test GAP.gap_to_julia(String, x) == "foo"
     @test GAP.gap_to_julia(AbstractString, x) == "foo"
     @test GAP.gap_to_julia(x) == "foo"
 
     ## Symbols
     @test GAP.gap_to_julia(Symbol, x) == :foo
-    x = GAP.EvalString("(1,2,3)")
+    x = GAP.evalstr("(1,2,3)")
     @test_throws GAP.ConversionError GAP.gap_to_julia(AbstractString, x)
 
     # Convert GAP string to Vector{UInt8} (==Array{UInt8,1})
-    x = GAP.EvalString("\"foo\"")
+    x = GAP.evalstr("\"foo\"")
     @test GAP.gap_to_julia(Array{UInt8,1}, x) == UInt8[0x66, 0x6f, 0x6f]
-    x = GAP.EvalString("[1,2,3]")
+    x = GAP.evalstr("[1,2,3]")
     @test GAP.gap_to_julia(Array{UInt8,1}, x) == UInt8[1, 2, 3]
 
     ## BitArrays
-    x = GAP.EvalString("[ true, false, false, true ]")
+    x = GAP.evalstr("[ true, false, false, true ]")
     @test GAP.gap_to_julia(BitArray{1}, x) == [true, false, false, true]
-    x = GAP.EvalString("[ 1, 0, 0, 1 ]")
+    x = GAP.evalstr("[ 1, 0, 0, 1 ]")
     @test_throws GAP.ConversionError GAP.gap_to_julia(BitArray{1}, x)
 
     ## Vectors
@@ -110,7 +110,7 @@
     n = GAP.julia_to_gap(big(2)^100)
     @test_throws GAP.ConversionError GAP.gap_to_julia(Array{Int64,1}, n)
     @test_throws GAP.ConversionError GAP.gap_to_julia(Array{BigInt,1}, n)
-    x = GAP.EvalString("[ [ 1, 2 ], [ 3, 4 ] ]")
+    x = GAP.evalstr("[ [ 1, 2 ], [ 3, 4 ] ]")
     nonrec1 = GAP.gap_to_julia(Array{GAP.GapObj,1}, x)
     nonrec2 = GAP.gap_to_julia(Array{Any,1}, x; recursive = false)
     rec = GAP.gap_to_julia(Array{Any,1}, x; recursive = true)
@@ -124,14 +124,14 @@
     @test z[1] === z[2]
 
     ## Matrices
-    n = GAP.EvalString("[[1,2],[3,4]]")
+    n = GAP.evalstr("[[1,2],[3,4]]")
     @test GAP.gap_to_julia(Array{Int64,2}, n) == [1 2; 3 4]
     xt = [(1,) (2,); (3,) (4,)]
     n = GAP.julia_to_gap(xt, Val(false))
     @test GAP.gap_to_julia(Array{Tuple{Int64},2}, n) == xt
     n = GAP.julia_to_gap(big(2)^100)
     @test_throws GAP.ConversionError GAP.gap_to_julia(Array{Int64,2}, n)
-    n = GAP.EvalString("[[1,2],[,4]]")
+    n = GAP.evalstr("[[1,2],[,4]]")
     @test GAP.gap_to_julia(Array{Union{Int64,Nothing},2}, n) == [1 2; nothing 4]
     x = [1, 2]
     m = Any[1 2; 3 4]
@@ -152,7 +152,7 @@
     @test_throws ArgumentError GAP.gap_to_julia(Tuple{Any,Any,Any,Any}, x)
     n = GAP.julia_to_gap(big(2)^100)
     @test_throws GAP.ConversionError GAP.gap_to_julia(Tuple{Int64,Any,Int32}, n)
-    x = GAP.EvalString("[ [ 1, 2 ], [ 3, [ 4, 5 ] ] ]")
+    x = GAP.evalstr("[ [ 1, 2 ], [ 3, [ 4, 5 ] ] ]")
     y = GAP.gap_to_julia(Tuple{GAP.Obj,Any}, x)
     @test isa(y, Tuple)
     @test isa(y[1], GAP.Obj)
@@ -165,33 +165,33 @@
     @test isa(y[2][2], GAP.Obj)
 
     ## Ranges
-    r = GAP.EvalString("[]")
+    r = GAP.evalstr("[]")
     @test GAP.gap_to_julia(UnitRange{Int64}, r) == 1:0
     @test GAP.gap_to_julia(StepRange{Int64,Int64}, r) == 1:1:0
-    r = GAP.EvalString("[ 1 ]")
+    r = GAP.evalstr("[ 1 ]")
     @test GAP.gap_to_julia(UnitRange{Int64}, r) == 1:1
     @test GAP.gap_to_julia(StepRange{Int64,Int64}, r) == 1:1:1
-    r = GAP.EvalString("[ 4 .. 13 ]")
+    r = GAP.evalstr("[ 4 .. 13 ]")
     @test GAP.gap_to_julia(UnitRange{Int64}, r) == 4:13
     @test GAP.gap_to_julia(StepRange{Int64,Int64}, r) == 4:1:13
-    r = GAP.EvalString("[ 1, 4 .. 10 ]")
+    r = GAP.evalstr("[ 1, 4 .. 10 ]")
     @test_throws ArgumentError GAP.gap_to_julia(UnitRange{Int64}, r)
     @test GAP.gap_to_julia(StepRange{Int64,Int64}, r) == 1:3:10
-    r = GAP.EvalString("[ 1, 2, 4 ]")
+    r = GAP.evalstr("[ 1, 2, 4 ]")
     @test_throws GAP.ConversionError GAP.gap_to_julia(UnitRange{Int64}, r)
     @test_throws GAP.ConversionError GAP.gap_to_julia(StepRange{Int64,Int64}, r)
-    r = GAP.EvalString("rec()")
+    r = GAP.evalstr("rec()")
     @test_throws GAP.ConversionError GAP.gap_to_julia(UnitRange{Int64}, r)
     @test_throws GAP.ConversionError GAP.gap_to_julia(StepRange{Int64,Int64}, r)
 
     ## Dictionaries
-    x = GAP.EvalString("rec( foo := 1, bar := \"foo\" )")
+    x = GAP.evalstr("rec( foo := 1, bar := \"foo\" )")
     y = Dict{Symbol,Any}(:foo => 1, :bar => "foo")
     @test GAP.gap_to_julia(Dict{Symbol,Any}, x) == y
     @test GAP.gap_to_julia(x) == y
     n = GAP.julia_to_gap(big(2)^100)
     @test_throws GAP.ConversionError GAP.gap_to_julia(Dict{Symbol,Any}, n)
-    x = GAP.EvalString("rec( a:= [ 1, 2 ], b:= [ 3, [ 4, 5 ] ] )")
+    x = GAP.evalstr("rec( a:= [ 1, 2 ], b:= [ 3, [ 4, 5 ] ] )")
     y = GAP.gap_to_julia(Dict{Symbol,Any}, x)
     @test isa(y, Dict)
     @test isa(y[:a], Array)
@@ -202,21 +202,21 @@
     @test isa(y[:b], GAP.Obj)
 
     ## Default
-    x = GAP.EvalString("(1,2,3)")
+    x = GAP.evalstr("(1,2,3)")
     @test_throws GAP.ConversionError GAP.gap_to_julia(x)
 
     ## Conversions involving circular references
-    xx = GAP.EvalString("l:=[1];x:=[l,l];")
+    xx = GAP.evalstr("l:=[1];x:=[l,l];")
     conv = GAP.gap_to_julia(xx)
     @test conv[1] === conv[2]
     conv = GAP.gap_to_julia(Tuple{Tuple{Int64},Tuple{Int64}}, xx)
     @test conv[1] === conv[2]
 
-    xx = GAP.EvalString("[~]")
+    xx = GAP.evalstr("[~]")
     conv = GAP.gap_to_julia(xx)
     @test conv === conv[1]
 
-    xx = GAP.EvalString("rec(a := 1, b := ~)")
+    xx = GAP.evalstr("rec(a := 1, b := ~)")
     conv = GAP.gap_to_julia(xx)
     @test conv === conv[:b]
 
@@ -225,7 +225,7 @@
     @test_throws ErrorException GAP.gap_to_julia(Dict{Int64,Int64}, xx)
 
     ## Test converting GAP lists with holes in them
-    xx = GAP.EvalString("[1,,1]")
+    xx = GAP.evalstr("[1,,1]")
     @test GAP.gap_to_julia(xx) == Any[1, nothing, 1]
     @test GAP.gap_to_julia(Array{Any,1}, xx) == Any[1, nothing, 1]
     @test_throws MethodError GAP.gap_to_julia(Array{Int64,1}, xx)
@@ -267,7 +267,7 @@ end
     @test GAP.Globals.IsInt(GAP.julia_to_gap(2^63))
 
     # see issue https://github.com/oscar-system/GAP.jl/issues/332
-    @test 2^60 * GAP.Globals.Factorial(20) == GAP.EvalString("2^60 * Factorial(20)")
+    @test 2^60 * GAP.Globals.Factorial(20) == GAP.evalstr("2^60 * Factorial(20)")
 
     ## Unsigned integers
     @test GAP.julia_to_gap(UInt128(1)) == 1
@@ -278,73 +278,73 @@ end
 
     ## BigInts
     @test GAP.julia_to_gap(BigInt(1)) == 1
-    x = GAP.EvalString("2^100")
+    x = GAP.evalstr("2^100")
     @test GAP.julia_to_gap(BigInt(2)^100) == x
 
     ## Rationals
-    x = GAP.EvalString("2^100")
+    x = GAP.evalstr("2^100")
     @test GAP.julia_to_gap(Rational{BigInt}(2)^100 // 1) == x
-    x = GAP.EvalString("2^100/3")
+    x = GAP.evalstr("2^100/3")
     @test GAP.julia_to_gap(Rational{BigInt}(2)^100 // 3) == x
     @test GAP.julia_to_gap(1 // 0) == GAP.Globals.infinity
     @test GAP.julia_to_gap(-1 // 0) == -GAP.Globals.infinity
 
     ## Floats
-    x = GAP.EvalString("2.")
+    x = GAP.evalstr("2.")
     @test GAP.julia_to_gap(2.0) == x
     @test GAP.julia_to_gap(Float32(2.0)) == x
     @test GAP.julia_to_gap(Float16(2.0)) == x
 
     ## Chars
-    x = GAP.EvalString("'x'")
+    x = GAP.evalstr("'x'")
     @test GAP.julia_to_gap('x') == x
 
     ## Strings & Symbols
-    x = GAP.EvalString("\"foo\"")
+    x = GAP.evalstr("\"foo\"")
     @test GAP.julia_to_gap("foo") == x
     @test GAP.julia_to_gap(:foo) == x
 
     ## Arrays
-    x = GAP.EvalString("[1,\"foo\",2]")
+    x = GAP.evalstr("[1,\"foo\",2]")
     @test GAP.julia_to_gap([1, "foo", BigInt(2)], Val(true)) == x
-    x = GAP.EvalString("[1,JuliaEvalString(\"\\\"foo\\\"\"),2]")
+    x = GAP.evalstr("[1,JuliaEvalString(\"\\\"foo\\\"\"),2]")
     @test GAP.julia_to_gap([1, "foo", BigInt(2)]) == x
-    x = GAP.EvalString("[[1,2],[3,4]]")
+    x = GAP.evalstr("[[1,2],[3,4]]")
     @test GAP.julia_to_gap([1 2; 3 4]) == x
 
     ## BitArrays
-    x = GAP.EvalString("BlistList([1,2],[1])")
+    x = GAP.evalstr("BlistList([1,2],[1])")
     y = GAP.julia_to_gap([true, false])
     @test y == x
     @test GAP.gap_to_julia(GAP.Globals.TNAM_OBJ(y)) == "list (boolean)"
 
     ## Tuples
-    x = GAP.EvalString("[1,\"foo\",2]")
+    x = GAP.evalstr("[1,\"foo\",2]")
     @test GAP.julia_to_gap((1, "foo", 2), Val(true)) == x
-    x = GAP.EvalString("[1,JuliaEvalString(\"\\\"foo\\\"\"),2]")
+    x = GAP.evalstr("[1,JuliaEvalString(\"\\\"foo\\\"\"),2]")
     @test GAP.julia_to_gap((1, "foo", 2)) == x
 
     ## Ranges
-    r = GAP.EvalString("[]")
+    r = GAP.evalstr("[]")
     @test GAP.julia_to_gap(1:0) == r
     @test GAP.julia_to_gap(1:1:0) == r
-    r = GAP.EvalString("[ 1 ]")
+    r = GAP.evalstr("[ 1 ]")
     @test GAP.julia_to_gap(1:1) == r
     @test GAP.julia_to_gap(1:1:1) == r
-    r = GAP.EvalString("[ 4 .. 13 ]")
+    r = GAP.evalstr("[ 4 .. 13 ]")
     @test GAP.julia_to_gap(4:13) == r
     @test GAP.julia_to_gap(4:1:13) == r
-    r = GAP.EvalString("[ 1, 4 .. 10 ]")
+    r = GAP.evalstr("[ 1, 4 .. 10 ]")
     @test GAP.julia_to_gap(1:3:10) == r
     @test_throws ErrorException GAP.julia_to_gap(1:2^62)
 
     ## Dictionaries
-    x = GAP.EvalString("rec( foo := 1, bar := \"foo\" )")
+    x = GAP.evalstr("rec( foo := 1, bar := \"foo\" )")
     # ... recursive conversion
     y = Dict{Symbol,Any}(:foo => 1, :bar => "foo")
     @test GAP.julia_to_gap(y, Val(true)) == x
     # ... non-recursive conversion
-    x = GAP.EvalString("rec( foo := 1, bar := JuliaEvalString(\"\\\"foo\\\"\") )")
+    x = GAP.evalstr("rec( foo := 1, bar := JuliaEvalString(\"\\\"foo\\\"\") )")
     @test GAP.julia_to_gap(y) == x
 
     ## Conversions with identical sub-objects
@@ -379,7 +379,7 @@ end
     @test conv === conv.b
 
     ## Test converting lists with 'nothing' in them -> should be converted to a hole in the list
-    xx = GAP.EvalString("[1,,1]")
+    xx = GAP.evalstr("[1,,1]")
     @test GAP.julia_to_gap([1, nothing, 1]) == xx
 
     ## Test function conversion
@@ -387,7 +387,7 @@ end
     return_first_gap = GAP.julia_to_gap(return_first)
     @test GAP.Globals.IsFunction(return_first) == false
     @test GAP.Globals.IsFunction(return_first_gap) == true
-    list = GAP.EvalString("[1,2,3]")
+    list = GAP.evalstr("[1,2,3]")
     @test GAP.Globals.List(list, return_first_gap) == list
 
 end

--- a/test/help.jl
+++ b/test/help.jl
@@ -1,7 +1,7 @@
 @testset "help" begin
     function test_gap_help(topic::String)
-        return isa(GAP.GAP_help_string(topic), String) &&
-               isa(GAP.GAP_help_string(topic, true), String)
+        return isa(GAP.gap_help_string(topic), String) &&
+               isa(GAP.gap_help_string(topic, true), String)
     end
 
     @test test_gap_help("")
@@ -17,7 +17,7 @@
     @test test_gap_help("?determinant")
     @test test_gap_help("?PermList")
     @test test_gap_help("?IsJuliaWrapper")
-    println(GAP.GAP_help_string("?IsJuliaWrapper"))
+    println(GAP.gap_help_string("?IsJuliaWrapper"))
 
     @test test_gap_help("books")
     @test test_gap_help("tut:chapters")

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1,11 +1,11 @@
 @testset "compat" begin
 
     x = @gap (1, 2, 3)
-    @test x == GAP.EvalString("(1,2,3)")
+    @test x == GAP.evalstr("(1,2,3)")
     x = @gap((1, 2, 3))
-    @test x == GAP.EvalString("(1,2,3)")
+    @test x == GAP.evalstr("(1,2,3)")
     x = @gap [1, 2, 3]
-    @test x == GAP.EvalString("[1,2,3]")
+    @test x == GAP.evalstr("[1,2,3]")
     x = @gap(SymmetricGroup)(3)
     @test GAP.Globals.Size(x) == 6
     x = GAP.g"foo"


### PR DESCRIPTION
- Added docstrings to several functions of GAP.jl,
  in particular, filled the "TODO" placeholders.

- related code changes:

  - Added `hasproperty` methods for `GapObj` that delegate to `ISB_REC`
    (which had been left out because earlier Julia versions did not support
    `hasproperty`).

  - Changed the `in` method that delegates to GAP's `\in` such that
    `Any` is allowed for the first argument (which may be also a Julia object).

  - Changed the `one` method that delegates to a GAP operation such that
    `ONE_MUT` is called instead of `ONE`; this way, the mutability of the
    result is the same as that of the argument (like in the cases of `ZERO`
    and `AINV`).

  - Added an `inv` method for `GapObj` that delegates to GAP's `INV_MUT`
    (which yields a result of the same mutability as the argument).
    [Yes, the names of the GAP operations are not consistent.]

  - Support an optional version number in `GAP.Packages.load`.

  - Avoid an error in the `getdoc` method if the argument is a `GapObj`
    without `NameFunction` value.

  - The GAP function `UrlOfManualEntry` computes an URL of a link
    in the "official" GAP manuals in the web
    from the bookname and label information.
    This is preliminary in the sense that the relevant addresses
    might be changed in the future,
    in order to improve the setup on the GAP side;
    for example, currently there is essentially only one supported version
    of a GAP (package) manual.
    The fact that this works only for GAPDoc based manuals should not be a
    restriction for Julia related stuff.

  - `GAP.compute_links_to_GAP_manuals` is called in `docs/make.jl`,
    in order to replace "external references" to GAP (package) manuals
    in the HTML file produced by Documenter.jl.
    (For examples, see the entries about `GAP.Packages.load` and
    `GAP.Packages.update`.)
    This approach is not optimal, Documenter.jl prints warnings because it
    expects explicit addresses, but this way we get specific links in the
    HTML version of the manual,
    and the version in the interactive Julia session is at least readable.
    *One open question* is:
    Where is the most natural place for the JuliaInterface manual?
    Since it is a GAP package, the first place to look for it is
    [the overview of GAP packages on the GAP website](https://www.gap-system.org/Packages/packages.html),
    with the HTML version of the manual  under https://www.gap-system.org/Manuals/pkg/.
    On the other hand, JuliaInterface relies on GAP.jl, perhaps the documentation should be stored
    close to that of GAP.jl.