### PR TITLE
Provide Oscar CI workflows for GitHub actions.

### DIFF
--- a/.github/workflows/FullCI.yml
+++ b/.github/workflows/FullCI.yml
@@ -1,0 +1,23 @@
+name: "Oscar CI (all tests)"
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: oscar-system/oscar-ci-action/configure@master
+      with:
+        julia: "1.5.3"
+        package: GAP
+        ref: ${{ github.sha }}
+        repository: ${{ github.repository }}
+        buildtype: master
+        test: all
+    - uses: oscar-system/oscar-ci-action/install@master
+    - uses: oscar-system/oscar-ci-action/test@master
+    - uses: actions/upload-artifact@v2
+      with:
+        name: logs
+        path: workspace/logs/

--- a/.github/workflows/PackageCI.yml
+++ b/.github/workflows/PackageCI.yml
@@ -1,0 +1,23 @@
+name: "Oscar CI (package tests)"
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: oscar-system/oscar-ci-action/configure@master
+      with:
+        julia: "1.5.3"
+        package: GAP
+        ref: ${{ github.sha }}
+        repository: ${{ github.repository }}
+        buildtype: master
+        test: packages
+    - uses: oscar-system/oscar-ci-action/install@master
+    - uses: oscar-system/oscar-ci-action/test@master
+    - uses: actions/upload-artifact@v2
+      with:
+        name: logs
+        path: workspace/logs/

--- a/.github/workflows/QuickCI.yml
+++ b/.github/workflows/QuickCI.yml
@@ -1,0 +1,23 @@
+name: "Oscar CI (quick minimal test)"
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: oscar-system/oscar-ci-action/configure@master
+      with:
+        julia: "1.5.3"
+        package: GAP
+        ref: ${{ github.sha }}
+        repository: ${{ github.repository }}
+        buildtype: master
+        test: load
+    - uses: oscar-system/oscar-ci-action/install@master
+    - uses: oscar-system/oscar-ci-action/test@master
+    - uses: actions/upload-artifact@v2
+      with:
+        name: logs
+        path: workspace/logs/


### PR DESCRIPTION
These workflows allow you to run the Oscar CI test suite (entirely or in part) via manually triggered GitHub actions.

Note that the workflows have to be on the master branch for that to work.

See also https://github.com/oscar-system/oscar-ci-action, which contains GitHub actions used by these workflows.