### PR TITLE
added `hash` methods for `GapObj` and `FFE`

### DIFF
--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -257,3 +257,10 @@ for (left, right) in typecombinations
         end
     end
 end
+
+# Since we define the equality of GAP objects (see above),
+# we must provide a safe `hash` method, otherwise `==` results may be wrong.
+# For example, `==` for `Set`s of GAP objects may erroneously return
+# `false` if the default `hash` is used.
+Base.hash(::GapObj) = 0
+Base.hash(::FFE) = 0

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -262,5 +262,5 @@ end
 # we must provide a safe `hash` method, otherwise `==` results may be wrong.
 # For example, `==` for `Set`s of GAP objects may erroneously return
 # `false` if the default `hash` is used.
-Base.hash(::GapObj) = 0
-Base.hash(::FFE) = 0
+Base.hash(::GapObj, h::UInt) = h
+Base.hash(::FFE, h::UInt) = h

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -22,6 +22,25 @@
     @test_throws ErrorException xx[4]
 
     @test string(GAP.julia_to_gap("x")) == "x"
+
+    # equality and hashing
+    x = GAP.evalstr("[]")
+    y = GAP.evalstr("[]")
+    @test !(x === y)
+    @test (x == y)
+    @test hash(x) == 0
+
+    x = GAP.evalstr("Z(2)")
+    y = GAP.evalstr("Z(4)^3")
+    @test !(x === y)
+    @test (x == y)
+    @test hash(x) == 0
+
+    # The following would sometimes fail if no dedicated `hash`
+    # method would be available for GAP objects.
+    x = Set{Any}([GAP.evalstr("()"), GAP.evalstr("(1,2)")])
+    y = Set{Any}([GAP.evalstr("()"), GAP.evalstr("(1,2)")])
+    @test (x == y)
 end
 
 @testset "globals" begin

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -38,9 +38,11 @@
 
     # The following would sometimes fail if no dedicated `hash`
     # method would be available for GAP objects.
-    x = Set{Any}([GAP.evalstr("()"), GAP.evalstr("(1,2)")])
-    y = Set{Any}([GAP.evalstr("()"), GAP.evalstr("(1,2)")])
-    @test (x == y)
+    for i in 1:100
+        x = Set{Any}([GAP.evalstr("()"), GAP.evalstr("(1,2)")])
+        y = Set{Any}([GAP.evalstr("()"), GAP.evalstr("(1,2)")])
+        @test (x == y)
+    end
 end
 
 @testset "globals" begin


### PR DESCRIPTION
because otherwise some `==` results can be wrong