### PR TITLE
fix string conversion

### DIFF
--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -101,7 +101,7 @@ function AssignGlobalVariable(name::Union{AbstractString,Symbol}, value::Any)
     _AssignGlobalVariable(name, tmp)
 end
 
-MakeString(val::String) = ccall(:MakeStringWithLen, GapObj, (Ptr{UInt8}, Culong), val, length(val))
+MakeString(val::String) = ccall(:MakeStringWithLen, GapObj, (Ptr{UInt8}, Culong), val, sizeof(val))
 #TODO: As soon as libgap provides :GAP_MakeStringWithLen, use it.
 
 function CSTR_STRING(val::GapObj)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -85,6 +85,8 @@
     @test GAP.gap_to_julia(x) == "foo"
     x = "abc\000def"
     @test GAP.gap_to_julia(GAP.julia_to_gap(x)) == x
+    x = "jμΛIα"
+    @test GAP.gap_to_julia(GAP.julia_to_gap(x)) == x
 
     ## Symbols
     x = GAP.evalstr("\"foo\"")
@@ -320,6 +322,11 @@ end
     substr = match(r"a(.*)c", "abc").match  # type is `SubString{String}`
     @test GAP.julia_to_gap(substr) == GAP.julia_to_gap("abc")
     @test length(GAP.julia_to_gap("abc\000def")) == 7  # contains a null character
+    x = GAP.evalstr("\"jμΛIα\"")
+    @test length(x) == 8  # in GAP, the number of bytes
+    @test GAP.julia_to_gap("jμΛIα") == x
+    @test length("jμΛIα") == 5
+    @test sizeof("jμΛIα") == 8
 
     ## Arrays
     x = GAP.evalstr("[1,\"foo\",2]")


### PR DESCRIPTION
Use `sizeof` not `length` in order to get the number of bytes in a string.

This fixes the problem from issue #545.