### PR TITLE
do not read startup.jl twice

### DIFF
--- a/pkg/JuliaInterface/init.g
+++ b/pkg/JuliaInterface/init.g
@@ -43,6 +43,11 @@ Unbind(_PATH_SO);
 CallFuncList( function()
     local dir, filename, res;
 
+    if JuliaEvalString( "Int64(Base.JLOptions().startupfile)" ) <> 2 then
+      # Julia has already read the file, do not read it again.
+      return;
+    fi;
+
     dir:= UserPreference( "JuliaInterface", "IncludeJuliaStartupFile" );
     if dir = true then
       filename:= Filename( DirectoryHome(), ".julia/config/startup.jl" );


### PR DESCRIPTION
When a GAP session is started then the underlying Julia does not read its `startup.jl` file by default;
the GAP user preference `IncludeJuliaStartupFile` can be used to read this file automatically.

When a Julia session is started then the command line option `--startup-file` controls whether `startup.jl` is read, the default value is `yes`.
A subsequent `using GAP` should read `startup.jl` if the user preference tells this (that happened up to now), but only if this file was not yet read by Julia (this is new).

(This is a intended to deal with issue #284, I think this issue can be closed afterwards.)