### PR TITLE
added `Set` for `GapObj`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -120,6 +120,7 @@ Tuple
 BitArray
 Vector{T}
 Matrix{T}
+Set{T}
 Dict{Symbol,T}
 ```
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -357,23 +357,39 @@ using [`gap_to_julia`](@ref).
 If `recursive` is `true` then the elements are
 converted recursively, otherwise non-recursively.
 
+This constructor method is intended for situations where the result
+involves only native Julia objects such as integers and strings.
+Dealing with results containing GAP objects will be inefficient.
+
 # Examples
 ```jldoctest
-julia> s = Set{Int}(GAP.evalstr("[ 1, 2, 1 ]"));
+julia> Set{Int}(GAP.evalstr("[ 1, 2, 1 ]"))
+Set{Int64} with 2 elements:
+  2
+  1
 
-julia> s == Set([1, 2])
-true
+julia> Set{Vector{Int}}(GAP.evalstr("[[1], [2], [1]]"))
+Set{Array{Int64,1}} with 2 elements:
+  [1]
+  [2]
 
-julia> s = Set{Vector{Int}}(GAP.evalstr("[[1], [2], [1]]"));
+julia> Set{String}(GAP.evalstr("[\"a\", \"b\"]"))
+Set{String} with 2 elements:
+  "b"
+  "a"
 
-julia> s == Set([[1], [2]])
-true
+julia> Set{Any}(GAP.evalstr("[[1], [2], [1]]"))
+Set{Any} with 2 elements:
+  Any[1]
+  Any[2]
 
-julia> s = Set{Any}(GAP.evalstr("[[1], [2], [1]]"));
+```
 
-julia> s == Set([[1], [2]])
-true
+In the following examples,
+the order in which the Julia output is shown may vary.
 
+# Examples
+```jldoctest
 julia> s = Set{Any}(GAP.evalstr("[[1], [2], [1]]"), recursive = false);
 
 julia> s == Set{Any}([GAP.evalstr("[ 1 ]"), GAP.evalstr("[ 2 ]")])

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -345,6 +345,50 @@ julia> Matrix{Int64}(val)
 Base.Matrix{T}(obj::GapObj; recursive = true) where {T} =
     gap_to_julia(Matrix{T}, obj; recursive = recursive)
 
+## Sets
+@doc """
+    Set{T}(obj::GapObj; recursive = true)
+
+Return the set converted from the
+[GAP list](GAP_ref(ref:Lists)) or [GAP collection](GAP_ref(ref:Collections))
+`obj`.
+The elements of `obj` are converted to the required type `T`,
+using [`gap_to_julia`](@ref).
+If `recursive` is `true` then the elements are
+converted recursively, otherwise non-recursively.
+
+# Examples
+```jldoctest
+julia> s = Set{Int}(GAP.evalstr("[ 1, 2, 1 ]"));
+
+julia> s == Set([1, 2])
+true
+
+julia> s = Set{Vector{Int}}(GAP.evalstr("[[1], [2], [1]]"));
+
+julia> s == Set([[1], [2]])
+true
+
+julia> s = Set{Any}(GAP.evalstr("[[1], [2], [1]]"));
+
+julia> s == Set([[1], [2]])
+true
+
+julia> s = Set{Any}(GAP.evalstr("[[1], [2], [1]]"), recursive = false);
+
+julia> s == Set{Any}([GAP.evalstr("[ 1 ]"), GAP.evalstr("[ 2 ]")])
+true
+
+julia> s = Set{Any}(GAP.evalstr("SymmetricGroup(2)"), recursive = false);
+
+julia> s == Set{Any}([GAP.evalstr("()"), GAP.evalstr("(1,2)")])
+true
+
+```
+"""
+Base.Set{T}(obj::GapObj; recursive = true) where {T} =
+    gap_to_julia(Set{T}, obj; recursive = recursive)
+
 ## Tuples
 (::Type{T})(obj::GapObj; recursive = true) where {T<:Tuple} =
     gap_to_julia(T, obj, recursive = recursive)
@@ -353,7 +397,7 @@ Base.Matrix{T}(obj::GapObj; recursive = true) where {T} =
 
 Return the tuple converted from the
 [GAP list](GAP_ref(ref:Lists)) `obj`.
-The entries of the list are converted to the requires types `Types...`,
+The entries of the list are converted to the required types `Types...`,
 using [`gap_to_julia`](@ref).
 If `recursive` is `true` then the entries of the list are
 converted recursively, otherwise non-recursively.

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -260,8 +260,14 @@ end
 ## Without this assumption, we would have to construct the set
 ## in the beginning, and then fill it up using `union!`.
 function gap_to_julia(::Type{Set{T}}, obj::GapObj; recursive = true) where {T}
