### PR TITLE
Improve _GAP_TO_JULIA

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -181,6 +181,7 @@ function initialize(argv::Array{String,1})
     @assert T_FLAGS == Base.invokelatest(ValueGlobalVariable,:T_FLAGS)
     @assert T_LVARS == Base.invokelatest(ValueGlobalVariable,:T_LVARS)
     @assert T_HVARS == Base.invokelatest(ValueGlobalVariable,:T_HVARS)
+    @assert FIRST_EXTERNAL_TNUM == Base.invokelatest(ValueGlobalVariable,:FIRST_EXTERNAL_TNUM)
 
     # load JuliaInterface
     loadpackage_return = ccall(

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -6,12 +6,18 @@ import Base: getproperty, hasproperty, setproperty!, propertynames
 # low-level GAP -> Julia conversion
 #
 function _GAP_TO_JULIA(ptr::Ptr{Cvoid})
+    ptr == C_NULL && return nothing
     # convert immediate ints and FFEs directly, to void (un)boxing
     as_int = reinterpret(Int, ptr)
-    if as_int & 1 == 1
-        return as_int >> 2
-    elseif as_int & 2 == 2
-        return reinterpret(FFE, ptr)
+    as_int & 1 == 1 && return as_int >> 2
+    as_int & 2 == 2 && return reinterpret(FFE, ptr)
+    tnum = TNUM_OBJ(ptr)
+    if tnum < FIRST_EXTERNAL_TNUM
+        if tnum == T_BOOL
+            ptr == unsafe_load(cglobal((:GAP_True, libgap), Ptr{Cvoid})) && return true
+            ptr == unsafe_load(cglobal((:GAP_False, libgap), Ptr{Cvoid})) && return false
+        end
+        return unsafe_pointer_to_objref(ptr)
     end
     return ccall(:julia_gap, Any, (Ptr{Cvoid},), ptr)
 end

--- a/src/lowlevel.jl
+++ b/src/lowlevel.jl
@@ -23,6 +23,8 @@ const T_FLAGS    = 17   # flags list
 const T_LVARS    = 18   # values bag
 const T_HVARS    = 19   # high variables bag
 
+const FIRST_EXTERNAL_TNUM = 82
+
 #
 # functions which directly interact with GAP objects, bypassing the GAP kernel
 #
@@ -33,6 +35,12 @@ end
 
 function TNUM_OBJ(obj::GapObj)
     header = unsafe_load(ADDR_OBJ(obj), 0)
+    return reinterpret(Int, header & 0xFF)
+end
+
+function TNUM_OBJ(ptr::Ptr)
+    mptr = Ptr{Ptr{Csize_t}}(ptr)
+    header = unsafe_load(unsafe_load(mptr), 0)
     return reinterpret(Int, header & 0xFF)
 end
 


### PR DESCRIPTION
Reimplement more of the julia_gap logic; this makes the cases we now handle on
the Julia side potentially a bit faster (??? untested) but most importantly it
means this code now works even if JuliaInterface is not yet loaded. On the
downside, if we end up ccalling julia_gap anyway, it performs a bunch of
checks a second time.