### PR TITLE
allow seeding GAP's global RNG

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ version = "0.4.4"
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -432,17 +432,8 @@ For a fixed seed, the stream of generated numbers is allowed to change between
 different versions of GAP.
 """
 function randseed!(seed::Union{Integer,Nothing}=nothing)
-    if seed === nothing
-        seed = rand(UInt128)
-    end
-    # Although GAP's `Reset` method can accept directly integers (also negative
-    # ones), we harmonize here the behavior with what Julia does, i.e. for two
-    # integers with the same value, even of different types, the initialization
-    # is the same (e.g. with `1` or `0x1`); so we re-use Julia's
-    # `Random.make_seed` internal function (which errors on negative argument)
-    # to normalize this, and create a string out of it.
-    str = String(reinterpret(UInt8, Random.make_seed(seed)))
-    Globals.Reset(Globals.GlobalMersenneTwister, str)
+    seed = something(seed, rand(UInt128))
+    Globals.Reset(Globals.GlobalMersenneTwister, seed)
     # when GlobalRandomSource is reset, the seed is taken modulo 2^28, so we just
     # pass an already reduced seed here
     Globals.Reset(Globals.GlobalRandomSource, seed % Int % 2^28)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -160,5 +160,4 @@ end
     @test gs2 == [random(GMT, G) for _=1:30]
     @test gs3 == [random(GRS, G) for _=1:30]
 
-    @test_throws DomainError GAP.randseed!(-rand(1:1234))
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -138,16 +138,27 @@ end
 @testset "randseed!" begin
     G = GAP.Globals.SymmetricGroup(9)
     random = GAP.Globals.Random
+    GMT = GAP.Globals.GlobalMersenneTwister
+    GRS = GAP.Globals.GlobalRandomSource
+
     GAP.randseed!()
-    g = random(G)
+    g1 = random(G)
+    g2 = random(GMT, G)
+    g3 = random(GRS, G)
     GAP.randseed!() # should initialize to a different state than before
-    @test g != random(G)
+    @test g1 != random(G)
+    @test g2 != random(GMT, G)
+    @test g3 != random(GRS, G)
 
     seed = rand(UInt128)
     GAP.randseed!(seed)
-    gs = [random(G) for _=1:30]
+    gs1 = [random(G) for _=1:30]
+    gs2 = [random(GMT, G) for _=1:30]
+    gs3 = [random(GRS, G) for _=1:30]
     GAP.randseed!(seed)
-    gs == [random(G) for _=1:30]
+    @test gs1 == [random(G) for _=1:30]
+    @test gs2 == [random(GMT, G) for _=1:30]
+    @test gs3 == [random(GRS, G) for _=1:30]
 
     @test_throws DomainError GAP.randseed!(-rand(1:1234))
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -134,3 +134,20 @@ end
     @test l[2] === l
     @test GAP.gap_to_julia(GAP.Globals.StringViewObj(l)) == "[ 1, ~, 3 ]"
 end
+
+@testset "randseed!" begin
+    G = GAP.Globals.SymmetricGroup(9)
+    random = GAP.Globals.Random
+    GAP.randseed!()
+    g = random(G)
+    GAP.randseed!() # should initialize to a different state than before
+    @test g != random(G)
+
+    seed = rand(UInt128)
+    GAP.randseed!(seed)
+    gs = [random(G) for _=1:30]
+    GAP.randseed!(seed)
+    gs == [random(G) for _=1:30]
+
+    @test_throws DomainError GAP.randseed!(-rand(1:1234))
+end


### PR DESCRIPTION
This is in line with the equivalent in Nemo (https://github.com/Nemocas/Nemo.jl/pull/880). The goal would be to have in Oscar a `Oscar.randseed!(seed)` function which calls the subprojects' `SubProject.randseed!(seed)` functions, to improve reproducibility of the system.

This is assuming single-threaded GAP. I saw there is some specific code around random number generation for HPCGAP, but I didn't look into it (should I?)
