### PR TITLE
make calling GapObj function objects faster when no keyword arguments are involved

### DIFF
--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -190,6 +190,14 @@ end
 # make all GapObj callable
 (func::GapObj)(args...; kwargs...) = call_gap_func(func, args...; kwargs...)
 
+# specialize non-kwargs versions, which increases performance
+(func::GapObj)(a1) = call_gap_func(func, a1)
+(func::GapObj)(a1, a2) = call_gap_func(func, a1, a2)
+(func::GapObj)(a1, a2, a3) = call_gap_func(func, a1, a2, a3)
+(func::GapObj)(a1, a2, a3, a4) = call_gap_func(func, a1, a2, a3, a4)
+(func::GapObj)(a1, a2, a3, a4, a5) = call_gap_func(func, a1, a2, a3, a4, a5)
+(func::GapObj)(a1, a2, a3, a4, a5, a6) = call_gap_func(func, a1, a2, a3, a4, a5, a6)
+
 #
 # below several "fastpath" methods for call_gap_func follow which directly
 # jump to the C handler functions, bypassing JuliaInterface, for optimal

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -187,16 +187,25 @@ function call_gap_func(func::GapObj, args...; kwargs...)
     end
 end
 
+# specialize call_gap_func for the no-keywords case, for performance
+function call_gap_func_nokw(func::GapObj, args...)
+    if TNUM_OBJ(func) == T_FUNCTION && length(args) <= 6
+        _call_gap_func(func, args...)
+    else
+        ccall(:call_gap_func, Any, (Any, Any), func, args)
+    end
+end
+
 # make all GapObj callable
 (func::GapObj)(args...; kwargs...) = call_gap_func(func, args...; kwargs...)
 
 # specialize non-kwargs versions, which increases performance
-(func::GapObj)(a1) = call_gap_func(func, a1)
-(func::GapObj)(a1, a2) = call_gap_func(func, a1, a2)
-(func::GapObj)(a1, a2, a3) = call_gap_func(func, a1, a2, a3)
-(func::GapObj)(a1, a2, a3, a4) = call_gap_func(func, a1, a2, a3, a4)
-(func::GapObj)(a1, a2, a3, a4, a5) = call_gap_func(func, a1, a2, a3, a4, a5)
-(func::GapObj)(a1, a2, a3, a4, a5, a6) = call_gap_func(func, a1, a2, a3, a4, a5, a6)
+(func::GapObj)(a1) = call_gap_func_nokw(func, a1)
+(func::GapObj)(a1, a2) = call_gap_func_nokw(func, a1, a2)
+(func::GapObj)(a1, a2, a3) = call_gap_func_nokw(func, a1, a2, a3)
+(func::GapObj)(a1, a2, a3, a4) = call_gap_func_nokw(func, a1, a2, a3, a4)
+(func::GapObj)(a1, a2, a3, a4, a5) = call_gap_func_nokw(func, a1, a2, a3, a4, a5)
+(func::GapObj)(a1, a2, a3, a4, a5, a6) = call_gap_func_nokw(func, a1, a2, a3, a4, a5, a6)
 
 #
 # below several "fastpath" methods for call_gap_func follow which directly


### PR DESCRIPTION
This is a low-hanging-fruits attemp to make calling functions from `GAP.Globals` faster. This is related to #530 in its goal.

This contains two commits which both improve performance, to such an extent that is a bit mysterious for me. Here is a small demo. First, the baseline, using GAP master and a 3-days old Julia master:
```julia
using GAP

julia> l = GAP.evalstr( "[1,2,3]" )
GAP: [ 1, 2, 3 ]

julia> @btime GAP.Globals.IsFinite($l); 
  750.697 ns (8 allocations: 128 bytes)    

julia> @btime $l[1]
  842.671 ns (8 allocations: 192 bytes)
1
```
The first surprise is the following (I would be curious if someone has any idea what happens there): by simply re-evaling `call_gap_func` at the repl, with the same definition which is in the source code, we get:
```julia
julia> @eval GAP function call_gap_func(func::GapObj, args...; kwargs...)
# ... content not reproduced here
end

julia> @btime GAP.Globals.IsFinite($l);
501.041 ns (5 allocations: 80 bytes)

julia> @btime $l[1];
  843.265 ns (8 allocations: 192 bytes)
```
So the 1-argument call `IsFinite(l)` is significantly sped up, but not so `l[1]`.

Anyway, the first commit consists in writing specialized "call syntax" for cases where no keywords are involved, like
```julia
(func::GapObj)(a1) = call_gap_func(func, a1)
(func::GapObj)(a1, a2) = call_gap_func(func, a1, a2)
```
The example becomes:
```julia
julia> @btime GAP.Globals.IsFinite($l);
  180.778 ns (1 allocation: 16 bytes)

julia> @btime $l[1];
  247.137 ns (2 allocations: 48 bytes)
```
The second commit rewrites a version of `call_gap_func` which doesn't take keyword arguments, i.e.
```julia
call_gap_func_nokw(func::GapObj, args...)
```
And have the above "call syntax" use that, e.g. `(func::GapObj)(a1) = call_gap_func_nokw(func, a1)`. The timings become:
```julia
julia> @btime GAP.Globals.IsFinite($l);
  89.268 ns (0 allocations: 0 bytes)

julia> @btime $l[1];
  71.274 ns (0 allocations: 0 bytes)
```
This is an order of magnitude faster than on master!