### PR TITLE
Switch to new GAP_jll and GAP_lib_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Thomas Breuer <sam@math.rwth-aachen.de>", "Sebastian Gutsche <gutsch
 version = "0.5.1"
 
 [deps]
-BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 GAP_jll = "5cd7a574-2c56-5be2-91dc-c8bc375b9ddf"
 GAP_lib_jll = "de1ad85e-c930-5cd4-919d-ccd3fcafd1a3"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -14,9 +13,8 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-BinaryProvider = "0.5.10"
-GAP_jll = "~4.11"
-GAP_lib_jll = "~4.11"
+GAP_jll = "~400.1100.1"
+GAP_lib_jll = "~400.1100"
 julia = "1.3"
 
 [extras]

--- a/src/types.jl
+++ b/src/types.jl
@@ -77,7 +77,7 @@ GAP: [ [ 1, 2 ], [ 3, 4 ] ]
 
 ```
 """
-abstract type GapObj end
+const GapObj = GAP_jll.MPtr
 
 # TODO: should we document Obj? What about ForeignGAP.MPtr?
 const Obj = Union{GapObj,FFE,Int64,Bool,Nothing}


### PR DESCRIPTION
The new GAP_jll initializes the GAP memory manager as part of its __init__
function. That means that the hackish global module `ForeignGAP` can be
removed; `ForeignGAP.MPtr` now is `GAP_jll.MPtr`. That in turn allows us to
turn `GapObj` from an abstract type into an alias for `GAP_jll.MPtr`, which
allow Julia to better optimize code involving GapObj, and in particular
structs with GapObj members. Thus it resolves #488

The new GAP version also contains https://github.com/gap-system/gap/pull/4212 which @ThomasBreuer may need for PR #566