### PR TITLE
Optimize access to GAP records

### DIFF
--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -118,7 +118,9 @@ Base.getindex(x::GapObj, i::Int64, j::Int64) = Globals.ELM_LIST(x, i, j)
 Base.setindex!(x::GapObj, v::Any, i::Int64, j::Int64) = Globals.ASS_LIST(x, i, j, v)
 
 # records
-RNamObj(f::Union{Symbol,Int64,AbstractString}) = Globals.RNamObj(MakeString(string(f)))
+Base.@pure RNamObj(f::Union{AbstractString,Symbol}) = ccall(:RNamName, Int, (Ptr{UInt8},), f)
+Base.@pure RNamObj(f::Int) = ccall(:RNamIntg, Int, (Int,), f)
+
 # note: we don't use Union{Symbol,Int64,AbstractString} below to avoid
 # ambiguity between these methods and method `getproperty(x, f::Symbol)`
 # from Julia's Base module


### PR DESCRIPTION
... by changing RNamObj to directly call into the GAP kernel,
and also by marking it via `@pure`

Consider this microbenchmark:
```julia
    using GAP, BenchmarkTools
    function test_rec()
        r = GAP.evalstr("rec( one := 1 )")
        for i = 1:100000
            r.one += 1
        end
    end
```
Before this patch:

    julia> @btime test_rec()
      394.038 ms (4696557 allocations: 172.37 MiB)

After this patch:

    julia> @btime test_rec()
      236.068 ms (3096549 allocations: 59.46 MiB)

That's a lot better, but still not great (part of the problem is that
getproperty / setproperty don't get inlined in this example; I am not
yet sure why exactly that is the case).