### PR TITLE
julia_to_gap: handle recursion via keyword argument

### DIFF
--- a/pkg/JuliaInterface/gap/convert.gi
+++ b/pkg/JuliaInterface/gap/convert.gi
@@ -65,6 +65,9 @@ end);
 
 BindGlobal("_JL_Dict_Symbol", JuliaEvalString("Dict{Symbol}"));
 BindGlobal("_JL_Dict_AbstractString", JuliaEvalString("Dict{AbstractString}"));
+
+# no longer used in the code, should be marked as obsolescent
+# (it was never documented)
 BindGlobal("_JL_VAL_TRUE", JuliaEvalString("Val(true)"));
 
 InstallMethod(JuliaToGAP, ["IsRecord", "IsJuliaObject"],
@@ -74,7 +77,10 @@ InstallMethod(JuliaToGAP, ["IsRecord", "IsJuliaObject", "IsBool"],
 function(filter, obj, recursive)
     if Julia.isa(obj, _JL_Dict_Symbol) or Julia.isa(obj, _JL_Dict_AbstractString) then
         if recursive then
-            return Julia.GAP.julia_to_gap(obj,_JL_VAL_TRUE);
+            return CallJuliaFunctionWithKeywordArguments(
+                       Julia.GAP.julia_to_gap,
+                       [ obj ],
+                       rec( recursive:= true ) );
         else
             return Julia.GAP.julia_to_gap(obj);
         fi;
@@ -90,7 +96,10 @@ function(filter, obj, recursive)
     if Julia.isa(obj, Julia.Base.Array) or Julia.isa(obj, Julia.Base.Tuple)
        or Julia.isa(obj, Julia.Base.AbstractRange) then
         if recursive then
-            return Julia.GAP.julia_to_gap(obj,_JL_VAL_TRUE);
+            return CallJuliaFunctionWithKeywordArguments(
+                       Julia.GAP.julia_to_gap,
+                       [ obj ],
+                       rec( recursive:= true ) );
         else
             return Julia.GAP.julia_to_gap(obj);
         fi;
@@ -106,7 +115,10 @@ InstallMethod(JuliaToGAP, ["IsRange", "IsJuliaObject", "IsBool"],
 function(filter, obj, recursive)
     if Julia.isa(obj, Julia.Base.AbstractRange) then
         if recursive then
-            return Julia.GAP.julia_to_gap(obj,_JL_VAL_TRUE);
+            return CallJuliaFunctionWithKeywordArguments(
+                       Julia.GAP.julia_to_gap,
+                       [ obj ],
+                       rec( recursive:= true ) );
         else
             return Julia.GAP.julia_to_gap(obj);
         fi;
@@ -124,7 +136,10 @@ InstallMethod(JuliaToGAP, ["IsBlist", "IsJuliaObject", "IsBool"],
 function(filter, obj, recursive)
     if Julia.isa(obj, _JL_Array_Bool_1) or Julia.isa(obj, _JL_BitArray_1) then
         if recursive then
-            return Julia.GAP.julia_to_gap(obj,_JL_VAL_TRUE);
+            return CallJuliaFunctionWithKeywordArguments(
+                       Julia.GAP.julia_to_gap,
+                       [ obj ],
+                       rec( recursive:= true ) );
         else
             return Julia.GAP.julia_to_gap(obj);
         fi;

--- a/src/obsolete.jl
+++ b/src/obsolete.jl
@@ -4,3 +4,10 @@ function EvalString(cmd::String)
     @warn "Use GAP.evalstr instead of GAP.EvalString"
     return evalstr(cmd)
 end
+
+## Deprecated signatures
+
+function julia_to_gap(obj::Any, recursive::Val{Recursive},
+    recursion_dict = IdDict()) where {Recursive}
+    return julia_to_gap(obj, recursion_dict; recursive = Recursive)
+end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -105,7 +105,7 @@
     @test nonrec1 != rec
     @test all(x -> isa(x, Array), rec)
     x = [1, 2]
-    y = GAP.julia_to_gap([x, x], Val(true))
+    y = GAP.julia_to_gap([x, x]; recursive = true)
     z = Vector{Any}(y)
     @test z[1] === z[2]
 
@@ -113,7 +113,7 @@
     n = GAP.evalstr("[[1,2],[3,4]]")
     @test Matrix{Int64}(n) == [1 2; 3 4]
     xt = [(1,) (2,); (3,) (4,)]
-    n = GAP.julia_to_gap(xt, Val(false))
+    n = GAP.julia_to_gap(xt; recursive = false)
     @test Matrix{Tuple{Int64}}(n) == xt
     n = GAP.julia_to_gap(big(2)^100)
     @test_throws GAP.ConversionError Matrix{Int64}(n)
@@ -123,7 +123,7 @@
     m = Any[1 2; 3 4]
     m[1, 1] = x
     m[2, 2] = x
-    x = GAP.julia_to_gap(m, Val(true))
+    x = GAP.julia_to_gap(m; recursive = true)
     y = Matrix{Any}(x)
     @test !isa(y[1, 1], GAP.GapObj)
     @test y[1, 1] === y[2, 2]

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -119,7 +119,7 @@
     @test nonrec1 != rec
     @test all(x -> isa(x, Array), rec)
     x = [1, 2]
-    y = GAP.julia_to_gap([x, x], Val(true))
+    y = GAP.julia_to_gap([x, x]; recursive = true)
     z = GAP.gap_to_julia(Vector{Any}, y)
     @test z[1] === z[2]
 
@@ -127,7 +127,7 @@
     n = GAP.evalstr("[[1,2],[3,4]]")
     @test GAP.gap_to_julia(Array{Int64,2}, n) == [1 2; 3 4]
     xt = [(1,) (2,); (3,) (4,)]
-    n = GAP.julia_to_gap(xt, Val(false))
+    n = GAP.julia_to_gap(xt; recursive = false)
     @test GAP.gap_to_julia(Array{Tuple{Int64},2}, n) == xt
     n = GAP.julia_to_gap(big(2)^100)
     @test_throws GAP.ConversionError GAP.gap_to_julia(Array{Int64,2}, n)
@@ -137,7 +137,7 @@
     m = Any[1 2; 3 4]
     m[1, 1] = x
     m[2, 2] = x
-    x = GAP.julia_to_gap(m, Val(true))
+    x = GAP.julia_to_gap(m; recursive = true)
     y = GAP.gap_to_julia(Array{Any,2}, x)
     @test !isa(y[1, 1], GAP.GapObj)
     @test y[1, 1] === y[2, 2]
@@ -306,7 +306,7 @@ end
 
     ## Arrays
     x = GAP.evalstr("[1,\"foo\",2]")
-    @test GAP.julia_to_gap([1, "foo", BigInt(2)], Val(true)) == x
+    @test GAP.julia_to_gap([1, "foo", BigInt(2)]; recursive = true) == x
     x = GAP.evalstr("[1,JuliaEvalString(\"\\\"foo\\\"\"),2]")
     @test GAP.julia_to_gap([1, "foo", BigInt(2)]) == x
     x = GAP.evalstr("[[1,2],[3,4]]")
@@ -320,7 +320,7 @@ end
 
     ## Tuples
     x = GAP.evalstr("[1,\"foo\",2]")
-    @test GAP.julia_to_gap((1, "foo", 2), Val(true)) == x
+    @test GAP.julia_to_gap((1, "foo", 2); recursive = true) == x
     x = GAP.evalstr("[1,JuliaEvalString(\"\\\"foo\\\"\"),2]")
     @test GAP.julia_to_gap((1, "foo", 2)) == x
 
@@ -342,7 +342,7 @@ end
     x = GAP.evalstr("rec( foo := 1, bar := \"foo\" )")
     # ... recursive conversion
     y = Dict{Symbol,Any}(:foo => 1, :bar => "foo")
-    @test GAP.julia_to_gap(y, Val(true)) == x
+    @test GAP.julia_to_gap(y; recursive = true) == x
     # ... non-recursive conversion
     x = GAP.evalstr("rec( foo := 1, bar := JuliaEvalString(\"\\\"foo\\\"\") )")
     @test GAP.julia_to_gap(y) == x
@@ -351,11 +351,11 @@ end
     l = [1]
     yy = [l, l]
     # ... recursive conversion
-    conv = GAP.julia_to_gap(yy, Val(true))
+    conv = GAP.julia_to_gap(yy; recursive = true)
     @test conv[1] isa GAP.GapObj
     @test conv[1] === conv[2]
     # ... non-recursive conversion
-    conv = GAP.julia_to_gap(yy, Val(false))
+    conv = GAP.julia_to_gap(yy; recursive = false)
     @test isa(conv[1], Array{Int64,1})
     @test conv[1] === conv[2]
 
@@ -364,18 +364,18 @@ end
     yy[1] = yy
     yy[2] = yy
     # ... recursive conversion
-    conv = GAP.julia_to_gap(yy, Val(true))
+    conv = GAP.julia_to_gap(yy; recursive = true)
     @test conv[1] === conv
     @test conv[1] === conv[2]
     # ... non-recursive conversion
-    conv = GAP.julia_to_gap(yy, Val(false))
+    conv = GAP.julia_to_gap(yy; recursive = false)
     @test conv[1] !== conv
     @test conv[1] === conv[2]
 
     ## converting a dictionary with circular refs
     d = Dict{String,Any}("a" => 1)
     d["b"] = d
-    conv = GAP.julia_to_gap(d, Val(true))
+    conv = GAP.julia_to_gap(d; recursive = true)
     @test conv === conv.b
 
     ## Test converting lists with 'nothing' in them -> should be converted to a hole in the list


### PR DESCRIPTION
Changed the syntax of `julia_to_gap`:
Use the keyword argument `recursive` (value `true` or `false`)
instead of the argument `Val(true)` or `Val(false)`;
this syntax is used already for `gap_to_julia`.

Adjusted the code that used the old syntax (some tests and
some conversion functions in JuliaInterface).

The old syntax is still supported, via a method in `src/obsolete.jl`.

Is this what was requested in issue #475 ?