### PR TITLE
Fix potential GC related crashes

### DIFF
--- a/pkg/JuliaInterface/src/calls.c
+++ b/pkg/JuliaInterface/src/calls.c
@@ -24,6 +24,7 @@ jl_value_t * call_gap_func(Obj func, jl_value_t * args)
     size_t len = jl_nfields(args);
     Obj    return_value = NULL;
     BEGIN_GAP_SYNC();
+    JL_GC_PUSH1(&args);
     if (IS_FUNC(func) && len <= 6) {
         switch (len) {
         case 0:
@@ -73,6 +74,7 @@ jl_value_t * call_gap_func(Obj func, jl_value_t * args)
         }
         return_value = CallFuncList(func, arg_list);
     }
+    JL_GC_POP();
     END_GAP_SYNC();
     if (return_value == NULL) {
         return jl_nothing;

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -81,7 +81,7 @@ function initialize(argv::Array{String,1})
         # Tell GAP to show some traceback on errors.
         append!(argv, ["--alwaystrace"])
     end
-    ccall(
+    GC.@preserve argv ccall(
         (:GAP_Initialize, libgap),
         Cvoid,
         (Int32, Ptr{Ptr{UInt8}}, Ptr{Cvoid}, Ptr{Cvoid}, Cuint),

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -35,9 +35,7 @@ julia_to_gap(x::Bool) = x   # Default for actual GAP objects is to do nothing
 ## which avoids the conversion to BigInt, if we wanted to.
 function julia_to_gap(x::Integer)
     # if it fits into a GAP immediate integer, convert x to Int64
-    if x in -1<<60:(1<<60-1)
-        return Int64(x)
-    end
+    x in -1<<60:(1<<60-1) && return Int64(x)
     # for the general case, fall back to BigInt
     return julia_to_gap(BigInt(x))
 end
@@ -54,10 +52,8 @@ julia_to_gap(x::UInt8) = Int64(x)
 
 ## BigInts are converted via a ccall
 function julia_to_gap(x::BigInt)
-    if x in -1<<60:(1<<60-1)
-        return Int64(x)
-    end
-    return ccall(:MakeObjInt, GapObj, (Ptr{UInt64}, Cint), x.d, x.size)
+    x in -1<<60:(1<<60-1) && return Int64(x)
+    return GC.@preserve x ccall(:MakeObjInt, GapObj, (Ptr{UInt64}, Cint), x.d, x.size)
 end
 
 ## Rationals


### PR DESCRIPTION
When we ccall a function to which we pass pointers (in)to Julia objects, if
that function may end up making memory allocations, in general we must use
GC.@preserve on the Julia objects we passed in to ensure they are not garbage
collected. This is not needed if the Julia object is in fact a GAP object (as
our stack scanning logic takes care of those), or if other Julia code later on
is guaranteed to access the object in danger of being GCed.

This could result in a crash in practice when using `evalstr`; the string
containing GAP code could be garbage collected while it was still being
executed.

In the same vein, call `JL_GC_PUSH1(&args)` in the C function `call_gap_func`.


This is unfortunately most likely *not* the same as the GC related crash @fieker reported in December 