### PR TITLE
SetPrintFormattingStatus( ..., false )

### DIFF
--- a/pkg/JuliaInterface/gap/utils.gi
+++ b/pkg/JuliaInterface/gap/utils.gi
@@ -20,6 +20,7 @@ function(obj)
   local str, out;
   str := "";
   out := OutputTextString(str, false);
+  SetPrintFormattingStatus(out, false);
   STREAM_CALL(out, Display, obj);
   CloseStream(out);
   return str;
@@ -30,6 +31,7 @@ function(obj)
   local str, out;
   str := "";
   out := OutputTextString(str, false);
+  SetPrintFormattingStatus(out, false);
   STREAM_CALL(out, ViewObj, obj);
   CloseStream(out);
   return str;

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -142,6 +142,7 @@ function reset_GAP_ERROR_OUTPUT()
     evalstr("_JULIAINTERFACE_ERROR_OUTPUT:= \"\";")
     Globals.MakeReadWriteGlobal(julia_to_gap("ERROR_OUTPUT"))
     evalstr("ERROR_OUTPUT:= OutputTextString( _JULIAINTERFACE_ERROR_OUTPUT, true );")
+    evalstr("SetPrintFormattingStatus( ERROR_OUTPUT, false )")
     Globals.MakeReadOnlyGlobal(julia_to_gap("ERROR_OUTPUT"))
 end
 


### PR DESCRIPTION
let Julia handle the line breaking. This is particularly useful for Jupyter notebooks.