### PR TITLE
Fix potential crashes in ccall

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -115,7 +115,7 @@ function initialize(argv::Array{String,1})
         ccall(
             (:GAP_CallFuncArray, libgap),
             Ptr{Cvoid},
-            (Ptr{Cvoid}, Culonglong, Ptr{Cvoid}),
+            (Any, Culonglong, Ptr{Cvoid}),
             FORCE_QUIT_GAP,
             0,
             C_NULL,

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -39,7 +39,7 @@ end
 
 
 function evalstr_ex(cmd::String)
-    res = ccall((:GAP_EvalString, libgap), GapObj, (Ptr{UInt8},), cmd)
+    res = ccall((:GAP_EvalString, libgap), GapObj, (Cstring,), cmd)
     return res
 end
 
@@ -79,7 +79,7 @@ end
 # Retrieve the value of a global GAP variable given its name. This function
 # returns a raw Ptr value, and should only be called by plumbing code.
 function _ValueGlobalVariable(name::Union{AbstractString,Symbol})
-    return ccall((:GAP_ValueGlobalVariable, libgap), Ptr{Cvoid}, (Ptr{UInt8},), name)
+    return ccall((:GAP_ValueGlobalVariable, libgap), Ptr{Cvoid}, (Cstring,), name)
 end
 
 function ValueGlobalVariable(name::Union{AbstractString,Symbol})
@@ -89,13 +89,13 @@ end
 
 # Test whether the global GAP variable with the given name can be assigned to.
 function CanAssignGlobalVariable(name::Union{AbstractString,Symbol})
-    ccall((:GAP_CanAssignGlobalVariable, libgap), Bool, (Ptr{UInt8},), name)
+    ccall((:GAP_CanAssignGlobalVariable, libgap), Bool, (Cstring,), name)
 end
 
 # Assign a value to the global GAP variable with the given name. This function
 # assigns a raw Ptr value, and should only be called by plumbing code.
 function _AssignGlobalVariable(name::Union{AbstractString,Symbol}, value::Ptr{Cvoid})
-    ccall((:GAP_AssignGlobalVariable, libgap), Cvoid, (Ptr{UInt8}, Ptr{Cvoid}), name, value)
+    ccall((:GAP_AssignGlobalVariable, libgap), Cvoid, (Cstring, Ptr{Cvoid}), name, value)
 end
 
 # Assign a value to the global GAP variable with the given name.
@@ -107,7 +107,7 @@ function AssignGlobalVariable(name::Union{AbstractString,Symbol}, value::Any)
     _AssignGlobalVariable(name, tmp)
 end
 
-MakeString(val::String) = ccall((:MakeStringWithLen, libgap), GapObj, (Ptr{UInt8}, Culong), val, sizeof(val))
+MakeString(val::String) = GC.@preserve val ccall((:MakeStringWithLen, libgap), GapObj, (Ptr{UInt8}, Culong), val, sizeof(val))
 #TODO: As soon as libgap provides :GAP_MakeStringWithLen, use it.
 
 function CSTR_STRING(val::GapObj)

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -35,9 +35,7 @@ julia_to_gap(x::Bool) = x   # Default for actual GAP objects is to do nothing
 ## which avoids the conversion to BigInt, if we wanted to.
 function julia_to_gap(x::Integer)
     # if it fits into a GAP immediate integer, convert x to Int64
-    if x in -1<<60:(1<<60-1)
-        return Int64(x)
-    end
+    x in -1<<60:(1<<60-1) && return Int64(x)
     # for the general case, fall back to BigInt
     return julia_to_gap(BigInt(x))
 end
@@ -54,10 +52,8 @@ julia_to_gap(x::UInt8) = Int64(x)
 
 ## BigInts are converted via a ccall
 function julia_to_gap(x::BigInt)
-    if x in -1<<60:(1<<60-1)
-        return Int64(x)
-    end
-    return ccall(:MakeObjInt, GapObj, (Ptr{UInt64}, Cint), x.d, x.size)
+    x in -1<<60:(1<<60-1) && return Int64(x)
+    return GC.@preserve x ccall(:MakeObjInt, GapObj, (Ptr{UInt64}, Cint), x.d, x.size)
 end
 
 ## Rationals


### PR DESCRIPTION
... due to arguments getting collected prematurely.

Seems to also cure the crash in https://gist.github.com/rbehrends/be0e03df33dbe88bea083613941eee6b -- @rbehrends @rfourquet can you confirm this ? Perhaps we can add that test to the test suite?

Closes #600