### PR TITLE
define some doctestfilters

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,13 @@ makedocs(
     modules = [GAP],
     clean = true,
     doctest = true,
+    doctestfilters = Regex[
+      r"BitVector|BitArray\{1\}",
+      r"Matrix\{Int64\}|Array\{Int64,2\}",
+      r"Vector\{Any\}|Array\{Any,1\}",
+      r"Vector\{Int64\}|Array\{Int64,1\}",
+      r"Vector\{UInt8\}|Array\{UInt8,1\}",
+    ],
     strict = false,
     checkdocs = :none,
     pages = ["index.md"],

--- a/pkg/JuliaInterface/tst/testall.g
+++ b/pkg/JuliaInterface/tst/testall.g
@@ -7,6 +7,32 @@
 LoadPackage("JuliaInterface");
 dir:=DirectoriesPackageLibrary("JuliaInterface", "tst");
 Assert(0, dir <> fail);
+
+CompareUpToWhitespaceAndMatches:= function( pairs )
+    return function( a, b )
+      local pair;
+
+      a:= ShallowCopy( a );
+      b:= ShallowCopy( b );
+      for pair in pairs do
+        if ForAll( [ a, b ],
+               str -> ForAny( pair,
+                          x -> PositionSublist( str, x ) <> fail ) ) then
+          a:= ReplacedString( a, pair[1], "" );
+          a:= ReplacedString( a, pair[2], "" );
+          b:= ReplacedString( b, pair[1], "" );
+          b:= ReplacedString( b, pair[2], "" );
+        fi;
+      od;
+      return TEST.compareFunctions.uptowhitespace( a, b );
+    end;
+end;
+
+# Several Julia types are shown differently in Julia 1.6.0-DEV
+# and older Julia versions.
+compare:= CompareUpToWhitespaceAndMatches(
+    [ [ "Array{Any,1}", "Vector{Any}" ] ] );
+
 TestDirectory(dir, rec(exitGAP := true,
-                       testOptions := rec(compareFunction := "uptowhitespace") ) );
+                       testOptions := rec(compareFunction := compare) ) );
 FORCE_QUIT_GAP(1);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,4 +9,4 @@ include("constructors.jl")
 include("macros.jl")
 include("packages.jl")
 include("help.jl")
-include("testmanual.jl")
+# include("testmanual.jl")  # leave this out until doctestfilters can be used here


### PR DESCRIPTION
... in order to avoid failures in doctests with Julia 1.6.0-DEV
(due to changed `typeof` outputs in Julia 1.6)

Note that `doctestfilters` is supported in `makedocs` but currently not in `doctest`,
therefore running doctests as a part of GAP.jl's test suite gets disabled with the proposed changes.

Perhaps there will be support also in `doctest` in the future, see JuliaDocs/Documenter.jl#1364.

The changes are intended to resolve issue #484 .