-    Globals.IsList(obj) || Globals.IsCollection(obj) || throw(ConversionError(obj, Set{T}))
-    obj = Globals.AsSet(obj)
+    if Globals.IsCollection(obj)
+        obj = Globals.AsSet(obj)
+    elseif Globals.IsList(obj)
+        # The list entries may be not comparable via `<`.
+        obj = Globals.DuplicateFreeList(obj)
+    else
+        throw(ConversionError(obj, Set{T}))
+    end
     len_list = Globals.Length(obj)
     new_array = Vector{T}(undef, len_list)
     if recursive

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -39,7 +39,7 @@ ERROR: LoadError: Error thrown by GAP: Error, no method found! For debugging hin
 [...]
 
 julia> @gap [ 1,, 2 ]
-ERROR: syntax: unexpected ","
+ERROR: syntax: unexpected \",\"
 [...]
 
 ```
@@ -47,13 +47,13 @@ ERROR: syntax: unexpected ","
 Note also that a string argument gets evaluated with `GAP.evalstr`.
 
 ```jldoctest
-julia> @gap "\\"abc\\""
-GAP: "abc"
+julia> @gap \"\\\"abc\\\"\"
+GAP: \"abc\"
 
-julia> @gap "[1,,2]"
+julia> @gap \"[1,,2]\"
 GAP: [ 1,, 2 ]
 
-julia> @gap "(1,2)(3,4)"
+julia> @gap \"(1,2)(3,4)\"
 GAP: (1,2)(3,4)
 
 ```

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -130,6 +130,12 @@
     @test isa(z[1, 1], GAP.GapObj)
     @test z[1, 1] === z[2, 2]
 
+    ## Sets
+    @test Set{Int}(GAP.evalstr("[1, 3, 1]")) == Set{Int}([1, 3, 1])
+    @test Set{Vector{Int}}(GAP.evalstr("[[1,2],[2,3,4]]")) == Set([[1, 2], [2, 3, 4]])
+    x = GAP.evalstr("SymmetricGroup(3)")
+    @test Set{GAP.GapObj}(x) == Set{GAP.GapObj}(GAP.Globals.AsSet(x))
+
     ## Tuples
     x = GAP.julia_to_gap([1, 2, 3])
     @test Tuple{Int64,Any,Int32}(x) == Tuple{Int64,Any,Int32}([1, 2, 3])

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -133,6 +133,7 @@
     ## Sets
     @test Set{Int}(GAP.evalstr("[1, 3, 1]")) == Set{Int}([1, 3, 1])
     @test Set{Vector{Int}}(GAP.evalstr("[[1,2],[2,3,4]]")) == Set([[1, 2], [2, 3, 4]])
+    @test Set{String}(GAP.evalstr("[\"b\", \"a\", \"b\"]")) == Set(["b", "a", "b"])
     x = GAP.evalstr("SymmetricGroup(3)")
     @test Set{GAP.GapObj}(x) == Set{GAP.GapObj}(GAP.Globals.AsSet(x))
 

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -158,6 +158,9 @@
     @test GAP.gap_to_julia(Set{GAP.GapObj}, x, recursive = false) == Set(y)
     @test GAP.gap_to_julia(Set{Any}, x, recursive = false) == Set(y)
     @test GAP.gap_to_julia(Set{Any}, x) == Set([[1], [2], [1]])
+    x = GAP.evalstr("[ Z(2), Z(3) ]")  # a non-collection
+    y = [GAP.evalstr("Z(2)"), GAP.evalstr("Z(3)")]
+    @test GAP.gap_to_julia(Set{GAP.FFE}, x) == Set(y)
 
     ## Tuples
     x = GAP.julia_to_gap([1, 2, 3])

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -151,6 +151,14 @@
     @test GAP.gap_to_julia(m) == Array{Any,2}([0 1; 2 3])
     @test GAP.gap_to_julia(Array{Int,2}, m) == Array{Int,2}([0 1; 2 3])
 
+    ## Sets
+    x = GAP.evalstr("[ [ 1 ], [ 2 ], [ 1 ] ]")
+    y = [GAP.evalstr("[ 1 ]"), GAP.evalstr("[ 2 ]")]
+    @test GAP.gap_to_julia(Set{Vector{Int}}, x) == Set([[1], [2], [1]])
+    @test GAP.gap_to_julia(Set{GAP.GapObj}, x, recursive = false) == Set(y)
+    @test GAP.gap_to_julia(Set{Any}, x, recursive = false) == Set(y)
+    @test GAP.gap_to_julia(Set{Any}, x) == Set([[1], [2], [1]])
+
     ## Tuples
     x = GAP.julia_to_gap([1, 2, 3])
     @test GAP.gap_to_julia(Tuple{Int64,Any,Int32}, x) == Tuple{Int64,Any,Int32}([1, 2, 3])


### PR DESCRIPTION
- This code deals only with GAP lists and GAP collections.
  Note that Julia supports also `Set{BigInt}(1)`.
  (We could extend the method, by replacing a GAP object
  that is neither a list nor a collection by a list containing this object,
  but this is not what Julia does in general,
  see for example `Set{Any}(Dict(:a => 1))`.)
- Note that we cannot provide nice examples for the documentation
  because the ordering of entries shown for a `Set` is not stable.