### PR TITLE
Rename artifact gap-4-11-0 to gap

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
-[gap-4-11-0]
+[gap]
 git-tree-sha1 = "848f0f318405266896d24d11e4baf5cf7bf3f203"
 
-    [[gap-4-11-0.download]]
+    [[gap.download]]
     sha256 = "8bb16ff9fc48c260be38c0953b3321df1d6d42ad1f71e0999d379497cca44c05"
     url = "https://github.com/oscar-system/GAP.jl/releases/download/v0.3.5/gap-4.11.0.tar.bz2"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,7 +7,7 @@ deps_jl = abspath(joinpath(@__DIR__, "deps-$(julia_version).jl"))
 rm(deps_jl, force = true)
 
 # Reference the Julia artifact containing the GAP source code
-artifact_dir = abspath(artifact"gap-4-11-0")
+artifact_dir = abspath(artifact"gap")
 
 # that artifact directory must contain a single subdirectory, with a name
 # which looks something like `gap-4.X.Y`; get that name

--- a/etc/generate_artifacts.jl
+++ b/etc/generate_artifacts.jl
@@ -7,7 +7,7 @@ import SHA
 gap_version = v"4.11.0"
 
 filename = "gap-$(gap_version)"
-artifact_name = replace(filename, "." => "-")
+artifact_name = "gap"
 gap_tarball = "$(filename).tar.bz2"
 url = "https://github.com/gap-system/gap/releases/download/v$(gap_version)/$(gap_tarball)"
 url2 = "https://files.gap-system.org/gap-4.$(gap_version.minor)/tar.bz2/$(gap_tarball)"


### PR DESCRIPTION
When I introduce this, I somehow thought that it made sense or even was
necessary to include the GAP version in the artifact name, but really,
it isn't. Dropping it slightly simplifies our code, but more
importantly, it will make it a tad easier to maintain CI scripts that
override the artifact (as they won't have to be adjusted to match
changes in the GAP version we bundle).