### PR TITLE
Partial fix for dlsym() not finding symbols.

### DIFF
--- a/pkg/JuliaInterface/init.g
+++ b/pkg/JuliaInterface/init.g
@@ -32,7 +32,7 @@ DeclareUserPreference( rec(
 
 ReadPackage( "JuliaInterface", "gap/JuliaTypeDeclarations.gd");
 
-_PATH_SO:=Filename(DirectoriesPackagePrograms("JuliaInterface"), "JuliaInterface.so");
+_PATH_SO:=Filename(DirectoriesPackagePrograms("JuliaInterface"), ".libs/JuliaInterface.so");
 if _PATH_SO <> fail then
     LoadDynamicModule(_PATH_SO);
 fi;

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -285,7 +285,7 @@ function initialize(argv::Array{String,1})
 
     # open JuliaInterface.so, too
     #global JuliaInterface_path = CSTR_STRING(EvalString("""Filename(DirectoriesPackagePrograms("JuliaInterface"), "JuliaInterface.so");"""))
-    global JuliaInterface_path = joinpath(@__DIR__, "..", "pkg", "JuliaInterface", "bin", sysinfo["GAParch"], ".libs", JuliaInterface)
+    global JuliaInterface_path = normpath(joinpath(@__DIR__, "..", "pkg", "JuliaInterface", "bin", sysinfo["GAParch"], ".libs", JuliaInterface))
     global JuliaInterface_handle = Libdl.dlopen(JuliaInterface_path,
         Libdl.RTLD_GLOBAL)
     CJuliaInterface._load(JuliaInterface_handle)

--- a/src/cbind.jl
+++ b/src/cbind.jl
@@ -28,16 +28,6 @@ end
 
 macro csym(libname, expr)
     if libname == :CJuliaInterface
-        # HACK: On macOS, the system seems to get confused by the fact
-        # that JuliaInterface.so is loaded twice, once from the GAP
-        # kernel and once from GAP.jl. If we remove this check, GAP
-        # will eventually crash. Instead, we resort to simply returning
-        # the symbol on macOS, which will result in dlsym() looking it
-        # up in the global namespace rather than within the specified
-        # library.
-        if Sys.isapple()
-	        return expr
-	    end
         lib = CJuliaInterface
     elseif libname == :CLibGap
         lib = CLibGap

--- a/src/cbind.jl
+++ b/src/cbind.jl
@@ -1,0 +1,68 @@
+# We store C symbols obtained via dlsym in an array. The @csym macro
+# returns an expression indexing the array (e.g. CLibGap._bindings[3]),
+# which matches the corresponding name (e.g. CLibGap._symnames[3]). The
+# index calculation is done at compile time, so at runtime only an
+# array indexing operation must be performed.
+
+module CLibGap
+    using Libdl
+    const _bindings = Vector{Ptr}()
+    const _symnames = Vector{Symbol}()
+    function _load(libgap_handle)
+        for i in 1:length(_bindings)
+            _bindings[i] = Libdl.dlsym(libgap_handle, _symnames[i])
+        end
+    end
+end
+
+module CJuliaInterface
+    using Libdl
+    const _bindings = Vector{Ptr}()
+    const _symnames = Vector{Symbol}()
+    function _load(JuliaInterface_handle)
+        for i in 1:length(_bindings)
+            _bindings[i] = Libdl.dlsym(JuliaInterface_handle, _symnames[i])
+        end
+    end
+end
+
+macro csym(libname, expr)
+    if libname == :CJuliaInterface
+        # HACK: On macOS, the system seems to get confused by the fact
+        # that JuliaInterface.so is loaded twice, once from the GAP
+        # kernel and once from GAP.jl. If we remove this check, GAP
+        # will eventually crash. Instead, we resort to simply returning
+        # the symbol on macOS, which will result in dlsym() looking it
+        # up in the global namespace rather than within the specified
+        # library.
+        if Sys.isapple()
+	        return expr
+	    end
+        lib = CJuliaInterface
+    elseif libname == :CLibGap
+        lib = CLibGap
+    end
+    # Extract the C function name from `expr`.
+    sym =
+        if expr isa String
+            Symbol(expr)
+        elseif expr isa QuoteNode
+            expr.value
+        elseif expr isa Symbol
+            expr
+        else
+            throw(ArgumentError("expression is not a symbol"))
+        end
+    # Have we already seen that symbol?
+    if ! (sym in lib._symnames)
+        # If no, add an entry to the end of _symnames/_bindings.
+        push!(lib._symnames, sym)
+        push!(lib._bindings, C_NULL)
+        index = length(lib._symnames)
+    else
+        # If yes, return the index of the existing symbol.
+        index = findfirst(s -> s == sym, lib._symnames)
+    end
+    # return an expression of the form mod._bindings[index].
+    return :($(lib)._bindings[$(esc(index))])
+end

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -13,13 +13,14 @@ function _GAP_TO_JULIA(ptr::Ptr{Cvoid})
     elseif as_int & 2 == 2
         return reinterpret(FFE, ptr)
     end
-    return ccall(:julia_gap, Any, (Ptr{Cvoid},), ptr)
+    return ccall(@csym(CJuliaInterface, :julia_gap), Any, (Ptr{Cvoid},), ptr)
 end
 
 #
 # low-level Julia -> GAP conversion
 #
-_JULIA_TO_GAP(val::Any) = ccall(:gap_julia, Ptr{Cvoid}, (Any,), val)
+_JULIA_TO_GAP(val::Any) = ccall(@csym(CJuliaInterface, :gap_julia),
+    Ptr{Cvoid}, (Any,), val)
 #_JULIA_TO_GAP(x::Bool) = x ? gap_true : gap_false
 _JULIA_TO_GAP(x::FFE) = reinterpret(Ptr{Cvoid}, x)
 _JULIA_TO_GAP(x::GapObj) = pointer_from_objref(x)
@@ -28,12 +29,12 @@ function _JULIA_TO_GAP(x::Int)
     if x in -1<<60:(1<<60-1)
         return Ptr{Cvoid}(x << 2 | 1)
     end
-    return ccall(:ObjInt_Int, Ptr{Cvoid}, (Int,), x)
+    return ccall(@csym(CLibGap, :ObjInt_Int), Ptr{Cvoid}, (Int,), x)
 end
 
 
 function evalstr_ex(cmd::String)
-    res = ccall(:GAP_EvalString, GapObj, (Ptr{UInt8},), cmd)
+    res = ccall(@csym(CLibGap, :GAP_EvalString), GapObj, (Ptr{UInt8},), cmd)
     return res
 end
 
@@ -73,7 +74,8 @@ end
 # Retrieve the value of a global GAP variable given its name. This function
 # returns a raw Ptr value, and should only be called by plumbing code.
 function _ValueGlobalVariable(name::Union{AbstractString,Symbol})
-    return ccall(:GAP_ValueGlobalVariable, Ptr{Cvoid}, (Ptr{UInt8},), name)
+    return ccall(@csym(CLibGap, :GAP_ValueGlobalVariable),
+        Ptr{Cvoid}, (Ptr{UInt8},), name)
 end
 
 function ValueGlobalVariable(name::Union{AbstractString,Symbol})
@@ -83,13 +85,15 @@ end
 
 # Test whether the global GAP variable with the given name can be assigned to.
 function CanAssignGlobalVariable(name::Union{AbstractString,Symbol})
-    ccall(:GAP_CanAssignGlobalVariable, Bool, (Ptr{UInt8},), name)
+    ccall(@csym(CLibGap, :GAP_CanAssignGlobalVariable),
+        Bool, (Ptr{UInt8},), name)
 end
 
 # Assign a value to the global GAP variable with the given name. This function
 # assigns a raw Ptr value, and should only be called by plumbing code.
 function _AssignGlobalVariable(name::Union{AbstractString,Symbol}, value::Ptr{Cvoid})
-    ccall(:GAP_AssignGlobalVariable, Cvoid, (Ptr{UInt8}, Ptr{Cvoid}), name, value)
+    ccall(@csym(CLibGap, :GAP_AssignGlobalVariable),
+        Cvoid, (Ptr{UInt8}, Ptr{Cvoid}), name, value)
 end
 
 # Assign a value to the global GAP variable with the given name.
@@ -101,29 +105,39 @@ function AssignGlobalVariable(name::Union{AbstractString,Symbol}, value::Any)
     _AssignGlobalVariable(name, tmp)
 end
 
-MakeString(val::String) = ccall(:GAP_MakeString, GapObj, (Ptr{UInt8},), val)
+MakeString(val::String) =
+    ccall(@csym(CLibGap, :GAP_MakeString), GapObj, (Ptr{UInt8},), val)
 
 function CSTR_STRING(val::GapObj)
-    char_ptr = ccall(:GAP_CSTR_STRING, Ptr{UInt8}, (Any,), val)
+    char_ptr = ccall(@csym(CLibGap, :GAP_CSTR_STRING),
+        Ptr{UInt8}, (Any,), val)
     return deepcopy(unsafe_string(char_ptr))::String
 end
 
 function CSTR_STRING_AS_ARRAY(val::GapObj)::Array{UInt8,1}
-    string_len = Int64(ccall(:GAP_LenString, Cuint, (Any,), val))
-    char_ptr = ccall(:GAP_CSTR_STRING, Ptr{UInt8}, (Any,), val)
+    string_len = Int64(ccall(@csym(CLibGap, :GAP_LenString),
+        Cuint, (Any,), val))
+    char_ptr = ccall(@csym(CLibGap, :GAP_CSTR_STRING), Ptr{UInt8}, (Any,), val)
     return deepcopy(unsafe_wrap(Array{UInt8,1}, char_ptr, string_len))
 end
 
 
-NewPlist(capacity::Int64) = ccall(:GAP_NewPlist, GapObj, (Int64,), capacity)
-NewPrecord(capacity::Int64) = ccall(:GAP_NewPrecord, GapObj, (Int64,), capacity)
-NEW_MACFLOAT(x::Float64) = ccall(:NEW_MACFLOAT, GapObj, (Cdouble,), x)
-ValueMacFloat(x::GapObj) = ccall(:GAP_ValueMacFloat, Cdouble, (Any,), x)
-CharWithValue(x::Cuchar) = ccall(:GAP_CharWithValue, GapObj, (Cuchar,), x)
-NewJuliaFunc(x::Function) = ccall(:NewJuliaFunc, GapObj, (Any,), x)
+NewPlist(capacity::Int64) = ccall(@csym(CLibGap, :GAP_NewPlist),
+    GapObj, (Int64,), capacity)
+NewPrecord(capacity::Int64) = ccall(@csym(CLibGap, :GAP_NewPrecord),
+    GapObj, (Int64,), capacity)
+NEW_MACFLOAT(x::Float64) = ccall(@csym(CLibGap, :NEW_MACFLOAT),
+    GapObj, (Cdouble,), x)
+ValueMacFloat(x::GapObj) = ccall(@csym(CLibGap, :GAP_ValueMacFloat),
+    Cdouble, (Any,), x)
+CharWithValue(x::Cuchar) = ccall(@csym(CLibGap, :GAP_CharWithValue),
+    GapObj, (Cuchar,), x)
+NewJuliaFunc(x::Function) =
+    ccall(@csym(CJuliaInterface, :NewJuliaFunc), GapObj, (Any,), x)
 
 function ElmList(x::GapObj, position)
-    o = ccall(:GAP_ElmList, Ptr{Cvoid}, (Any, Culong), x, Culong(position))
+    o = ccall(@csym(CLibGap, :GAP_ElmList),
+        Ptr{Cvoid}, (Any, Culong), x, Culong(position))
     return _GAP_TO_JULIA(o)
 end
 
@@ -173,7 +187,8 @@ function call_gap_func(func::GapObj, args...; kwargs...)
         if TNUM_OBJ(func) == T_FUNCTION && length(args) <= 6
             result = _call_gap_func(func, args...)
         else
-            result = ccall(:call_gap_func, Any, (Any, Any), func, args)
+            result = ccall(:call_gap_func,
+	        Any, (Any, Any), func, args)
         end
         if options
             Globals.PopOptions()


### PR DESCRIPTION
This PR is a partial fix for the problem that dlsym() occasionally fails to find library symbols (this has primarily been observed with Julia 1.3.1). These issues seems to arise from conflicting symbol search strategies. By specifying the library to search for symbols, we avoid ambiguities and implementation-defined behavior (for example, that Linux defaults to RTLD_LOCAL for dlopen() and macOS defaults to RTLD_GLOBAL, as well as subtle differences in search strategies for RTLD_DEFAULT).

The net effect of this change is that the problems do not manifest anymore on Julia 1.3 on Linux. However, this will now (reliably) crash on macOS with Julia 1.3 (though not 1.4).

The underlying problem on macOS is that multiple instances of `JuliaInterface.so` are being loaded. This can be illustrated with the following code:

```
using GAP, Libdl

# macOS specific, as Libdl does not define that value.

RTLD_DEFAULT = reinterpret(Ptr{Cvoid}, -2)

p1 = Libdl.dlsym(GAP.JuliaInterface_handle, :gap_julia)
p2 = Libdl.dlsym(RTLD_DEFAULT, :gap_julia)
println("dlsym() on JuliaInterface.so handle: $p1")
println("dlsym() on RTLD_DEFAULT:             $p2")
println("Do these values match?               $(p1 === p2)")
```

These calls should normally return the same result (as `dlopen()` is supposed to not load the same dynamic library twice), but on macOS they don't. Linux does not have this problem, so the problem does not crop up there. For macOS and Julia >= 1.4, we can fix this problem by using `ccall(:sym, ...)` semantics, as in those cases `RTLD_DEFAULT` will be used, which happens to be give us references to the version of the library that GAP uses. However, this is very fragile.

The underlying problem that needs to be fixed is that we have to avoid loading `JuliaInterface.so` twice.

This fragility is also on display with `gap.sh -c 'LoadPackage("JuliaInterface");'`, which will crash reliably on macOS (regardless of the Julia version). This does not happen when calling `LoadPackage("JuliaInterface");` from the prompt. It appears that there are differences in initialization order if `-c` is used, which can be observed by adding debugging output to the GAP.jl initialization. This can probably also be traced back to the issue above.