### PR TITLE
fix `julia_to_gap` conversion of strings

### DIFF
--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -69,7 +69,7 @@ julia_to_gap(x::Float16) = NEW_MACFLOAT(Float64(x))
 julia_to_gap(x::Char) = CharWithValue(Cuchar(x))
 
 ## Strings and symbols
-julia_to_gap(x::AbstractString) = MakeString(x)
+julia_to_gap(x::AbstractString) = MakeString(string(x))
 julia_to_gap(x::Symbol) = MakeString(string(x))
 
 ## Generic caller for optional arguments

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -309,6 +309,8 @@ end
     x = GAP.evalstr("\"foo\"")
     @test GAP.julia_to_gap("foo") == x
     @test GAP.julia_to_gap(:foo) == x
+    substr = match(r"a(.*)c", "abc").match  # type is `SubString{String}`
+    @test GAP.julia_to_gap(substr) == GAP.julia_to_gap("abc")
 
     ## Arrays
     x = GAP.evalstr("[1,\"foo\",2]")


### PR DESCRIPTION
Up to now, objects of type `SubString{String}` were not supported