### PR TITLE
changed JuliaIncludeFile

### DIFF
--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -152,12 +152,16 @@ DeclareGlobalFunction( "IsArgumentForJuliaFunction" );
 #! @EndExampleSession
 #DeclareGlobalFunction( "JuliaEvalString" );
 
-#! @Arguments filename
+#! @Arguments filename[, module_name]
 #! @Returns nothing.
 #! @Description
-#!  calls &Julia;'s <C>Base.include</C> with the string <A>filename</A>.
-#!  This means that the &Julia; code in the file with this name gets
-#!  executed in the current &Julia; session.
+#!  calls &Julia;'s <C>Base.include</C> with the strings <A>filename</A>
+#!  (an absolute filename, as returned by
+#!  <Ref Oper="Filename" BookName="ref"/>) and <A>module_name</A>
+#!  (the name of a &Julia; module, the default is <C>"Main"</C>).
+#!  This means that the &Julia; code in the file with name <A>filename</A>
+#!  gets executed in the current &Julia; session,
+#!  in the context of the &Julia; module <A>module_name</A>.
 #!  If the file defines a new &Julia; module then the next step will be
 #!  to import this module, see <Ref Func="ImportJuliaModuleIntoGAP"/>.
 DeclareGlobalFunction( "JuliaIncludeFile" );

--- a/pkg/JuliaInterface/gap/JuliaInterface.gi
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gi
@@ -127,10 +127,21 @@ InstallOtherMethod( \[\],
 BindGlobal( "JuliaKnownFiles", [] );
 
 InstallGlobalFunction( "JuliaIncludeFile",
-function( filename )
-    if not filename in JuliaKnownFiles then
-      JuliaEvalString( Concatenation( "Base.include(@__MODULE__,\"", filename, "\")" ) );
-      AddSet( JuliaKnownFiles, filename );
+function( filename, module_name... )
+    local pair;
+
+    if Length( module_name ) = 0 then
+      module_name:= "Main";
+    elif Length( module_name ) = 1 and IsString( module_name[1] ) then
+      module_name:= module_name[1];
+    else
+      Error( "usage: JuliaIncludeFile( <filename>[, <module_name>] ) ",
+             "where <module_name>, if given, must be a string" );
+    fi;
+    pair:= [ module_name, filename ];
+    if not pair in JuliaKnownFiles then
+      JuliaEvalString( Concatenation( "Base.include(", module_name,", \"", filename, "\")" ) );
+      AddSet( JuliaKnownFiles, pair );
     fi;
 end );
 


### PR DESCRIPTION
- added a two-argument version of `JuliaIncludeFile`, where also the name of the Julia module is specified into which the file shall be included,
- in the one-argument case, use the `Main` module as the default; up to now, `@__MODULE__` had been used, which is usually `Main` in the situation of `JuliaIncludeFile` (and if not then it is better to state explicitly which module is intended),
- documented the above statements, and that the filename must be an absolute path; relative paths will almost always be misunderstood by Julia,
- adjusted `JuliaKnownFiles`, which is used to make sure that files get included only once; now it makes sense to include the same file in serveral modules.