### PR TITLE
Change default install dir for GAP packages

### DIFF
--- a/src/packages.jl
+++ b/src/packages.jl
@@ -79,7 +79,9 @@ export LoadPackageAndExposeGlobals
 
 module Packages
 
-import ...GAP: Globals, julia_to_gap, GAPROOT
+import ...GAP: Globals, julia_to_gap
+
+const DEFAULT_PKGDIR = joinpath(get(ENV, "HOME", ""), ".gap", "pkg")
 
 """
     load(spec::String, version::String = ""; install = false)
@@ -129,7 +131,7 @@ containing a package, or the URL of a `PackageInfo.g` file.
 The function uses [the function `InstallPackage` from GAP's package
 `PackageManager`](GAP_ref(PackageManager:InstallPackage)).
 """
-function install(spec::String; interactive::Bool = true, pkgdir::AbstractString = GAPROOT * "/pkg")
+function install(spec::String; interactive::Bool = true, pkgdir::AbstractString = DEFAULT_PKGDIR)
     res = load("PackageManager")
     @assert res
     # FIXME: crude hack to allow PackageManager 1.0 shipped with GAP
@@ -158,7 +160,7 @@ containing a package, or the URL of a `PackageInfo.g` file.
 The function uses [the function `UpdatePackage` from GAP's package
 `PackageManager`](GAP_ref(PackageManager:UpdatePackage)).
 """
-function update(spec::String; interactive::Bool = true, pkgdir::AbstractString = GAPROOT * "/pkg")
+function update(spec::String; interactive::Bool = true, pkgdir::AbstractString = DEFAULT_PKGDIR)
     res = load("PackageManager")
     @assert res
 
@@ -181,7 +183,7 @@ Return `true` if the removal was successful, and `false` otherwise.
 The function uses [the function `RemovePackage` from GAP's package
 `PackageManager`](GAP_ref(PackageManager:RemovePackage)).
 """
-function remove(spec::String; interactive::Bool = true, pkgdir::AbstractString = GAPROOT * "/pkg")
+function remove(spec::String; interactive::Bool = true, pkgdir::AbstractString = DEFAULT_PKGDIR)
     res = load("PackageManager")
     @assert res
 


### PR DESCRIPTION
Right now, `GAP.Packages.install` installs GAP packages  by default into `GAPROOT * "/pkg"`, which means: into the GAP 4.11.0 artifact. This is bad because that artifact is supposed to be read-only, and we only succeed because Julia only makes the files in artifacts readonly, not the directories, so we can add new files, just modify existing ones. Still this is not a good thing.

This PR changes it to `~/.gap/pkg` -- I should probably say "back to" because I think it was there before and we changed it after some back and forth. 

I've now opened this PR so we can discuss this (again?).

See also https://github.com/gap-system/gap/issues/3917 where the suggestion is to use `~/.gap/v4.11/pkg`.

Another idea would be to put this into a Julia specific path, say `~/.julia/gap/pkg` or ~/.julia/gap/v4.11/pkg` -- but then this directory will never be cleaned unless we teach the user about it and ask them to clean it. (Once we drop compatibility with Julia versions before 1.5, we could switch to using https://github.com/JuliaPackaging/Scratch.jl which allows creating scratch spaces that are removed when the Julia package is removed -- i.e. users who delete GAP.jl get their disk space back eventually.


