### PR TITLE
Make calls from Julia to GAP faster

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -232,6 +232,37 @@ function initialize(argv::Array{String,1})
         error("FORCE_QUIT_GAP failed")
     end
 
+    # Unfortunately, the following trick does not work if GAP.jl is
+    # used by another package, such as Oscar.jl; we get errors like this:
+    #   WARNING: eval into closed module GAP:
+    #   Expr(:const, :gap_true = Expr(:call, :cglobal, :(:True)))
+    #     ** incremental compilation may be fatally broken for this module **
+    #@eval const gap_true = cglobal(:True)
+    #@eval const gap_false = cglobal(:False)
+
+    # verify our TNUMs are still correct
+    # (Base.invokelatest is only needed for Julia 1.3)
+    @assert T_INT == Base.invokelatest(ValueGlobalVariable,:T_INT)
+    @assert T_INTPOS == Base.invokelatest(ValueGlobalVariable,:T_INTPOS)
+    @assert T_INTNEG == Base.invokelatest(ValueGlobalVariable,:T_INTNEG)
+    @assert T_RAT == Base.invokelatest(ValueGlobalVariable,:T_RAT)
+    @assert T_CYC == Base.invokelatest(ValueGlobalVariable,:T_CYC)
+    @assert T_FFE == Base.invokelatest(ValueGlobalVariable,:T_FFE)
+    @assert T_MACFLOAT == Base.invokelatest(ValueGlobalVariable,:T_MACFLOAT)
+    @assert T_PERM2 == Base.invokelatest(ValueGlobalVariable,:T_PERM2)
+    @assert T_PERM4 == Base.invokelatest(ValueGlobalVariable,:T_PERM4)
+    @assert T_TRANS2 == Base.invokelatest(ValueGlobalVariable,:T_TRANS2)
+    @assert T_TRANS4 == Base.invokelatest(ValueGlobalVariable,:T_TRANS4)
+    @assert T_PPERM2 == Base.invokelatest(ValueGlobalVariable,:T_PPERM2)
+    @assert T_PPERM4 == Base.invokelatest(ValueGlobalVariable,:T_PPERM4)
+    @assert T_BOOL == Base.invokelatest(ValueGlobalVariable,:T_BOOL)
+    @assert T_CHAR == Base.invokelatest(ValueGlobalVariable,:T_CHAR)
+    @assert T_FUNCTION == Base.invokelatest(ValueGlobalVariable,:T_FUNCTION)
+    @assert T_BODY == Base.invokelatest(ValueGlobalVariable,:T_BODY)
+    @assert T_FLAGS == Base.invokelatest(ValueGlobalVariable,:T_FLAGS)
+    @assert T_LVARS == Base.invokelatest(ValueGlobalVariable,:T_LVARS)
+    @assert T_HVARS == Base.invokelatest(ValueGlobalVariable,:T_HVARS)
+
     # load JuliaInterface
     loadpackage_return = ccall(
         Libdl.dlsym(libgap_handle, :GAP_EvalString),

--- a/src/lowlevel.jl
+++ b/src/lowlevel.jl
@@ -1,4 +1,29 @@
 #
+# hardcoded TNUM values: these are unlikely to change, but to be
+# safe, we check them in __init__ via some assertions
+#
+const T_INT      = 0    # integer
+const T_INTPOS   = 1    # large positive integer
+const T_INTNEG   = 2    # large negative integer
+const T_RAT      = 3    # rational
+const T_CYC      = 4    # cyclotomic
+const T_FFE      = 5    # ffe
+const T_MACFLOAT = 6    # macfloat
+const T_PERM2    = 7    # permutation (small)
+const T_PERM4    = 8    # permutation (large)
+const T_TRANS2   = 9    # transformation (small)
+const T_TRANS4   = 10   # transformation (large)
+const T_PPERM2   = 11   # partial perm (small)
+const T_PPERM4   = 12   # partial perm (large)
+const T_BOOL     = 13   # boolean or fail
+const T_CHAR     = 14   # character
+const T_FUNCTION = 15   # function
+const T_BODY     = 16   # function body bag
+const T_FLAGS    = 17   # flags list
+const T_LVARS    = 18   # values bag
+const T_HVARS    = 19   # high variables bag
+
+#
 # functions which directly interact with GAP objects, bypassing the GAP kernel
 #
 function TNUM_OBJ(obj::GapObj)
@@ -20,4 +45,17 @@ function SIZE_OBJ(obj::GapObj)
     bag_ptr = unsafe_load(mptr)
     header = unsafe_load(bag_ptr, 0)
     return Int((header >> 16))
+end
+
+
+# given a GAP T_FUNCTION object, fetch its n-th function handler (handler 0-6
+# are for calls with that many arguments, handler 7 is for any higher number
+# of arguments)
+function GET_FUNC_PTR(obj::GapObj, narg::Int)
+    mptr = Ptr{Ptr{Culonglong}}(pointer_from_objref(obj))
+    bag_ptr = unsafe_load(mptr)
+    @assert (unsafe_load(bag_ptr, 0) & 0xFF) == T_FUNCTION
+    @assert 0 <= narg && narg <= 7
+    bag_ptr = Ptr{Ptr{Nothing}}(bag_ptr)
+    unsafe_load(bag_ptr, narg + 1)
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -70,6 +70,15 @@ end
     @test GAP.julia_to_gap([1, 2, 3, 4, 5, 6]) == f(1, 2, 3, 4, 5, 6)
     @test GAP.julia_to_gap([1, 2, 3, 4, 5, 6, 7]) == f(1, 2, 3, 4, 5, 6, 7)
 
+    @test [] == convert(Vector{String}, f())
+    @test ["1"] == convert(Vector{String}, f("1"))
+    @test ["1", "2"] == convert(Vector{String}, f("1", "2"))
+    @test ["1", "2", "3"] == convert(Vector{String}, f("1", "2", "3"))
+    @test ["1", "2", "3", "4"] == convert(Vector{String}, f("1", "2", "3", "4"))
+    @test ["1", "2", "3", "4", "5"] == convert(Vector{String}, f("1", "2", "3", "4", "5"))
+    @test ["1", "2", "3", "4", "5", "6"] == convert(Vector{String}, f("1", "2", "3", "4", "5", "6"))
+    @test ["1", "2", "3", "4", "5", "6", "7"] == convert(Vector{String}, f("1", "2", "3", "4", "5", "6", "7"))
+
     # check to see if a non-basic object (here: a tuple) can be
     # passed and then extracted again
     @test f((1, 2, 3))[1] == (1, 2, 3)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -254,11 +254,13 @@ end
     @test GAP.julia_to_gap(true)
 
     ## Integers
-    @test GAP.julia_to_gap(Int128(1)) == 1
-    @test GAP.julia_to_gap(Int64(1)) == 1
-    @test GAP.julia_to_gap(Int32(1)) == 1
-    @test GAP.julia_to_gap(Int16(1)) == 1
-    @test GAP.julia_to_gap(Int8(1)) == 1
+    for i in -2:2
+        @test GAP.julia_to_gap(Int128(i)) == i
+        @test GAP.julia_to_gap(Int64(i)) == i
+        @test GAP.julia_to_gap(Int32(i)) == i
+        @test GAP.julia_to_gap(Int16(i)) == i
+        @test GAP.julia_to_gap(Int8(i)) == i
+    end
 
     ## Int64 corner cases
     @test GAP.julia_to_gap(-2^60) === -2^60
@@ -283,9 +285,12 @@ end
     @test GAP.julia_to_gap(UInt8(1)) == 1
 
     ## BigInts
-    @test GAP.julia_to_gap(BigInt(1)) == 1
+    for i = -2:2
+        @test GAP.julia_to_gap(BigInt(i)) == i
+    end
     x = GAP.evalstr("2^100")
     @test GAP.julia_to_gap(BigInt(2)^100) == x
+    @test GAP.julia_to_gap(-BigInt(2)^100) == -x
 
     ## Rationals
     x = GAP.evalstr("2^100")


### PR DESCRIPTION
**UPDATE: once again rebased and timings updated; also added more extensive GAP microbenchmarking results to show how close we are to matching the GAP interpreter.**

... by avoiding conversion calls for immediate integers, immediate FFE and
GapObj; and also by directly ccalling into the GAP function handlers.

Before this patch:

    julia> @btime test_simple()
      25.844 ms (0 allocations: 0 bytes)

    julia> @btime test_isabelian_1()
      195.323 ms (1000000 allocations: 15.26 MiB)

    julia> @btime test_isabelian_2()
      159.374 ms (1000000 allocations: 15.26 MiB)

After this patch (note the avoided allocations):

    julia> @btime test_simple()
      25.546 ms (0 allocations: 0 bytes)

    julia> @btime test_isabelian_1()
      53.635 ms (0 allocations: 0 bytes)

    julia> @btime test_isabelian_2()
      25.289 ms (0 allocations: 0 bytes)

For comparison, here are timings for roughly equivalent GAP functions;

    julia> @btime GAP.Globals.test_simple()
      5.134 ms (0 allocations: 0 bytes)

    julia> @btime GAP.Globals.test_isabelian_1()
      20.187 ms (0 allocations: 0 bytes)

    julia> @btime GAP.Globals.test_isabelian_2()
      18.176 ms (0 allocations: 0 bytes)

Here is the Julia microbenchmark:
```julia
    using GAP, BenchmarkTools
    function test_simple()
      for i = 1:1000000
        x = GAP.Globals.IsAbelian
      end
    end

    G = GAP.Globals.CyclicGroup(10)

    function test_isabelian_1()
      x = true
      for i = 1:1000000
        x = x && GAP.Globals.IsAbelian(G)
      end
    end

    function test_isabelian_2()
      f = GAP.Globals.IsAbelian
      x = true
      for i = 1:1000000
        x = x && f(G)
      end
    end
```
And here is the GAP version (can be entered using `GAP.prompt()`)
```gap
    test_simple := function()
      local x, i;
      for i in [1.. 1000000] do
        x := IsAbelian;
      od;
    end;

    G := CyclicGroup(10);

    test_isabelian_1 := function()
      local x, i;
      x := true;
      for i in [1.. 1000000] do
        x := x and IsAbelian(G);
      od;
    end;

    test_isabelian_2 := function()
      local f, x, i;
      f := IsAbelian;
      x := true;
      for i in [1.. 1000000] do
        x := x and f(G);
      od;
    end;
```
Resolves #486

TODO:
- [x] add tests that pass in/out various types combos
- [x] add tests that verify that calls with 0-6 args work fine
- [ ] in threaded mode, we ought to call `BeginGapSync` and `EndGapSync` (and then we also need to worry about catching errors, so that we can call `EndGapSync` regardless)
