### PR TITLE
make GAP.Globals.<TAB> complete faster

### DIFF
--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -224,8 +224,4 @@ function setproperty!(funcobj::GlobalsType, name::Symbol, val::Any)
     ccall(:GAP_AssignGlobalVariable, Cvoid, (Ptr{UInt8}, Ptr{Cvoid}), name, tmp)
 end
 
-function propertynames(funcobj::GlobalsType, private)
-    list = Globals.NamesGVars()
-    list_converted = gap_to_julia(Array{Symbol,1}, list)
-    return tuple(list_converted...)
-end
+propertynames(::GlobalsType) = gap_to_julia(Vector{Symbol}, Globals.NamesGVars())


### PR DESCRIPTION
Converting a `Vector{Symbol}` to a tuple had no clear benefit, when the vector
is already an acceptable return value for `propertynames`. Constructing big
tuples does not scale well with their size.

Also, this removes the unused `private` argument, as this made
`propertynames(GAP.Globals) != propertynames(GAP.Globals, false)`, which goes
against the definition of this function (there is already a fall-back
`propertynames(x, private) = propertynames(x)` defined in `Base`).

Fix #489.