### PR TITLE
try to make the Julia help available in a GAP session

### DIFF
--- a/pkg/JuliaInterface/gap/juliahelp.g
+++ b/pkg/JuliaInterface/gap/juliahelp.g
@@ -1,0 +1,82 @@
+##  Make the Julia help available in the GAP session,
+##  via a (virtual) help book called `Julia`,
+##  which uses a custom handler called `juliahelpformat`.
+##  This works only for the `"text"` help in the terminal,
+##  we cannot access PDF and HTML formats.
+##
+##  The idea is to enter `?Julia:sqrt` or `?Base.isdefined`,
+##  to get one entry for the book `Julia` in the list of choices
+##  if Julia knows documentation for the topic,
+##  and to show *all* matching docstrings from Julia when this entry
+##  is chosen from the menu (since this is the way how Julia behaves).
+
+HELP_ADD_BOOK( "Julia", "dummy entry for accessing Julia documentation",
+    DirectoriesPackageLibrary( "JuliaInterface", "help" )[1] );
+
+HELP_BOOK_HANDLER.juliahelpformat:= rec(
+    # see "The Help Book Handler"
+    ReadSix:= stream -> rec( bookname:= "Julia", entries:= [] ),
+
+    ShowChapters:= book -> "",  # This feature is not supported for Julia.
+
+    ShowSection:= book -> "",   # This feature is not supported for Julia.
+
+    SearchMatches:= function( book, topic, frombegin )
+      local module, start, pos, sub, func, res;
+
+      # `topic` may contain a prefix that describes a Julia module.
+      module:= Julia;
+      start:= 1;
+      for pos in Positions( topic, '.' ) do
+        sub:= topic{ [ start .. pos-1 ] };
+        # hack:
+        # 'topic' was turned to lowercase in 'HELP' (by 'SIMPLE_STRING')
+        # but module names involve uppercase letters.
+        if sub = "gap" then
+          sub:= "GAP";
+        else
+          sub[1]:= UppercaseChar( sub[1] );
+        fi;
+        if not IsBound( module.( sub ) ) then
+          return [ [], [] ];
+        fi;
+        module:= module.( sub );
+        if not IsJuliaModule( module ) then
+          return [ [], [] ];
+        fi;
+        start:= pos + 1;
+      od;
+      func:= topic{ [ start .. Length( topic ) ] };
+      if not IsBound( module.( func ) ) then
+        # Give up.
+        return [ [], [] ];
+      fi;
+      
+      res:= JuliaToGAP( IsString,
+                Julia.GAP.julia_help_string( module.( func ) ) );
+
+      # Store the information such that `HelpData` will find it.
+      HELP_BOOKS_INFO.julia.entries:= [ [ topic, res ] ];
+      HELP_BOOKS_INFO.julia.topic:= topic;
+
+      # Return the result, meaning that there is one (non-exact) match
+      # at position 1, which has been set in the `entries` list.
+      return [ [], [ 1 ] ];
+    end,
+
+    HelpData:= function( book, entrynr, type )
+      local res;
+
+      if type <> "text" then
+        # We cannot access PDF and HTML versions of the Julia documentation.
+        return fail;
+      elif not IsBound( HELP_BOOKS_INFO.julia.topic ) then
+        # We expect that the component has been bound by `SearchMatches`.
+        return fail;
+      fi;
+
+      res:= HELP_BOOKS_INFO.julia.entries[1][2];
+      return rec( formatted:= true, lines:= res, start:= 1 );
+    end,
+    );
+

--- a/pkg/JuliaInterface/help/README
+++ b/pkg/JuliaInterface/help/README
@@ -1,0 +1,4 @@
+The `help` directory and the file `help/manual.six`
+are needed only because of the `HELP_ADD_BOOK` call
+that makes the Julia help available in a GAP session,
+via a (virtual) book named `Julia`.

--- a/pkg/JuliaInterface/help/manual.six
+++ b/pkg/JuliaInterface/help/manual.six
@@ -1,0 +1,1 @@
+#SIXFORMAT juliahelpformat

--- a/pkg/JuliaInterface/read.g
+++ b/pkg/JuliaInterface/read.g
@@ -20,3 +20,4 @@ ReadPackage( "JuliaInterface", "gap/calls.gi");
 ReadPackage( "JuliaInterface", "gap/convert.gi");
 ReadPackage( "JuliaInterface", "gap/utils.gi");
 ReadPackage( "JuliaInterface", "gap/helpstring.g");
+ReadPackage( "JuliaInterface", "gap/juliahelp.g");

--- a/src/help.jl
+++ b/src/help.jl
@@ -99,3 +99,26 @@ function Base.Docs.getdoc(x::GapObj)
       return nothing
     end
 end
+
+## enable access to Julia's help system from GAP
+function julia_help_string(obj)
+    doc = Base.Docs.doc(obj)
+    io = IOBuffer()
+    ioc = IOContext(io, :color => true)
+    if ! isempty(doc.content)
+      hr = Markdown.HorizontalRule()
+      n = Markdown.cols(io)
+      doc_found = ! isa(doc.content[1], Markdown.Paragraph)
+      for md in doc.content[1:end-1]
+        Markdown.term(ioc, md, n)
+        print(ioc, "\n\n")
+        if doc_found
+          Markdown.term(ioc, hr, n)
+          print(ioc, "\n\n")
+        end
+      end
+      Markdown.term(ioc, doc.content[end], n)
+      println(ioc)
+    end
+    return String(take!(io))
+end


### PR DESCRIPTION
For that, notify a virtual GAP help book called `Julia`,
extract the Julia help about the Julia object in question
(including the relevant ANSI escape sequences),
and feed it into the data structures expected by the GAP help system.

For example, the following requests in a GAP session will include entries from the Julia help.
```
?Julia:size
?Julia:GAP.julia_to_gap
?Julia:GAP.julia_help_string
```
One problem is that the Julia help system is *case sensitive*, but the GAP help system turns the given string to lowercase in the beginning (in a call to `SIMPLE_STRING` in GAP's `HELP` function).
Note that Julia does not understand the request `?base.sqrt`, one has to enter `?Base.sqrt`.
I think the solution to this problem would be to change the GAP help system such that the custom handler functions get access to the original search string, either by not changing the string to lowercase (and then adjust the functions that expect lowercase) or by storing the original search string in a global variable or global option; what do you think?

Another problem (or rather a feature) is that help requests to a Julia object work only if the Julia module in question has been loaded. (Note that GAP can load the documentation of a GAP package also when the package itself is not loaded.)