### PR TITLE
get rid of a RadioMenu warning

### DIFF
--- a/src/help.jl
+++ b/src/help.jl
@@ -21,7 +21,7 @@ function gap_help_string(topic::String, onlyexact::Bool = false,
                 choice = REPL.TerminalMenus.request(
                     term,
                     "Choose an entry (out of $len) to view, 'q' for none:",
-                    REPL.TerminalMenus.RadioMenu(options, pagesize = pagesize))
+                    REPL.TerminalMenus.RadioMenu(options, pagesize = pagesize, charset = :ascii))
                 if choice == -1
                     # canceled
                     return ""


### PR DESCRIPTION
that appears in newer versions of `REPL.TerminalMenus.RadioMenu`.

Note that `charset = :ascii` is chosen not `charset = :unicode` because of the "no unicode" policy that is stated in the discussion of Nemocas/AbstractAlgebra.jl/pull/389.

(It would be good to state this policy explicitly somewhere, for the Oscar project.)