### PR TITLE
improvements to the JuliaInterface manual

### DIFF
--- a/pkg/JuliaInterface/PackageInfo.g
+++ b/pkg/JuliaInterface/PackageInfo.g
@@ -16,6 +16,24 @@ License := "GPL-2.0-or-later",
 
 Persons := [
   rec(
+    LastName := "Breuer",
+    FirstNames := "Thomas",
+    IsAuthor := true,
+    IsMaintainer := true,
+    Email := "sam@math.rwth-aachen.de",
+    WWWHome := "http://www.math.rwth-aachen.de/~Thomas.Breuer",
+    PostalAddress := Concatenation( [
+                       "Thomas Breuer\n",
+                       "Lehrstuhl für Algebra und Zahlentheorie\n",
+                       "RWTH Aachen\n",
+                       "Pontdriesch 14/16\n",
+                       "52062 Aachen\n",
+                       "Germany"
+      ] ),
+    Place := "Aachen",
+    Institution := "RWTH Aachen",
+  ),
+  rec(
     IsAuthor := true,
     IsMaintainer := true,
     FirstNames := "Sebastian",
@@ -117,7 +135,22 @@ end,
 
 TestFile := "tst/testall.g",
 
-#Keywords := [ "TODO" ],
+Keywords := [ "GAP-Julia integration" ],
 
+AutoDoc := rec(
+  TitlePage := rec(
+    Abstract := Concatenation(
+      "The &GAP; package <Package>JuliaInterface</Package> is part of ",
+      "a bidirectional interface between &GAP; and &Julia;.\n"
+    ),
+    Acknowledgements := Concatenation(
+      "The development of this &GAP; package has been supported ",
+      "by the <URL><Link>https://www.computeralgebra.de/sfb/</Link>",
+      "<LinkText>SFB-TRR 195 ",
+      "<Q>Symbolic Tools in Mathematics and their Applications</Q>",
+      "</LinkText></URL> (from 2017 until 2020).\n",
+      "<P/>\n"
+    ),
+  ),
+),
 ));
-

--- a/pkg/JuliaInterface/PackageInfo.g
+++ b/pkg/JuliaInterface/PackageInfo.g
@@ -148,7 +148,7 @@ AutoDoc := rec(
       "by the <URL><Link>https://www.computeralgebra.de/sfb/</Link>",
       "<LinkText>SFB-TRR 195 ",
       "<Q>Symbolic Tools in Mathematics and their Applications</Q>",
-      "</LinkText></URL> (from 2017 until 2020).\n",
+      "</LinkText></URL> (from 2017 until 2021).\n",
       "<P/>\n"
     ),
   ),

