### PR TITLE
two-step help request via a menu

### DIFF
--- a/pkg/JuliaInterface/gap/helpstring.g
+++ b/pkg/JuliaInterface/gap/helpstring.g
@@ -380,7 +380,7 @@ end);
 #F  HELP_Info( <string>, <onlyexact> ) . . . . . . . deal with a help request
 #F  HELP_String( <string>, <onlyexact> ) . . . . . . deal with a help request
 ##  
-##  The return value of 'HELP_INFO' is either a list (in cases where just
+##  The return value of 'HELP_Info' is either a list (in cases where just
 ##  one entry shall be shown) or a record with the components 'entries' and
 ##  'menu' (in cases where more than one entry may exist, and where an
 ##  intermediate step via choosing from a menu may be appropriate).
@@ -390,7 +390,7 @@ end);
 ##  and 'start' (the position of the first line to show).
 ##
 ##  The return value of 'HELP_String' is a list that contains the
-##  concatenation of the contents of the result of ''HELP_Info' when this
+##  concatenation of the contents of the result of 'HELP_Info' when this
 ##  is called with the same arguments.
 ##
 DeclareGlobalFunction( "HELP_String" );

--- a/test/help.jl
+++ b/test/help.jl
@@ -1,8 +1,16 @@
 @testset "help" begin
+    using REPL
+    tt = REPL.TerminalMenus.terminal
+
     function test_gap_help(topic::String)
-        return isa(GAP.gap_help_string(topic), String) &&
-               isa(GAP.gap_help_string(topic, true), String)
+        inp = Base.IOBuffer("qq") # exit the menu if applicable
+        term = REPL.Terminals.TTYTerminal( "dumb", inp, tt.out_stream, tt.err_stream)
+        return isa(GAP.gap_help_string(topic, false, term), String) &&
+               isa(GAP.gap_help_string(topic, true, term), String)
     end
+
+    # Do not print the menus.
+    REPL.TerminalMenus.config(supress_output = true)
 
     @test test_gap_help("")
     @test test_gap_help("&")
@@ -17,7 +25,6 @@
     @test test_gap_help("?determinant")
     @test test_gap_help("?PermList")
     @test test_gap_help("?IsJuliaWrapper")
-    println(GAP.gap_help_string("?IsJuliaWrapper"))
 
     @test test_gap_help("books")
     @test test_gap_help("tut:chapters")
@@ -28,4 +35,6 @@
     @test test_gap_help("ref:isobject")
     @test test_gap_help("unknow")
     @test test_gap_help("something for which no match is found")
+
+    REPL.TerminalMenus.config(supress_output = false)
 end


### PR DESCRIPTION
This is a draft proposal of an alternative access to documentation.
Instead of showing all matching entries for a help request (which is Julia's way to look at things), a menu with an overview of the matching entries is shown, from which one can choose what one wants to see.
I think this is more useful than looking through several pages of screen output. (Try `?GAP.Globals.Size`.)

A problem is how to test this kind of help access, since one has to enter some characters (at least the `q` for exiting the menu) in interactive mode.
I have tried to simulate a terminal, but this is too simpleminded, since one gets warnings when the tests are run.

(If this kind of help access is interesting then it would perhaps make sense to provide also a variant that is based on GAP's Browse package instead of Julia's REPL menus.)