### PR TITLE
set GAP's AlwaysPrintTracebackOnError in tests

### DIFF
--- a/pkg/JuliaInterface/tst/testall.g
+++ b/pkg/JuliaInterface/tst/testall.g
@@ -33,6 +33,10 @@ end;
 compare:= CompareUpToWhitespaceAndMatches(
     [ [ "Array{Any,1}", "Vector{Any}" ] ] );
 
+# The testfiles assume that no traceback is printed.
+AlwaysPrintTracebackOnError:= false;
+#TODO: This can be removed as soon as GAP's `Test` sets the value to `false`-
+
 TestDirectory(dir, rec(exitGAP := true,
                        testOptions := rec(compareFunction := compare) ) );
 FORCE_QUIT_GAP(1);


### PR DESCRIPTION
When GAP tests are run by reading the file `testall.g`, set the variable `AlwaysPrintTracebackOnError` to `false`, see issue #528.
(This will become obsolete as soon as the GAP in question does the same during tests, see gap-system/gap/issues/4121.)

Note that currently the automatic tests do not report errors because they run the tests by mentioning `testall.g` on the GAP command line, with the effect that this file gets read earlier than it should be read, cf. issue #518.
(If one calls `Read( "testall.g" )` at the GAP prompt then differences are reported if `AlwaysPrintTracebackOnError` is not set to `false`.)