--- a/pkg/JuliaInterface/PackageInfo.g
+++ b/pkg/JuliaInterface/PackageInfo.g
@@ -35,7 +35,7 @@ Persons := [
   ),
   rec(
     IsAuthor := true,
-    IsMaintainer := true,
+    IsMaintainer := false,
     FirstNames := "Sebastian",
     LastName := "Gutsche",
     WWWHome := "https://sebasguts.github.io",

--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -533,8 +533,10 @@ DeclareGlobalFunction( "CallJuliaFunctionWithKeywordArguments" );
 #!    access to and assignment of entries of arrays, via
 #!    <Ref Oper="\[\]" BookName="ref"/>,
 #!    <Ref Oper="\[\]\:\=" BookName="ref"/>,
-#!    <Ref Oper="MatElm" BookName="ref"/>, and
-#!    <Ref Oper="SetMatElm" BookName="ref"/>,
+#!    <!-- <Ref Oper="MatElm" BookName="ref"/>, and
+#!    <Ref Oper="SetMatElm" BookName="ref"/>, -->
+#!    and the (up to &GAP; 4.11 undocumented) operations <C>MatElm</C> and
+#!    <C>SetMatElm</C>,
 #!    delegating to
 #!    <C>Julia.Base.getindex</C> and
 #!    <C>Julia.Base.setindex</C>,
@@ -593,5 +595,6 @@ DeclareGlobalFunction( "CallJuliaFunctionWithKeywordArguments" );
 #! gap> m + m;
 #! <Julia: [2 4; 6 8]>
 #! @EndExampleSession
+#TODO: add the cross-references to MatElm, SetMatElm when they are documented
 
 #! @InsertChunk JuliaHelpInGAP

--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -17,7 +17,7 @@
 #!  in a &Julia; session,
 #!  to access &Julia; objects and to call &Julia; functions
 #!  in a &GAP; session,
-#!  and to convert low level data such as integers, Booleans, strings,
+#!  and to convert low level data such as integers, booleans, strings,
 #!  arrays/lists, dictionaries/records between the two systems.
 #!
 #!  In particular, this interface is <E>not</E> intended to provide

--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -11,7 +11,86 @@
 #!  The &GAP; package <Package>JuliaInterface</Package> is part of
 #!  a bidirectional interface between &GAP; and &Julia;.
 #!
-#!  TODO: state the aims, describe the installation
+#! @Section Aims of the <Package>JuliaInterface</Package> package
+#!  The low level interface between &GAP; and &Julia; allows one
+#!  to access &GAP; objects and to call &GAP; functions
+#!  in a &Julia; session,
+#!  to access &Julia; objects and to call &Julia; functions
+#!  in a &GAP; session,
+#!  and to convert low level data such as integers, Booleans, strings,
+#!  arrays/lists, dictionaries/records between the two systems.
+#!
+#!  In particular, this interface is <E>not</E> intended to provide
+#!  a very <Q>&Julia;-ish</Q> interface to &GAP; objects and functions,
+#!  nor a <Q>&GAP;-ish</Q> interface to &Julia; objects and functions.
+#!
+#!  Also, the interface does not provide conversions to &GAP;
+#!  for &Julia; objects whose types are defined in &Julia; packages
+#!  (that is, not in the <Q>core &Julia;</Q>).
+#!  For example, the &Julia; package <Package>Nemo.jl</Package> defines
+#!  an integer type <C>fmpz</C>.
+#!  The conversion of integers of type <C>fmpz</C> between &Julia; and &GAP;
+#!  is handled in the context of the <Package>Oscar</Package> system,
+#!  which uses both &GAP; and <Package>Nemo.jl</Package>,
+#!  but <Package>JuliaInterface</Package> does not deal with it.
+#!
+#!  The interface consists of
+#!
+#!  <List>
+#!  <Item>
+#!    the integration of &Julia;'s garbage collector into &GAP;
+#!    (which belongs to the &GAP; core system),
+#!  </Item>
+#!  <Item>
+#!    <C>C</C> code for converting and wrapping low level objects
+#!    (which belongs to <Package>JuliaInterface</Package>),
+#!  </Item>
+#!  <Item>
+#!    &Julia; code for converting low level objects
+#!    (which belongs to the &Julia; package <C>GAP.jl</C>,
+#!    see <URL>https://github.com/oscar-system/GAP.jl</URL>),
+#!  </Item>
+#!  <Item>
+#!    and &GAP; code (again in <Package>JuliaInterface</Package>)
+#!    which is described in this manual.
+#!  </Item>
+#!  </List>
+#!
+#!  The <Package>JuliaInterface</Package> manual takes the viewpoint
+#!  of a &GAP; session from where one wants to use &Julia; functionality.
+#!  The opposite direction, using &GAP; functionality in a &Julia; session,
+#!  is described in the documentation of the &Julia; package <C>GAP.jl</C>.
+#!
+#! @Section Installation of the <Package>JuliaInterface</Package> package
+#!  The package can be used only when the underlying &GAP; has been
+#!  compiled with the &Julia; garbage collector,
+#!  and the recommended way to install such a &GAP; is to install &Julia;
+#!  first (see <URL>https://julialang.org/downloads/</URL>)
+#!  and then to ask &Julia;'s package manager to download and install &GAP;,
+#!  by entering
+#!  <Listing Type="Julia">using Pkg; Pkg.add( "GAP" )</Listing>
+#!  at the &Julia; prompt.
+#!
+#!  One way to start a &GAP; session from the &Julia; session is to enter
+#!  <Listing Type="Julia">using GAP; GAP.prompt()</Listing>
+#!  at the &Julia; prompt,
+#!  afterwards the package <Package>JuliaInterface</Package> is already
+#!  installed and loaded.
+#!
+#!  Alternatively, one can start &GAP; in the traditional way,
+#!  by executing a shell script.
+#!  Such a script is generated automatically during the installation of
+#!  &GAP; via &Julia;,
+#!  its location is returned in a &Julia; session by
+#!  <Listing Type="Julia">using GAP; GAP.gap_exe()</Listing>
+#!
+#!  Note that the <Package>JuliaInterface</Package> code belongs to
+#!  <URL><Link>https://github.com/oscar-system/GAP.jl</Link>
+#!  <LinkText>the &Julia; package <C>GAP.jl</C></LinkText></URL>,
+#!  hence it can be found there.
+#!
+#! @Section User preferences in the <Package>JuliaInterface</Package> package
+#! @InsertChunk IncludeJuliaStartupFile
 
 #! @Chapter Using &Julia; from &GAP;
 #! @Section Filters for <Package>JuliaInterface</Package>
@@ -21,7 +100,7 @@
 #! @Description
 #!  The result is <K>true</K> if and only if <A>obj</A> is a pointer to a
 #!  &Julia; object.
-#!  <P/>
+#!
 #!  The results of <Ref Func="JuliaModule"/> are always in
 #!  <Ref Filt="IsJuliaObject" Label="for IsObject"/>.
 #!  The results of <Ref Func="JuliaEvalString"/> are in
@@ -61,11 +140,11 @@ BindGlobal("TheTypeJuliaObject", NewType( JuliaObjectFamily, IsJuliaObject ));
 #!  for &Julia; objects that behave just like the &Julia; objects
 #!  when used as arguments in calls to &Julia; functions.
 #!  <!-- No other functionality is implemented for IsJuliaWrapper -->
-#!  <P/>
+#!
 #!  Objects in <Ref Filt="IsJuliaWrapper" Label="for IsObject"/>
 #!  should <E>not</E> be in the filter
 #!  <Ref Filt="IsJuliaObject" Label="for IsObject"/>.
-#!  <P/>
+#!
 #!  Examples of objects in <Ref Filt="IsJuliaWrapper" Label="for IsObject"/>
 #!  are the return values of <Ref Func="JuliaModule"/>.
 DeclareCategory( "IsJuliaWrapper", IsObject );
@@ -173,19 +252,19 @@ DeclareGlobalFunction( "JuliaIncludeFile" );
 #!  for the &Julia; package with name <A>pkgname</A>.
 #!  It returns <K>true</K> if the call was successful,
 #!  and <K>false</K> otherwise.
-#!  <P/>
+#!
 #!  Note that we just want to load the package into &Julia;,
 #!  we do <E>not</E> want to import variable names from the package
 #!  into &Julia;'s <C>Main</C> module, because the &Julia; variables must be
 #!  referenced relative to their modules if we want to be sure to access
 #!  the correct values.
-#!  <P/>
+#!
 #!  Why is this function needed?
-#!  <P/>
+#!
 #!  Apparently <C>libjulia</C> throws an error
 #!  when trying to compile the package, which happens when some files from
 #!  the package have been modified since compilation.
-#!  <P/>
+#!
 #!  Thus &GAP; has to check whether the &Julia; package has been loaded
 #!  successfully, and can then safely load and execute code
 #!  that relies on this &Julia; package.
@@ -210,10 +289,7 @@ BindGlobal( "_JuliaFunctions", rec( ) );
 #! the function is taken from &Julia;'s <C>Main</C> module.
 #! The returned function can be called on arguments in
 #! <Ref Func="IsArgumentForJuliaFunction"/>.
-#! <!-- The result is not in IsJuliaObject, note that JuliaFunction calls
-#!      _JuliaFunction, which calls NewJuliaFunc;
-#!      and this returns a GAP function that delegates to
-#!      DoCallJuliaFunc0Arg and eventually to jl_call. -->
+#!
 #! @BeginExampleSession
 #! gap> fun:= JuliaFunction( "sqrt" );
 #! <Julia: sqrt>
@@ -221,31 +297,75 @@ BindGlobal( "_JuliaFunctions", rec( ) );
 #! function ( arg... )
 #!     <<kernel code>> from Julia:sqrt
 #! end
+#! gap> IsFunction( fun );
+#! true
+#! gap> IsJuliaObject( fun );
+#! false
+#! @EndExampleSession
+#!
+#! Alternatively, one can access &Julia; functions also via the global object
+#! <Ref Var="Julia"/>, as follows.
+#!
+#! @BeginExampleSession
+#! gap> Julia.sqrt;
+#! <Julia: sqrt>
+#! @EndExampleSession
+#!
+#! Note that each call to <Ref Func="JuliaFunction"/> and each component
+#! access to <Ref Var="Julia"/> create a <E>new</E> &GAP; object.
+#!
+#! @BeginExampleSession
+#! gap> IsIdenticalObj( JuliaFunction( "sqrt" ), JuliaFunction( "sqrt" ) );
+#! false
+#! gap> IsIdenticalObj( Julia.sqrt, Julia.sqrt );
+#! false
 #! @EndExampleSession
 DeclareGlobalFunction( "JuliaFunction" );
 
 #! @Description
 #!  This global variable represents the &Julia; module <C>Main</C>,
 #!  see <Ref Filt="IsJuliaModule" Label="for IsJuliaWrapper"/>.
+#!
+#!  The variables from the underlying &Julia; session can be accessed via
+#!  <Ref Var="Julia"/>, as follows.
+#!
+#! @BeginExampleSession
+#! gap> Julia.sqrt;  # a Julia function
+#! <Julia: sqrt>
+#! gap> JuliaEvalString( "x = 1" );  # an assignment in the Julia session
+#! 1
+#! gap> Julia.x;  # access to the value that was just assigned
+#! 1
+#! gap> Julia.Main.x;
+#! 1
+#! @EndExampleSession
 DeclareGlobalVariable( "Julia" );
 
 #! @Arguments name
 #! @Returns nothing.
 #! @Description
-#!  The aim of this function is to make those global variables
-#!  that are exported by the &Julia; module with name <A>name</A>
-#!  available in the global object <Ref Var="Julia"/>.
-#!  After the call, the <A>name</A> component of <Ref Var="Julia"/>
-#!  will be bound to a record that contains the variables from the
-#!  &Julia; module.
+#!  The aim of this function is to make the &Julia; module with name
+#!  <A>name</A> available in the current &GAP; session.
+#!  After the call,
+#!  the <A>name</A> component of the global object <Ref Var="Julia"/> will be
+#!  bound, and one can access the module as a component of <Ref Var="Julia"/>
+#!  or via <Ref Func="JuliaModule"/>.
+#! @BeginExampleSession
+#! gap> ImportJuliaModuleIntoGAP( "GAP" );
+#! gap> Julia.GAP;
+#! <Julia module GAP>
+#! @EndExampleSession
+#!  The &Julia; modules <C>Base</C>, <C>Core</C>, and <C>GAP</C>
+#!  have in fact already been imported when the
+#!  <Package>JuliaInterface</Package> package got loaded.
 DeclareGlobalFunction( "ImportJuliaModuleIntoGAP" );
 
 #! @Arguments name
 #! @Returns a &Julia; object
 #! @Description
-#!  Returns the &Julia; object that points to the module
+#!  Returns the &Julia; object that points to the &Julia; module
 #!  with name <A>name</A>.
-#!  Note that the module needs to be imported before being present,
+#!  Note that this module needs to be imported before being present,
 #!  see <Ref Func="ImportJuliaModuleIntoGAP"/>.
 #! @BeginExampleSession
 #! gap> gapmodule:= JuliaModule( "GAP" );
@@ -267,6 +387,8 @@ DeclareGlobalFunction( "JuliaModule" );
 #! "Module"
 #! gap> JuliaTypeInfo( JuliaEvalString( "sqrt(2)" ) );
 #! "Float64"
+#! gap> JuliaTypeInfo( 1 );
+#! "Int64"
 #! @EndExampleSession
 DeclareGlobalFunction( "JuliaTypeInfo" );
 
@@ -308,7 +430,7 @@ DeclareGlobalFunction( "CallJuliaFunctionWithCatch" );
 #!  and keyword arguments given by the component names (keys) and values
 #!  of the record <A>arec</A>,
 #!  and returns the function value.
-#!  <P/>
+#!
 #!  Note that the entries of <A>arguments</A> and the components of
 #!  <A>arec</A> are not implicitly converted to &Julia;.
 #! @BeginExampleSession
@@ -357,26 +479,41 @@ DeclareGlobalFunction( "CallJuliaFunctionWithKeywordArguments" );
 #! gap> jsqrt( 2 );
 #! <Julia: 1.4142135623730951>
 #! @EndExampleSession
-#!  In fact, there are slightly different ways to achieve this.
-#!
-#!  <List>
-#!  <Item>
-#!    If we have an object <C>obj</C> in
-#!    <Ref Filt="IsJuliaObject" Label="for IsObject"/>
-#!    that points to a &Julia; function then we can call <C>obj</C> with
-#!    suitable arguments.
-#!    In this situation, the function call is executed via
-#!    the applicable <Ref Oper="CallFuncList" BookName="ref"/> method,
-#!    which calls &Julia;'s <C>Core._apply</C>.
-#!  </Item>
-#!  <Item>
-#!    If we have a &GAP; function that was created with
-#!    <Ref Func="JuliaFunction"/> then the function call is executed
-#!    on the C level, using &Julia;'s <C>jl_call</C>.
-#!  </Item>
-#!  </List>
-#!
-#!  TODO: Add examples.
+#!  In fact, there are slightly different kinds of function calls.
+#!  A &Julia; function such as <C>Julia.sqrt</C>
+#!  (or equivalently <C>JuliaFunction( "sqrt" )</C>) is represented by
+#!  a &GAP; function object,
+#!  and calls to it are executed on the C level,
+#!  using &Julia;'s <C>jl_call</C>.
+#! @BeginExampleSession
+#! gap> fun:= Julia.sqrt;
+#! <Julia: sqrt>
+#! gap> IsJuliaObject( fun );
+#! false
+#! gap> IsFunction( fun );
+#! true
+#! gap> fun( 2 );
+#! <Julia: 1.4142135623730951>
+#! @EndExampleSession
+#!  There are also callable &Julia; objects which aren't represented by
+#!  &GAP; functions, for example &Julia; types can be called like functions.
+#!  In this situation, the function call is executed via
+#!  the applicable <Ref Oper="CallFuncList" BookName="ref"/> method,
+#!  which calls &Julia;'s <C>Core._apply</C>.
+#! @BeginExampleSession
+#! gap> smalltype:= Julia.Int32;
+#! <Julia: Int32>
+#! gap> IsJuliaObject( smalltype );
+#! true
+#! gap> IsFunction( smalltype );
+#! false
+#! gap> val:= smalltype( 1 );
+#! <Julia: 1>
+#! gap> JuliaTypeInfo( val );
+#! "Int32"
+#! gap> JuliaTypeInfo( 1 );
+#! "Int64"
+#! @EndExampleSession
 
 #! @Subsection Convenience methods for &Julia; objects
 #!  For the following operations, methods are installed that require

--- a/pkg/JuliaInterface/gap/convert.gd
+++ b/pkg/JuliaInterface/gap/convert.gd
@@ -361,7 +361,16 @@
 #!
 #!  For recursive structures (&GAP; lists and records),
 #!  only the outermost level is converted except if the optional argument
-#!  <A>recursive</A> is given and has the value <K>true</K>.
+#!  <A>recursive</A> is given and has the value <K>true</K>,
+#!  in this case all layers are converted recursively.
+#!
+#!  Note that this default is different from the default in the other
+#!  direction (see <Ref Func="GAPToJulia"/>).
+#!  The idea behind this choice is that from the viewpoint of a &GAP; session,
+#!  it is more likely to use plain &Julia; objects for computations on the
+#!  &Julia; side than &Julia; objects that contain &GAP; subobjects,
+#!  whereas <Q>shallow conversion</Q> of &Julia; objects to &GAP; yields
+#!  something useful on the &GAP; side.
 #!
 #! @BeginExampleSession
 #! gap> s:= GAPToJulia( "abc" );
@@ -401,11 +410,11 @@ DeclareConstructor("JuliaToGAP", [IsObject, IsObject, IsBool]);
 #!  such that a corresponding &Julia; object with type <A>juliatype</A>
 #!  can be constructed.
 #!  Then <Ref Func="GAPToJulia"/> returns this &Julia; object.
-#!  <P/>
+#!
 #!  If <A>juliatype</A> is not given then a default type is chosen.
 #!  The function is implemented via the &Julia; function
 #!  <C>GAP.gap_to_julia</C>.
-#!  <P/>
+#!
 #! <!-- Note that the Julia output contains the "forbidden" sequence "]]>",
 #!      thus the CDATA syntax cannot be used. -->
 #!<Example>
@@ -427,12 +436,19 @@ DeclareConstructor("JuliaToGAP", [IsObject, IsObject, IsBool]);
 #!gap> GAPToJulia( r );
 #!&lt;Julia: Dict{Symbol,Any}(:a => 1,:b => Any[1, 2, 3])>
 #!</Example>
-#! If <A>gapobj</A> is a list or a record, one may want that its subobjects
-#! are also converted to &Julia; or that they are kept as they are,
-#! which can be decided by entering <K>true</K> or <K>false</K> as the value
-#! of the optional argument <A>recursive</A>;
-#! the default is <K>true</K>, that is, the subobjects of <A>gapobj</A> are
-#! converted recursively.
+#!
+#!  If <A>gapobj</A> is a list or a record, one may want that its subobjects
+#!  are also converted to &Julia; or that they are kept as they are,
+#!  which can be decided by entering <K>true</K> or <K>false</K> as the value
+#!  of the optional argument <A>recursive</A>;
+#!  the default is <K>true</K>, that is, the subobjects of <A>gapobj</A> are
+#!  converted recursively.
+#!
+#!  Note that this default is different from the default in the other
+#!  direction,
+#!  see the description of
+#!  <Ref Constr="JuliaToGAP" Label="for IsObject, IsObject"/>.
+#!
 #!<Example>
 #!gap> jl:= GAPToJulia( m, false );
 #!&lt;Julia: Any[GAP: [ 1, 2 ], GAP: [ 3, 4 ]]>
@@ -452,17 +468,6 @@ DeclareGlobalFunction("GAPToJulia");
 #!   kinds, e.g.:
 #!   <List>
 #!   <Item>
-#!     Add a custom <C>big</C> or <C>BigInt</C> method (or both?)
-#!     which converts &GAP; integers to &Julia;;
-#!     similar for &GAP; rationals, but there we may want to let the user
-#!     choose which integer type to use on the &Julia; side for numerator
-#!     and denominator.
-#!   </Item>
-#!   <Item>
-#!     Add conversions from &Julia; bigints and rationals over
-#!     various integer types, including bigints, to &GAP;.
-#!   </Item>
-#!   <Item>
 #!     There could be a &Julia; type hierarchy of wrappers, e.g.,
 #!     <C>GAPInt &lt;: GAPRat &lt;: GAPCyc</C>;
 #!     those types would wrap the corresponding &GAP; objects,
@@ -472,32 +477,12 @@ DeclareGlobalFunction("GAPToJulia");
 #!     or nicer printing (w/o the <C>GAP:</C> prefix even?).
 #!     Not really sure whether this is useful, though.
 #!   </Item>
-#!   <Item>
-#!     How do other types of integers, e.g., fmpz from FLINT,
-#!     enter this setup? Are &Julia;'s <C>Big</C> really useful?
-#!   </Item>
 #!   </List>
 #! </Item>
 #! <Item>
-#!   Should we restrict the automatic FFE conversion to <C>IsInternalRep</C>?
-#! </Item>
-#! <Item>
-#!   Why is <Ref Func="GAPToJulia"/> always recursive?
-#! </Item>
-#! <Item>
-#!   Should we allow the three argument case of <C>JuliaToGAP</C> in all
-#!   cases, e.g., <C>JuliaToGAP( IsInt, 1, true )</C>?
-#! </Item>
-#! <Item>
-#!   Would it make sense to show &Julia; help in a &GAP; session,
-#!   for example via <C>?Julia:length</C> or <C>?Julia:Base.length</C>?
-#!   (What is the easiest way to regard <C>"Julia"</C> as a &GAP; help book?)
-#!   <!-- see REPL/src/docview.jl in Julia -->
-#! </Item>
-#! <Item>
-#!   The introductory chapter/section
-#!   (see <Ref Chap="Chapter_Introduction_to_PackageJuliaInterfacePackage"/>)
-#!   is missing.
+#!   Should we allow the three argument case of
+#!   <Ref Constr="JuliaToGAP" Label="for IsObject, IsObject"/> in all cases,
+#!   e.g., <C>JuliaToGAP( IsInt, 1, true )</C>?
 #! </Item>
 #! <Item>
 #!   Many tests of conversions are missing.

--- a/pkg/JuliaInterface/gap/convert.gd
+++ b/pkg/JuliaInterface/gap/convert.gd
@@ -79,7 +79,9 @@
 #!  whose values are stored inside the <Q>pointer</Q> referencing them.
 #!  &GAP; uses this to store small integers
 #!  and elements of small finite fields,
-#!  (see <Ref Chap="Immediate Integers and FFEs" BookName="dev"/>).
+#!  <!-- (see <Ref Chap="Immediate Integers and FFEs" BookName="dev"/>). -->
+#!  see for example the beginning of Chapter
+#!  <Ref Chap="Integers" BookName="ref"/> in the &GAP; Reference Manual.
 #!  Since these are not valid pointers, &Julia; cannot treat them like other
 #!  &GAP; objects, which are simply &Julia; objects of type
 #!  <C>Main.ForeignGAP.MPtr</C>.
@@ -160,6 +162,7 @@
 #!    other &Julia; objects to &Julia; object wrapper.
 #!  </Item>
 #!  </List>
+#TODO: re-enter the cross-reference to the "dev" manual when this is possible
 
 #! @Subsection Manual (explicit) conversions
 #!  Manual conversion in &GAP; is done via the functions

--- a/pkg/JuliaInterface/init.g
+++ b/pkg/JuliaInterface/init.g
@@ -5,8 +5,6 @@
 #
 
 #! @BeginChunk IncludeJuliaStartupFile
-#! @Chapter Introduction to <Package>JuliaInterface</Package>
-#! @Section User preferences in the <Package>JuliaInterface</Package> package
 #!  <Subsection Label="subsect:IncludeJuliaStartupFile">
 #!  <Heading>User preference <C>IncludeJuliaStartupFile</C></Heading>
 #!  <Index Key="IncludeJuliaStartupFile"><C>IncludeJuliaStartupFile</C></Index>

--- a/pkg/JuliaInterface/init.g
+++ b/pkg/JuliaInterface/init.g
@@ -12,9 +12,11 @@
 #!  When one starts an interactive &Julia; session,
 #!  the &Julia; startup file <F>~/.julia/config/startup.jl</F> gets
 #!  included automatically by default,
-#!  see the section <Q>The Julia REPL</Q> in the &Julia; documentation.
+#!  see <URL><Link>https://docs.julialang.org/en/v1/stdlib/REPL</Link>
+#!  <LinkText>the section <Q>The Julia REPL</Q> in the &Julia; documentation</LinkText></URL>.
 #!  Hence the effects of this inclusion can be used in a &GAP; session
-#!  which one gets via the input <C>using GAP; GAP.prompt()</C>.
+#!  which one gets via the following input.
+#!  <Listing Type="Julia">using GAP; GAP.prompt()</Listing>
 #!  <P/>
 #!  However,
 #!  this &Julia; startup file is <E>not</E> included into &Julia; by default

--- a/pkg/JuliaInterface/init.g
+++ b/pkg/JuliaInterface/init.g
@@ -4,22 +4,46 @@
 # Reading the declaration part of the package.
 #
 
-##
-##  If the value is <K>true</K> then the file
-##  <F>~/.julia/config/startup.jl</F>
-##  gets imported into &Julia; after startup.
-##  If the value is a nonempty string that is the name of a directory
-##  then the <F>startup.jl</F> file in this directory gets imported into
-##  &Julia;.
-##  Otherwise no <F>startup.jl</F> file will be imported automatically,
-##  since apparently <C>libjulia</C> does not import such a file.
+#! @BeginChunk IncludeJuliaStartupFile
+#! @Chapter Introduction to <Package>JuliaInterface</Package>
+#! @Section User preferences in the <Package>JuliaInterface</Package> package
+#!  <Subsection Label="subsect:IncludeJuliaStartupFile">
+#!  <Heading>User preference <C>IncludeJuliaStartupFile</C></Heading>
+#!  <Index Key="IncludeJuliaStartupFile"><C>IncludeJuliaStartupFile</C></Index>
+#!
+#!  When one starts an interactive &Julia; session,
+#!  the &Julia; startup file <F>~/.julia/config/startup.jl</F> gets
+#!  included automatically by default,
+#!  see the section <Q>The Julia REPL</Q> in the &Julia; documentation.
+#!  Hence the effects of this inclusion can be used in a &GAP; session
+#!  which one gets via the input <C>using GAP; GAP.prompt()</C>.
+#!  <P/>
+#!  However,
+#!  this &Julia; startup file is <E>not</E> included into &Julia; by default
+#!  when &GAP; gets started via the <F>gap.sh</F> script that is created
+#!  during the installation of &GAP; (controlled by &Julia;).
+#!  <P/>
+#!  The user preference <C>IncludeJuliaStartupFile</C> can be used to
+#!  force that the startup file gets included also in the latter situation,
+#!  as follows.
+#!  <P/>
+#!  If the value is <K>true</K> then the file
+#!  <F>~/.julia/config/startup.jl</F>
+#!  gets included into &Julia; after startup.
+#!  If the value is a nonempty string that is the name of a directory
+#!  then the <F>startup.jl</F> file in this directory gets included into
+#!  &Julia;.
+#!  Otherwise (this is the default) no <F>startup.jl</F> file will be
+#!  included automatically.
+#!  </Subsection>
+#! @EndChunk IncludeJuliaStartupFile
 ##
 DeclareUserPreference( rec(
     package:= "JuliaInterface",
     name:= "IncludeJuliaStartupFile",
     description:= [
       "If the value is 'true' then the file '~/.julia/config/startup.jl'",
-      "gets imported into Julia after startup.",
+      "gets included into Julia after startup.",
       "If the value is a nonempty string that is the name of a directory",
       "then the 'startup.jl' file in this directory gets imported into",
       "Julia.",

--- a/src/types.jl
+++ b/src/types.jl
@@ -21,7 +21,7 @@ primitive type FFE 64 end
     GapObj
 
 This is the Julia type of all those GAP objects that are not
-"immediate" (Booleans, small integers, FFEs).
+"immediate" (booleans, small integers, FFEs).
 
 # Examples
 ```jldoctest
@@ -43,7 +43,7 @@ Int64
 julia> typeof( GAP.evalstr( "Z(2)" ) )          # a GAP FFE
 FFE
 
-julia> typeof( GAP.evalstr( "true" ) )          # a Boolean
+julia> typeof( GAP.evalstr( "true" ) )          # a boolean
 Bool
 
 ```


### PR DESCRIPTION
... such that we get a meaningful version for the GAP Days.

The details:

- extended `PackageInfo.g`:
  - added myself to the involved persons,
  - added `Keywords` entry,
  - added `AutoDoc` component,
    with the components `Abstract` and `Acknowledgements`,
- added the introductory chapter (aims, installation),
- clarified/corrected the description of `ImportJuliaModuleIntoGAP`,
- clarified the description of the different kinds of function calls,
- explained the defaults of `GAPToJulia` and `JuliaToGAP` w.r.t. recursion,
- removed those open items that have meanwhile been dealt with,
- added a description of the user preference `IncludeJuliaStartupFile`,
- added a few examples.

Now there are no visible `TODO` markers anymore, but I have still some questions:

- The chunk `IncludeJuliaStartupFile` is requested in `gap/JuliaInterface.gd`, *behind* the other two sections of the first chapter, but it appears as the *first* section.
  Am I misusing AutoDoc?
- There had been an open item "Should we restrict the automatic FFE conversion to `IsInternalRep`?"
  However, in fact we do not provide a conversion of non-internal FFEs at all.
  For example, `GAPToJulia( Z(101, 10) )` yields an error.
- Currently the cross-references to `MatElm` and `SetMatElm` in the GAP Reference Manual do not work, because GAP 4.11.0 provides these operations but no documentation for them.
  Can we expect this documentation in GAP soon, or shall we reformulate the cross-references?
- Also cross-references to the GAP `dev` manual will not work if users do not have this manual installed (which is usually the case).
- The `AutoDoc` manual contains a section on copyright and license; shall we add this also for `JuliaInterface`? (If yes with which copyright?)
