### PR TITLE
Optimize use of locks in calling out to GAP.

### DIFF
--- a/pkg/JuliaInterface/src/sync.c
+++ b/pkg/JuliaInterface/src/sync.c
@@ -4,9 +4,12 @@
 
 #ifndef HPCGAP
 static pthread_mutex_t GapLock;
+static int             is_threaded;
 
 void InitGapSync(void)
 {
+    extern int jl_n_threads;
+    is_threaded = jl_n_threads > 1;
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
@@ -16,11 +19,13 @@ void InitGapSync(void)
 
 void BeginGapSync(void)
 {
-    pthread_mutex_lock(&GapLock);
+    if (is_threaded)
+        pthread_mutex_lock(&GapLock);
 }
 
 void EndGapSync(void)
 {
-    pthread_mutex_unlock(&GapLock);
+    if (is_threaded)
+        pthread_mutex_unlock(&GapLock);
 }
 #endif

--- a/pkg/JuliaInterface/src/sync.h
+++ b/pkg/JuliaInterface/src/sync.h
@@ -1,11 +1,9 @@
 #ifndef JULIAINTERFACE_SYNC_H
 #define JULIAINTERFACE_SYNC_H
 
-// #define THREADSAFE_GAP_JL 1
-
 #include <src/compiled.h>
 
-#if defined(HPCGAP) || !defined(THREADSAFE_GAP_JL)
+#if defined(HPCGAP)
 #define BEGIN_GAP_SYNC() ((void)0)
 #define END_GAP_SYNC() ((void)0)
 #else

--- a/pkg/JuliaInterface/src/sync.h
+++ b/pkg/JuliaInterface/src/sync.h
@@ -1,9 +1,11 @@
 #ifndef JULIAINTERFACE_SYNC_H
 #define JULIAINTERFACE_SYNC_H
 
+// #define THREADSAFE_GAP_JL 1
+
 #include <src/compiled.h>
 
-#if defined(HPCGAP)
+#if defined(HPCGAP) || !defined(THREADSAFE_GAP_JL)
 #define BEGIN_GAP_SYNC() ((void)0)
 #define END_GAP_SYNC() ((void)0)
 #else


### PR DESCRIPTION
This checks if Julia is actually running in multi-threaded mode and, if not, elides the use of locks.

Note that this also gets rid of the `THREADSAFE_GAP_JL` macro and turns them on all the time. Thus, there is actually a small overhead for the sync macros now that are equivalent to a function call. However, that overhead should be a fairly small part of the overall overhead for calling GAP from Julia. It can probably be tweaked further by making them inline if needed.