### PR TITLE
support computed external references

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,49 @@
-using Documenter, GAP
+using Documenter, GAP, Markdown
+
+abstract type ExternalReference <: Documenter.Builder.DocumentPipeline end
+
+Documenter.Selectors.order(::Type{ExternalReference}) = 3.1  # After cross-references
+
+function Documenter.Selectors.runner(::Type{ExternalReference}, doc::Documenter.Documents.Document)
+    @info "ExternalReference: building external references."
+    compute_external_references(doc)
+end
+
+function compute_external_references(doc::Documenter.Documents.Document)
+    for (src, page) in doc.blueprint.pages
+        empty!(page.globals.meta)
+        for element in page.elements
+            compute_external_reference(page.mapping[element], page, doc)
+        end
+    end
+end
+
+function compute_external_reference(elem, page, doc)
+    Documenter.Documents.walk(page.globals.meta, elem) do link
+        compute_external_reference(link, page.globals.meta, page, doc)
+    end
+end
+
+function compute_external_reference(link, meta, page, doc)
+    if isa(link, Markdown.Link) && startswith(link.url, "GAP_ref")
+        @info "Computing external reference: $(link.url)."
+        reference = match(r"GAP_ref\((.*)\)", link.url)
+        if ! isnothing(reference) && length(reference.captures) == 1
+            reference = string(reference.captures[1])
+            key = split(reference, ":")
+            if length(key) == 2
+                key = GAP.julia_to_gap(string(key[2]))
+                urls = GAP.Globals.MatchURLs(GAP.julia_to_gap(reference),
+                           GAP.julia_to_gap("https://www.gap-system.org/Manuals/"))
+                urls = GAP.Globals.Filtered(urls, x -> x[2] == key)
+                if length(urls) == 1
+                    link.url = String(urls[1][3])
+                end
+            end
+        end
+    end
+    return true
+end
 
 DocMeta.setdocmeta!(GAP, :DocTestSetup, :(using GAP); recursive = true)
 
@@ -12,8 +57,5 @@ makedocs(
     checkdocs = :none,
     pages = ["index.md"],
 )
-
-# Compute the links to GAP manuals.
-GAP.compute_links_to_gap_manuals(@__DIR__)
 
 deploydocs(repo = "github.com/oscar-system/GAP.jl.git", target = "build")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,37 @@
 using Documenter, GAP, Markdown
 
+## The following code inserts a step into the list of tasks
+## that are performed by Documenter.jl's function `makedocs`.
+## The idea is to encode external references to GAP manuals
+## by strings of the form `"GAP_ref(<bookname>:<label>)"`
+## in the source files, and to compute the corresponding URLs
+## in the manuals available at `https://www.gap-system.org/Manuals/`
+## when `makedocs` creates GAP.jl's documentation.
+## (Note that these URLs may change when new GAP versions get released,
+## thus one does not want to update them by hand.)
+##
+## The steps for `makedocs` are given by the subtypes of
+## `Documenter.Builder.DocumentPipeline`,
+## they get executed in the order defined by the values (floats)
+## of the function `Documenter.Selectors.order` for these subtypes,
+## and executing the step for the subtype `T` means to call
+## `Documenter.Selectors.runner` with `T` and the document object.
+##
+## The code was adapted from the package
+## https://github.com/ali-ramadhan/DocumenterBibliographyTest.jl,
+## the hint to use this approach came up in the discussion of
+## https://github.com/JuliaDocs/Documenter.jl/issues/1343.
+
+## Declare a new subtype for our step,
+## the evaluation of external references.
 abstract type ExternalReference <: Documenter.Builder.DocumentPipeline end
 
-Documenter.Selectors.order(::Type{ExternalReference}) = 3.1  # After cross-references
+## Execute our step after the computation of cross-references (3.0)
+## and before the check of the document (4.0).
+Documenter.Selectors.order(::Type{ExternalReference}) = 3.1
 
+## When executing our step, print an info line
+## and call the function that does the work.
 function Documenter.Selectors.runner(::Type{ExternalReference}, doc::Documenter.Documents.Document)
     @info "ExternalReference: building external references."
     compute_external_references(doc)
@@ -25,6 +53,7 @@ function compute_external_reference(elem, page, doc)
 end
 
 function compute_external_reference(link, meta, page, doc)
+    # Do something only if the current element has the type `Markdown.Link`.
     if isa(link, Markdown.Link) && startswith(link.url, "GAP_ref")
         @info "Computing external reference: $(link.url)."
         reference = match(r"GAP_ref\((.*)\)", link.url)
@@ -33,10 +62,13 @@ function compute_external_reference(link, meta, page, doc)
             key = split(reference, ":")
             if length(key) == 2
                 key = GAP.julia_to_gap(string(key[2]))
+                # Find all matches of `"<bookname>:<label>"`.
                 urls = GAP.Globals.MatchURLs(GAP.julia_to_gap(reference),
                            GAP.julia_to_gap("https://www.gap-system.org/Manuals/"))
+                # Take only exact matches, this should be unique.
                 urls = GAP.Globals.Filtered(urls, x -> x[2] == key)
                 if length(urls) == 1
+                    # Replace the URL in the link.
                     link.url = String(urls[1][3])
                 end
             end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -74,12 +74,3 @@ end
 function Display(x::GapObj)
     print(gap_to_julia(AbstractString, Globals.StringDisplayObj(x)))
 end
-
-## Compute the links to GAP manuals in the HTML file created by Documenter.jl.
-function compute_links_to_gap_manuals(docsdir)
-    filename = abspath(joinpath(docsdir, "build", "index.html"))
-    str = read(filename, String)
-    replstr = gap_to_julia( Globals.ComputeLinksToGAPManuals( julia_to_gap( str ) ) )
-    Base.Filesystem.mv( filename, filename * "~", force = true )
-    Base.write( filename, replstr )
-end


### PR DESCRIPTION
Preliminary support for computed external references in the documentation
of GAP.jl had been proposed in pull request #472,
but this was of course not satisfactory because it misused Documenter.jl.

In the discussion of JuliaDocs/Documenter.jl/issues/1343,
@mortenpi suggested to get the required functionality by adding a plugin
to Documented.jl, analogous to an implementation of citations by @ali-ramadhan.
This works well, and from my point of view the issue JuliaDocs/Documenter.jl/issues/1343 can be closed.

Thanks a lot to @mortenpi for the hint, and to @ali-ramadhan for the code.

The details of the changes are:

- added a plugin for Documenter.jl
- replaced the GAP function `UrlOfManualEntry` by `MatchURLs`
  (thanks to @frankluebeck for this code)
- removed the now unnecessary GAP function `ComputeLinksToGAPManuals` and the Julia function `compute_links_to_gap_manuals`