### PR TITLE
add iteration for GAP objects

### DIFF
--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -288,7 +288,7 @@ function Base.iterate(obj::GapObj, (i, len)::Tuple{Int,Any})
     ElmList(obj, i), (i+1, len)
 end
 
-function Base.iterate(obj::GapObj, iter)
+function Base.iterate(obj::GapObj, iter::GapObj)
     if Globals.IsDoneIterator(iter)
         nothing
     else

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -274,13 +274,12 @@ Base.literal_pow(::typeof(^), x::GapObj, ::Val{-1}) = Globals.INV_MUT(x)
 # iteration
 
 function Base.iterate(obj::GapObj)
-    islist = Globals.IsList(obj)
-    islist || Globals.IsCollection(obj) ||
-        throw(ArgumentError("object cannot be iterated"))
-    if islist
+    if Globals.IsList(obj)
         iterate(obj, (1, Globals.Length(obj)))
-    else
+    elseif Globals.IsCollection(obj)
         iterate(obj, Globals.Iterator(obj))
+    else
+        throw(ArgumentError("object cannot be iterated"))
     end
 end
 

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -274,12 +274,26 @@ Base.literal_pow(::typeof(^), x::GapObj, ::Val{-1}) = Globals.INV_MUT(x)
 # iteration
 
 function Base.iterate(obj::GapObj)
-    Globals.IsList(obj) || Globals.IsCollection(obj) ||
+    islist = Globals.IsList(obj)
+    islist || Globals.IsCollection(obj) ||
         throw(ArgumentError("object cannot be iterated"))
-    iterate(obj, (1, Globals.Length(obj)))
+    if islist
+        iterate(obj, (1, Globals.Length(obj)))
+    else
+        iterate(obj, Globals.Iterator(obj))
+    end
 end
 
-function Base.iterate(obj::GapObj, (i, len))
+function Base.iterate(obj::GapObj, (i, len)::Tuple{Int,Any})
     i > len && return nothing
     ElmList(obj, i), (i+1, len)
+end
+
+function Base.iterate(obj::GapObj, iter)
+    if Globals.IsDoneIterator(iter)
+        nothing
+    else
+        x = Globals.NextIterator(iter)
+        (x, iter)
+    end
 end

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -271,3 +271,15 @@ Base.hash(::FFE, h::UInt) = h
 # only if `x` is a multiplicative element in the sense of GAP.
 Base.literal_pow(::typeof(^), x::GapObj, ::Val{-1}) = Globals.INV_MUT(x)
 
+# iteration
+
+function Base.iterate(obj::GapObj)
+    Globals.IsList(obj) || Globals.IsCollection(obj) ||
+        throw(ArgumentError("object cannot be iterated"))
+    iterate(obj, (1, Globals.Length(obj)))
+end
+
+function Base.iterate(obj::GapObj, (i, len))
+    i > len && return nothing
+    ElmList(obj, i), (i+1, len)
+end

--- a/test/adapter.jl
+++ b/test/adapter.jl
@@ -1,0 +1,9 @@
+@testset "iteration" begin
+    l = GAP.evalstr("[1, 2, 3]")
+    lj = collect(l)
+    @test lj isa Vector{Any}
+    @test lj == [1, 2, 3]
+    lj = collect(Int, l)
+    @test lj isa Vector{Int}
+    @test lj == [1, 2, 3]
+end

--- a/test/adapter.jl
+++ b/test/adapter.jl
@@ -6,4 +6,11 @@
     lj = collect(Int, l)
     @test lj isa Vector{Int}
     @test lj == [1, 2, 3]
+
+    s = GAP.Globals.SymmetricGroup(3)
+    xs = []
+    for x in s
+        push!(xs, x)
+    end
+    @test length(xs) == 6
 end


### PR DESCRIPTION
This is an alternative to #537 to create Julia containers from GAP containers, but seems more general. For `Set` creation, it's faster than #537, except if the GAP list has a lot of duplicates. Demo:

