### PR TITLE
changed the `show` method for GAP objects ...

### DIFF
--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -3,7 +3,7 @@
 
 import Base: getindex, setindex!, length, show
 
-function Base.show(io::IO, ::MIME"text/plain", obj::Union{GapObj,FFE})
+function show_string(io::IO, obj::Union{GapObj,FFE})
     str = Globals.StringViewObj(obj)
     stri = CSTR_STRING(str)
     lines = split(stri, "\n")
@@ -15,6 +15,11 @@ function Base.show(io::IO, ::MIME"text/plain", obj::Union{GapObj,FFE})
       stri = join(lines[1:upper], "\n") * "\n  ⋮\n" *
              join(lines[(end-rows+upper+2):end], "\n")
     end
+    return stri
+end
+
+function Base.show(io::IO, obj::Union{GapObj,FFE})
+    stri = show_string(io, obj)
     print(io, "GAP: $stri")
 end
 

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -3,9 +3,18 @@
 
 import Base: getindex, setindex!, length, show
 
-function Base.show(io::IO, obj::Union{GapObj,FFE})
+function Base.show(io::IO, ::MIME"text/plain", obj::Union{GapObj,FFE})
     str = Globals.StringViewObj(obj)
     stri = CSTR_STRING(str)
+    lines = split(stri, "\n")
+    rows = displaysize(io)[1]-3  # the maximum number of lines to show
+    if length(lines) > rows
+      # For objects that do not fit on the screen,
+      # show only the first and the last lines.
+      upper = div(rows, 2)
+      stri = join(lines[1:upper], "\n") * "\n  ⋮\n" *
+             join(lines[(end-rows+upper+2):end], "\n")
+    end
     print(io, "GAP: $stri")
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,4 @@
 import REPL.REPLCompletions: completions
-import Base: show
 
 ## These two functions are used on the GAP side.
 


### PR DESCRIPTION
... such that not more lines are shown than fit on the screen
(including the Julia prompts), by omitting the middle part
of too long `ViewObj` results.

The unicode symbol `⋮` is used, which seems to be standard in Julia
for this purpose.

I hope this does not conflict with the "no unicode" policy
that is mentioned in the discussion about Nemocas/AbstractAlgebra.jl/pull/389.
(Where is this policy stated?)

Additionally, the string to be shown except the prefix `GAP: ` can now be computed with `show_string`.
The dedicated `show` methods for group elements etc. in files in `Oscar.jl/src/Groups` (where the prefix `GAP: ` is omitted) can be changed to use `show_string`, and then benefit from the abbreviation.
