### PR TITLE
admit installing a package in `Packages.load`

### DIFF
--- a/test/packages.jl
+++ b/test/packages.jl
@@ -1,6 +1,8 @@
 @testset "packages" begin
 
     @test GAP.Packages.load("PackageManager")
+    @test ! GAP.Packages.load("no such package")
+    @test ! GAP.Packages.load("no such package", install = true)
 
     @test GAP.Packages.install("io", interactive = false)
     @test GAP.Packages.remove("io", interactive = false)


### PR DESCRIPTION
A new keyword argument `install` can be used to force
`Packages.load` to install the package in question
if it is not yet installed.

This is intended to resolve issue #476.