### PR TITLE
CI: remove version restriction for AbstractAlgebra

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,7 +60,6 @@ jobs:
         run: |
           julia -e '
             using Pkg
-            Pkg.add(PackageSpec(name="AbstractAlgebra", version="0.10"))
             Pkg.add(["Singular", "Nemo"])
             '
       - name: "GAP tests"


### PR DESCRIPTION
This reverts commit 65ee87cbdb79c325cf9b3fe1372ab9696cab3eab.

But it does not (yet) adjust the tests: IMHO the new printing is worse in some cases, and so I wonder if we ought to discuss this with AA/Nemo people. But to do that, one should extract pure Julia versions of those tests, etc. etc. which I don't have time for right now.