### PR TITLE
added a missing `julia_to_gap` method

### DIFF
--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -89,7 +89,8 @@ julia_to_gap(x::AbstractString) = MakeString(string(x))
 julia_to_gap(x::Symbol) = MakeString(string(x))
 
 ## Generic caller for optional arguments
-julia_to_gap(obj::Any, recursion_dict; recursive = true) = julia_to_gap(obj)
+julia_to_gap(obj::Any; recursive::Bool) = julia_to_gap(obj)
+julia_to_gap(obj::Any, recursion_dict::IdDict{Any,Any}; recursive = true) = julia_to_gap(obj)
 
 ## Arrays (including BitArray{1})
 function julia_to_gap(

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -403,6 +403,7 @@ end
     @test nonrec[1] == [1, 2]
     rec = GAP.julia_to_gap(val, recursive = true)
     @test rec[1] == GAP.julia_to_gap([1, 2])
+    @test GAP.julia_to_gap(1, recursive = false) == 1
 
     ## Test function conversion
     return_first(args...) = args[1]


### PR DESCRIPTION
for the case that the keyword argument `recursive` is given
but no dictionary of subobjects.
In this situation,
we assume that the object in question does not have subobjects
because otherwise another method would have dealt with it.