### PR TITLE
document the Julia help access from GAP

### DIFF
--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -426,7 +426,7 @@ DeclareGlobalFunction( "CallJuliaFunctionWithKeywordArguments" );
 #!    <Ref Oper="\-" BookName="ref"/>,
 #!    <Ref Oper="\*" BookName="ref"/>,
 #!    <Ref Oper="\/" BookName="ref"/>,
-#!    <Ref Oper="LQuo" BookName="ref"/>,
+#!    <Ref Oper="LeftQuotient" BookName="ref"/>,
 #!    <Ref Oper="\^" BookName="ref"/>,
 #!    <Ref Oper="\=" BookName="ref"/>,
 #!    <Ref Oper="\&lt;" BookName="ref"/>,
@@ -456,3 +456,5 @@ DeclareGlobalFunction( "CallJuliaFunctionWithKeywordArguments" );
 #! gap> m + m;
 #! <Julia: [2 4; 6 8]>
 #! @EndExampleSession
+
+#! @InsertChunk JuliaHelpInGAP

--- a/pkg/JuliaInterface/gap/juliahelp.g
+++ b/pkg/JuliaInterface/gap/juliahelp.g
@@ -1,3 +1,65 @@
+#! @BeginChunk JuliaHelpInGAP
+#! @Chapter Using &Julia; from &GAP;
+#! @Section Access &Julia; help from a &GAP; session
+#!  In a &Julia; session, one can ask for help about the object with the name
+#!  <C>obj</C> (a function or a type) by entering <C>?obj</C>,
+#!  and &Julia; prints all matches to the screen.
+#!  One can get the same output in a &GAP; session by entering
+#!  <C>?Julia:obj</C>,
+#!  cf. Section <Ref Sect="Invoking the Help" BookName="ref"/>
+#!  in the &GAP; Reference Manual.
+#!  For example, <C>?Julia:sqrt</C> shows the &Julia; help about the
+#!  &Julia; function <C>sqrt</C>
+#!  (which is available in &GAP; as <C>Julia.sqrt</C>).
+#!  <P/>
+#!  Note that this way to access the &Julia; help is different from the usual
+#!  access to &GAP; help books, in the following sense.
+#!  <List>
+#!  <Item>
+#!   The qualifying prefix <C>Julia:</C> is mandatory.
+#!   Thus the help request <C>?sqrt</C> will show matches from usual
+#!   &GAP; help books (there is one match in the &GAP; Reference Manual),
+#!   but not the help abot the &Julia; function <C>sqrt</C>.
+#!  </Item>
+#!  <Item>
+#!   Since the prefix <C>Julia:</C> does not belong to a <Q>preprocessed</Q>
+#!   help book with chapters, sections, index, etc.,
+#!   help requests of the kinds
+#!   <C>?&lt;</C>, <C>?&lt;&lt;</C>, <C>?&gt;</C>, <C>?&gt;&gt;</C>
+#!   are not meaningful when the previous help request had the prefix
+#!   <C>?Julia:</C>.
+#!   (Also requests with the prefix <C>??Julia:</C> do not work,
+#!   but this holds also for usual &GAP; help books.)
+#!  </Item>
+#!  <Item>
+#!   The &Julia; help system is case sensitive.
+#!   Thus <C>?Julia:sqrt</C> yields a match but <C>?Julia:Sqrt</C> does not,
+#!   and <C>?Julia:Set</C> yields a match but <C>?Julia:set</C> does not.
+#!  </Item>
+#!  <Item>
+#!   The &Julia; help system does currently not support menus
+#!   in case of multiple matches, all matches are shown at once,
+#!   and this happens also in a &GAP; session.
+#!  </Item>
+#!  <Item>
+#!   No PDF or HTML version of the &Julia; help is supported in &GAP;,
+#!   only the text format can be shown on the screen.
+#!   Thus it does not make sense to change the help viewer,
+#!   cf. Section <Ref Sect="Changing the Help Viewer" BookName="ref"/>
+#!   in the &GAP; Reference Manual.
+#!  </Item>
+#!  <Item>
+#!   &Julia; functions belong to &Julia; modules.
+#!   Many &Julia; functions can be accessed only relative to their modules,
+#!   and then also the help requests work only for the qualified names.
+#!   For example, <C>?Julia:GAP.julia_to_gap</C> yields the description
+#!   of the &Julia; function <C>julia_to_gap</C> that is defined in the
+#!   &Julia; module <C>GAP</C>,
+#!   whereas no match is found for the input <C>?Julia:julia_to_gap</C>.
+#!  </Item>
+#!  </List>
+#! @EndChunk
+
 ##  Make the Julia help available in the GAP session,
 ##  via a (virtual) help book called `Julia`,
 ##  which uses a custom handler called `juliahelpformat`.
@@ -17,9 +79,18 @@ HELP_BOOK_HANDLER.juliahelpformat:= rec(
     # see "The Help Book Handler"
     ReadSix:= stream -> rec( bookname:= "Julia", entries:= [] ),
 
-    ShowChapters:= book -> "",  # This feature is not supported for Julia.
+    ShowChapters:= book -> [ "" ],  # This feature is not supported for Julia.
+#T In GAP 4.11.0, PAGER_BUILTIN would run into an error when called with an empty list.
 
-    ShowSection:= book -> "",   # This feature is not supported for Julia.
+    ShowSections:= book -> [ "" ],   # This feature is not supported for Julia.
+
+    MatchPrevChap:= { info, i } -> [ , fail ],   # This feature is not supported for Julia.
+
+    MatchNextChap:= { info, i } -> [ , fail ],   # This feature is not supported for Julia.
+
+    MatchPrev:= { info, i } -> [ , fail ],   # This feature is not supported for Julia.
+
+    MatchNext:= { info, i } -> [ , fail ],   # This feature is not supported for Julia.
 
     SearchMatches:= function( book, topic, frombegin )
       local orig_topic, start, module, pos, sub, func, res;


### PR DESCRIPTION
and make sure that help requests that are not supported (`?<` etc.) do not end up in errors

(Yes, and fix a cross-reference to the GAP Reference Manual.)