### PR TITLE
Avoid function call overhead when CxxWrap.jl is loaded

### DIFF
--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -2,7 +2,7 @@
 
 import Base: getproperty, hasproperty, setproperty!, propertynames
 
-function RAW_GAP_TO_JULIA(ptr::Ptr{Cvoid})::Any
+function RAW_GAP_TO_JULIA(ptr::Ptr{Cvoid})
     return ccall(:julia_gap, Any, (Ptr{Cvoid},), ptr)
 end
 


### PR DESCRIPTION
... by dropping the `::Any` return value annotation in `RAW_GAP_TO_JULIA`:
Normally, Julia optimizes this away as a no-op. But CxxWrap.jl installs
a method for converting `CxxWrap.CxxWrapCore.SmartPointer{DerivedT}` to `Any`;
this precludes Julia from optimizing the conversion away.

See also:
- https://github.com/oscar-system/GAP.jl/issues/485
- https://github.com/JuliaInterop/CxxWrap.jl/issues/258