### PR TITLE
Fix using GAP.jl from Oscar.jl in Julia 1.3

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -286,7 +286,7 @@ function initialize(argv::Array{String,1})
     global JuliaInterface_handle = Libdl.dlopen(JuliaInterface_path)
 
     # Redirect error messages, in order not to print them to the screen.
-    reset_GAP_ERROR_OUTPUT()
+    Base.invokelatest(reset_GAP_ERROR_OUTPUT)
 end
 
 function finalize()

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -282,7 +282,7 @@ function initialize(argv::Array{String,1})
 
     # open JuliaInterface.so, too
     #global JuliaInterface_path = CSTR_STRING(EvalString("""Filename(DirectoriesPackagePrograms("JuliaInterface"), "JuliaInterface.so");"""))
-    global JuliaInterface_path = joinpath(@__DIR__, "..", "pkg", "JuliaInterface", "bin", sysinfo["GAParch"], ".libs", JuliaInterface)
+    global JuliaInterface_path = normpath(joinpath(@__DIR__, "..", "pkg", "JuliaInterface", "bin", sysinfo["GAParch"], JuliaInterface))
     global JuliaInterface_handle = Libdl.dlopen(JuliaInterface_path)
 
     # Redirect error messages, in order not to print them to the screen.


### PR DESCRIPTION
Fixes #509
Closes #512 

Better fixes may be possible, but this is the minimal change to make to get things working. We then can quickly release GAP.jl 0.4.4. Since I can now reproduce this locally, it'll be easy enough to experiment with further variations.