### PR TITLE
added `literal_pow` method for inverting

### DIFF
--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -264,3 +264,10 @@ end
 # `false` if the default `hash` is used.
 Base.hash(::GapObj, h::UInt) = h
 Base.hash(::FFE, h::UInt) = h
+
+# The following bypasses GAP's redirection of `x^-1` to `INV_MUT(x)`.
+# Installing analogous methods for `x^0` and `x^1` would *not* be allowed,
+# these terms are equivalent to `ONE_MUT(x)` and `x`, respectively,
+# only if `x` is a multiplicative element in the sense of GAP.
+Base.literal_pow(::typeof(^), x::GapObj, ::Val{-1}) = Globals.INV_MUT(x)
+

--- a/test/convenience.jl
+++ b/test/convenience.jl
@@ -64,6 +64,7 @@ end
     pi = @gap "(1,2,3)(4,17)"
     @test !(pi in sym5)
     @test pi^2 in sym5
+    @test pi^-1 == pi^5
 
     # Julia object in GAP list
     l = [ [ 1 2 ], [ 3 4 ] ]


### PR DESCRIPTION
Thanks to @rfourquet for mentioning `literal_pow`.
It can be used for improving `x^-1` but not for improving `x^0` and `x^1`
(where `x` is a GAP object).