### PR TITLE
optimize Vector{T} constructor for isbitstype

### DIFF
--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -202,7 +202,7 @@ function gap_to_julia(
         recursion_dict[obj] = new_array
         for i = 1:len_list
             current_obj = elmlist(obj, i)
-            if recursive
+            if recursive && !isbitstype(typeof(current_obj))
                 new_array[i] = get!(recursion_dict, current_obj) do
                     gap_to_julia(T, current_obj, recursion_dict; recursive = true)
                 end


### PR DESCRIPTION
It was observed in #538 that conversion of a GAP list of integers to Julia is slower than what it could be (whit the default `recursive=true)`:
```julia
julia>  lj = rand(1:99, 999); l = GAP.julia_to_gap(lj);

julia> @btime Vector{Int}($l);
  369.584 μs (1982 allocations: 58.66 KiB)

julia> @btime Vector{Int}($l, recursive=false);
  44.048 μs (980 allocations: 23.56 KiB)
```
But in this case, recursivity doesn't matter. So by avoiding interacting with the `recursive_dict` (when the object is `isbitstype`), we can get back the performance of `recursive=false` even when `recursive=true` was passed.

Now, a similar optimization might be had for other non-isbitstype objects, but I wonder: is the purpose of using a `recursion_dict` to save time on conversions (to not convert multiple times the same object), or to replicate "aliasing" on the Julia side (i.e. in `a = [1]; b = [a, a]`, `b` is not structurally equal to `[[1], [1]]`). Or both? If the former, using the `recursion_dict` could be avoided when it's cheaper to convert than to lookup and update the recursion dict.