### PR TITLE
fix `GAP.Packages.load`

### DIFF
--- a/src/packages.jl
+++ b/src/packages.jl
@@ -102,16 +102,10 @@ function load(spec::String, version::String = ""; install = false)
     if loaded == true
         return true
     elseif install == true
-        # Check whether an admissible version of the package is installed;
-        # if yes then we do not try to install the package anew.
-        info = Globals.PackageInfo(gspec)
-        available = [i -> info[i].Version for i in 1:length(info)]
-        if all(v -> ! Globals.CompareVersionNumbers(v, gversion), available)
-            # Try to install the package.
-            if Packages.install(spec)
-                # Make sure that the version is admissible.
-                return Globals.LoadPackage(gspec, gversion, false)
-            end
+        # Try to install the package.
+        if Packages.install(spec)
+            # Make sure that the installed version is admissible.
+            return Globals.LoadPackage(gspec, gversion, false)
         end
     end
 


### PR DESCRIPTION
I think this code does not what one wants (my fault).

If the package cannot be loaded and the keyword argument `install` is `true`
then it does not help to check whether an admissible version is already
known to GAP, since the package directory may be there but the package
has not been compiled yet.
(Besides that, the check for the availability of the package was not correct.)
Thus `GAP.Packages.install` should always be called in this case.

After this fix is available,
the call `GAP.Packages.install("ferret")` in `Oscar.jl/examples/GaloisGrp.jl`
should be replaced by `GAP.Packages.load("ferret", install = true)`,
otherwise a new installation is forced at runtime whenever the file gets read.