With a Set constructor (#537):
```julia
julia> lj = rand(1:999, 999); l = GAP.julia_to_gap(lj);

julia> @btime Set{Int}($l);
  382.950 μs (2369 allocations: 144.41 KiB)

julia> @btime Set{Any}($l);
  535.653 μs (4511 allocations: 177.88 KiB)

julia> lj = rand(1:99, 999); l = GAP.julia_to_gap(lj);

julia> @btime Set{Int}($l);
  118.623 μs (220 allocations: 22.99 KiB)
```
This PR:
```julia
julia> lj = rand(1:999, 999); l = GAP.julia_to_gap(lj);

julia> @btime Set{Int}($l);
  197.645 μs (4944 allocations: 142.65 KiB)

julia> @btime Set{Any}($l);
  227.194 μs (5518 allocations: 151.62 KiB)

julia> lj = rand(1:99, 999); l = GAP.julia_to_gap(lj);

julia> @btime Set{Int}($l);
  177.146 μs (4006 allocations: 127.99 KiB)

julia> @btime Set{Int}(GAP.Globals.AsSet($l));
  92.361 μs (411 allocations: 22.51 KiB)
```
This shows that when the list is expected to have duplicates, calling manually `GAP.Globals.AsSet` can solve the slow-down.

This approach works also for creating other containers. For example we can now call `collect`, which is faster than calling GAP's `Vector{T}` method:
```julia
julia> @btime Vector{Int}($l);
  364.568 μs (1982 allocations: 58.66 KiB)

julia> @btime collect(Int, $l);
  161.715 μs (3489 allocations: 109.28 KiB)
```

What this doesn't solve is the recursivity, i.e. you can call `Vector{Any}(x, recursive=true)` (similar for the proposed `Set` constructor in #537). But there is a workaround: you can lazily map `gap_to_julia` to the iterator. In julia 1.6, you can use `Iterators.map` (and in 1.5 and older, generator expressions can be used):
```julia
julia> lj = [rand(1:9, 2) for _=1:3]; l = GAP.julia_to_gap(lj, recursive=true)
GAP: [ [ 8, 7 ], [ 6, 6 ], [ 7, 2 ] ]

julia> Set(Iterators.map(x -> GAP.gap_to_julia(x, recursive=true), l))
Set{Vector{Any}} with 3 elements:
  Any[6, 6]
  Any[8, 7]
  Any[7, 2]
```
This is not strictly equivalent to using the `recursive` keyword from a dedicated `Set` constructor like in #537, as this doesn't use a `recursion_dict` at the top-level. But we could imagine an orthogonal approach to handle recursive conversion. Here is below a possible solution: a `Recursive` (poorly named) wrapper to a GAP iterable object, which caches the construction of a `recursion_dict` (implying that the performance is improved, and matches #537 at least in a couple of tests):
```julia
struct Recursive{T}
    x::GapObj
    d::IdDict
end

Recursive{T}(x) where {T} = Recursive{T}(x, IdDict())
Recursive(x) = Recursive{Any}(x, IdDict())

Base.length(r::Recursive) = length(r.x)

function Base.iterate(r::Recursive{T}, st...) where T
    res = iterate(r.x, st...)
    res === nothing && return nothing
    x, st = res
    gap_to_julia(T, x, r.d, recursive=true), st
end

Base.eltype(::Type{GAP.Recursive{T}}) where T = T
```
Demo:
```julia
julia> Set(GAP.Recursive{Vector{Int}}(l))
Set{Vector{Int64}} with 3 elements:
  [6, 6]
  [8, 7]
  [7, 2]

julia> Set(GAP.Recursive(l))
Set{Any} with 3 elements:
  Any[6, 6]
  Any[8, 7]
  Any[7, 2]
```
Defining iteration on `GapObj` doesn't seem ideal, as most objects are presumably not iterable, but it's good enough for me to just error when the object is not iterable and we try to iterate. On the performance side: if we add more supported objects to be iterated, the benchmarks shown above _might_ look less good (for example, I see that in the `gap_to_julia(::Type{<Vector}, ...` [method](https://github.com/oscar-system/GAP.jl/blob/d743256c8afe8ee1f7a883844d612bacecb99814/src/gap_to_julia.jl#L183), the `elmlist` method depends on the type of the object, so this might introduce overhead here). 