### PR TITLE
Use optimized call_gap_func in more situations

### DIFF
--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -197,7 +197,11 @@ function call_gap_func(func::GapObj, args...; kwargs...)
         options = true
     end
     try
-        result = ccall(:call_gap_func, Any, (Any, Any), func, args)
+        if TNUM_OBJ(func) == T_FUNCTION && length(args) <= 6
+            result = _call_gap_func(func, args...)
+        else
+            result = ccall(:call_gap_func, Any, (Any, Any), func, args)
+        end
         if options
             Globals.PopOptions()
         end
@@ -220,14 +224,14 @@ end
 #
 
 # 0 arguments
-function call_gap_func(func::GapObj)
+function _call_gap_func(func::GapObj)
     fptr = GET_FUNC_PTR(func, 0)
     ret = ccall(fptr, Ptr{Cvoid}, (Ptr{Cvoid},), pointer_from_objref(func))
     return _GAP_TO_JULIA(ret)
 end
 
 # 1 argument
-function call_gap_func(func::GapObj, a1::Obj)
+function _call_gap_func(func::GapObj, a1)
     fptr = GET_FUNC_PTR(func, 1)
     ret = ccall(
         fptr,
@@ -240,7 +244,7 @@ function call_gap_func(func::GapObj, a1::Obj)
 end
 
 # 2 arguments
-function call_gap_func(func::GapObj, a1::Obj, a2::Obj)
+function _call_gap_func(func::GapObj, a1, a2)
     fptr = GET_FUNC_PTR(func, 2)
     ret = ccall(
         fptr,
@@ -254,7 +258,7 @@ function call_gap_func(func::GapObj, a1::Obj, a2::Obj)
 end
 
 # 3 arguments
-function call_gap_func(func::GapObj, a1::Obj, a2::Obj, a3::Obj)
+function _call_gap_func(func::GapObj, a1, a2, a3)
     fptr = GET_FUNC_PTR(func, 3)
     ret = ccall(
         fptr,
@@ -269,7 +273,7 @@ function call_gap_func(func::GapObj, a1::Obj, a2::Obj, a3::Obj)
 end
 
 # 4 arguments
-function call_gap_func(func::GapObj, a1::Obj, a2::Obj, a3::Obj, a4::Obj)
+function _call_gap_func(func::GapObj, a1, a2, a3, a4)
     fptr = GET_FUNC_PTR(func, 4)
     ret = ccall(
         fptr,
@@ -285,7 +289,7 @@ function call_gap_func(func::GapObj, a1::Obj, a2::Obj, a3::Obj, a4::Obj)
 end
 
 # 5 arguments
-function call_gap_func(func::GapObj, a1::Obj, a2::Obj, a3::Obj, a4::Obj, a5::Obj)
+function _call_gap_func(func::GapObj, a1, a2, a3, a4, a5)
     fptr = GET_FUNC_PTR(func, 5)
     ret = ccall(
         fptr,
@@ -302,7 +306,7 @@ function call_gap_func(func::GapObj, a1::Obj, a2::Obj, a3::Obj, a4::Obj, a5::Obj
 end
 
 # 6 arguments
-function call_gap_func(func::GapObj, a1::Obj, a2::Obj, a3::Obj, a4::Obj, a5::Obj, a6::Obj)
+function _call_gap_func(func::GapObj, a1, a2, a3, a4, a5, a6)
     fptr = GET_FUNC_PTR(func, 6)
     ret = ccall(
         fptr,

--- a/src/lowlevel.jl
+++ b/src/lowlevel.jl
@@ -50,9 +50,8 @@ end
 # are for calls with that many arguments, handler 7 is for any higher number
 # of arguments)
 function GET_FUNC_PTR(obj::GapObj, narg::Int)
-    bag_ptr = ADDR_OBJ(obj)
-    @assert (unsafe_load(bag_ptr, 0) & 0xFF) == T_FUNCTION
-    @assert 0 <= narg && narg <= 7
-    bag_ptr = Ptr{Ptr{Nothing}}(bag_ptr)
+    #@assert TNUM_OBJ(obj) == T_FUNCTION
+    #@assert 0 <= narg && narg <= 7
+    bag_ptr = Ptr{Ptr{Nothing}}(ADDR_OBJ(obj))
     unsafe_load(bag_ptr, narg + 1)
 end


### PR DESCRIPTION
Conversely, make sure not to call these optimized methods on "custom" function
objects (i.e. any not of type T_FUNCTION), as that would just cause an
immediate crash.