### PR TITLE
fixed the @g_str macro

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -74,10 +74,42 @@ Create a GAP string by typing `g"content"`.
 ```jldoctest
 julia> g"foo"
 GAP: "foo"
+
+julia> g"ab\\ncd\\\"ef\\\\gh"   # special characters are handled as in GAP
+GAP: "ab\\ncd\\\"ef\\\\gh"
+
+```
+
+Due to Julia's way of handing over arguments into the code of macros,
+not all strings representing valid GAP strings can be processed.
+
+```jldoctest
+julia> g"\\\\"
+ERROR: LoadError: failed to convert to GapObj:
+ \\
+[...]
+
+```
+
+Conversely,
+there are valid arguments for the macro that are not valid Julia strings.
+
+```jldoctest
+julia> g"\\c"
+GAP: "\\c"
+
 ```
 """
 macro g_str(str)
-    return julia_to_gap(str)
+    # Note that here backslashes inside `str` are literally contained in `str`,
+    # except for backslashes that escape doublequotes.
+    # In order to get the intended meaning (as stated in the GAP manual section
+    # "Special Characters"),
+    # we escape doublequotes and leave the interpretation to `evalstr`.
+    evl = evalstr("\"" * replace(str, "\"" => "\\\"") * "\"")
+    evl === nothing && error("failed to convert to GapObj:\n $str")
+
+    return evl
 end
 
 export @g_str

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -64,6 +64,22 @@ end
 
 export @gap
 
+# Define a plain function that contains the code of the `@g_str` macro.
+# Note that errors thrown by macros can apparently not be tested using
+# `@test_throw`.
+function gap_string_macro_helper(str::String)
+    # We assume that `str` is the input of the `@g_str` macro;
+    # more precisely, `str` is what arrives inside the code of the macro.
+    # Note that here backslashes inside `str` are literally contained in `str`,
+    # except for backslashes that escape doublequotes.
+    # In order to get the intended meaning (as stated in the GAP manual section
+    # "Special Characters"),
+    # we escape doublequotes and leave the interpretation to `evalstr`.
+    evl = evalstr("\"" * replace(str, "\"" => "\\\"") * "\"")
+    evl === nothing && error("failed to convert to GapObj:\n $str")
+
+    return evl
+end
 
 """
     @g_str
@@ -101,15 +117,7 @@ GAP: "\\c"
 ```
 """
 macro g_str(str)
-    # Note that here backslashes inside `str` are literally contained in `str`,
-    # except for backslashes that escape doublequotes.
-    # In order to get the intended meaning (as stated in the GAP manual section
-    # "Special Characters"),
-    # we escape doublequotes and leave the interpretation to `evalstr`.
-    evl = evalstr("\"" * replace(str, "\"" => "\\\"") * "\"")
-    evl === nothing && error("failed to convert to GapObj:\n $str")
-
-    return evl
+    return gap_string_macro_helper(str)
 end
 
 export @g_str

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -10,4 +10,9 @@
     @test GAP.Globals.Size(x) == 6
     x = GAP.g"foo"
     @test x == GAP.julia_to_gap("foo")
+    x = GAP.g"1:\n, 2:\", 3:\\, 4:\b, 5:\r, 6:\c, 7:\001"
+    @test x == GAP.julia_to_gap("1:\n, 2:\", 3:\\, 4:\b, 5:\r, 6:\003, 7:\001")
+#TODO: Can the following error not be tested?
+#    @test_throws LoadError GAP.g"\\"
+
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -12,7 +12,8 @@
     @test x == GAP.julia_to_gap("foo")
     x = GAP.g"1:\n, 2:\", 3:\\, 4:\b, 5:\r, 6:\c, 7:\001"
     @test x == GAP.julia_to_gap("1:\n, 2:\", 3:\\, 4:\b, 5:\r, 6:\003, 7:\001")
-#TODO: Can the following error not be tested?
-#    @test_throws LoadError GAP.g"\\"
+    # Errors thrown by the GAP.g macro cannot be tested directly,
+    # and the string "\\" can be handed over in the macro.
+    @test_throws ErrorException GAP.gap_string_macro_helper("\\")
 
 end


### PR DESCRIPTION
- changed the code such that escaped characters are handled correctly,
- added comments/examples concerning the limitations,
- added a test

(How can one test using `@test_throws` that a macro throws an error?)