### PR TITLE
Re-enable doctests in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,12 +107,9 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
-      #- name: Run doctests
-      #  run: |
-      #    julia --project=docs --color=yes -e '
-      #      using Documenter, GAP
-      #      DocMeta.setdocmeta!(GAP, :DocTestSetup, :(using GAP); recursive = true)
-      #      doctest(GAP)'
+      - name: Run doctests
+        run: |
+          julia --project=docs --color=yes test/doctest.jl
       - name: Deploy documentation
         run: julia --project=docs --color=yes docs/make.jl
         env:

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -362,7 +362,7 @@ involves only native Julia objects such as integers and strings.
 Dealing with results containing GAP objects will be inefficient.
 
 # Examples
-```jldoctest
+```
 julia> Set{Int}(GAP.evalstr("[ 1, 2, 1 ]"))
 Set{Int64} with 2 elements:
   2
@@ -373,7 +373,7 @@ Set{Array{Int64,1}} with 2 elements:
   [1]
   [2]
 
-julia> Set{String}(GAP.evalstr("[\"a\", \"b\"]"))
+julia> Set{String}(GAP.evalstr("[\\"a\\", \\"b\\"]"))
 Set{String} with 2 elements:
   "b"
   "a"

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -30,7 +30,7 @@ not all expressions representing valid GAP code can be processed.
 For example, the GAP syntax of permutations consisting of more than one cycle
 cause problems, as well as the GAP syntax of non-dense lists.
 
-```jldoctest
+```
 julia> @gap (1,2,3)
 GAP: (1,2,3)
 

--- a/test/doctest.jl
+++ b/test/doctest.jl
@@ -1,0 +1,11 @@
+using Documenter, GAP
+
+DocMeta.setdocmeta!(GAP, :DocTestSetup, :(using GAP); recursive = true)
+
+doctest(GAP; doctestfilters = Regex[
+  r"BitVector|BitArray\{1\}",
+  r"Matrix\{Int64\}|Array\{Int64,2\}",
+  r"Vector\{Any\}|Array\{Any,1\}",
+  r"Vector\{Int64\}|Array\{Int64,1\}",
+  r"Vector\{UInt8\}|Array\{UInt8,1\}",
+])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,5 @@
 using Test, Documenter, GAP
 
-DocMeta.setdocmeta!(GAP, :DocTestSetup, :(using GAP); recursive = true)
-
 include("basics.jl")
 include("adapter.jl")
 include("convenience.jl")
@@ -11,4 +9,6 @@ include("convert.jl")
 include("macros.jl")
 include("packages.jl")
 include("help.jl")
-# include("testmanual.jl")  # skip this for now, difficult to get to work on all Julia versions
+@testset "manual examples" begin
+  include("doctest.jl")
+end

--- a/test/testmanual.jl
+++ b/test/testmanual.jl
@@ -1,9 +1,0 @@
-@testset "manual examples" begin
-    doctest(GAP; doctestfilters = Regex[
-      r"BitVector|BitArray\{1\}",
-      r"Matrix\{Int64\}|Array\{Int64,2\}",
-      r"Vector\{Any\}|Array\{Any,1\}",
-      r"Vector\{Int64\}|Array\{Int64,1\}",
-      r"Vector\{UInt8\}|Array\{UInt8,1\}",
-    ])
-end


### PR DESCRIPTION
Currently these fail for various reasons, I don't have time to track that down, but didn't want to forget about it.

There are at least two options for us how to run the tests: either we run them along with the rest of the test suite; this way we get most coverage, but the downside is that we need to make sure the doctests pass in all tested Julia versions, which puts an extra maintenance burden on us. Or we could just run the doctests in one config, and make sure it works there. 

I've enabled both variants here, we can later remove the one we don't want.

One issue is that the printing of `Set` instances seems to vary between Julia versions or perhaps even in a single Julia version based on some random seed? (Perhaps @rfourquet knows more).