### PR TITLE
catch GAP errors in `GAP.evalstr`

### DIFF
--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -47,7 +47,8 @@ end
     evalstr(cmd::String)
 
 Let GAP execute the command(s) given by `cmd`;
-if the last command has a result then return it,
+if an error occurs then report this error,
+otherwise if the last command has a result then return it,
 otherwise return `nothing`.
 
 # Examples
@@ -68,7 +69,10 @@ GAP: [ 1 ]
 function evalstr(cmd::String)
     res = evalstr_ex(cmd * ";")
     res = res[end]
-    if Globals.ISB_LIST(res, 2)
+    if res[1] == false
+      # error
+      GAP.error_handler()
+    elseif Globals.ISB_LIST(res, 2)
       return res[2]
     else
       return

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -101,8 +101,7 @@ not all strings representing valid GAP strings can be processed.
 
 ```jldoctest
 julia> g"\\\\"
-ERROR: LoadError: failed to convert to GapObj:
- \\
+ERROR: LoadError: Error thrown by GAP: Syntax error: String must end with " before end of file in stream:1
 [...]
 
 ```

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -8,11 +8,15 @@
     @test x == GAP.evalstr("[1,2,3]")
     x = @gap(SymmetricGroup)(3)
     @test GAP.Globals.Size(x) == 6
+    # Errors thrown by the GAP.@gap macro cannot be tested directly,
+    # the following test does not work as intended.
+    # @test_throws ErrorException @gap (1,2)(3,4)
+
     x = GAP.g"foo"
     @test x == GAP.julia_to_gap("foo")
     x = GAP.g"1:\n, 2:\", 3:\\, 4:\b, 5:\r, 6:\c, 7:\001"
     @test x == GAP.julia_to_gap("1:\n, 2:\", 3:\\, 4:\b, 5:\r, 6:\003, 7:\001")
-    # Errors thrown by the GAP.g macro cannot be tested directly,
+    # Errors thrown by the GAP.@g_str macro cannot be tested directly,
     # and the string "\\" can be handed over in the macro.
     @test_throws ErrorException GAP.gap_string_macro_helper("\\")
 


### PR DESCRIPTION
The right way to do this is to check the return value of `evalstr_ex`,
and to call `GAP.error_handler` if necessary,
as was proposed in the discussion of gap-system/gap/issues/4199.

This is intended to resolve issue #580.

(The change does of course *not* affect the problems described in issue #596.
It is also not related to issue #516.)