### PR TITLE
Remove references to ForeignGAP

### DIFF
--- a/pkg/JuliaInterface/example/function_perform.jl
+++ b/pkg/JuliaInterface/example/function_perform.jl
@@ -1,6 +1,6 @@
 module GapFunctionPerform
 
-import Main.ForeignGAP: MPtr
+import GAP_jll: MPtr
 
 function typed_func(a::MPtr, b::MPtr)
     return a

--- a/pkg/JuliaInterface/gap/convert.gd
+++ b/pkg/JuliaInterface/gap/convert.gd
@@ -39,7 +39,7 @@
 #!   On the &Julia; side, there is usually no need for a wrapper,
 #!   as (thanks to the shared garbage collector)
 #!   most &GAP; objects are valid &Julia; objects of type
-#!   <C>Main.ForeignGAP.MPtr</C>.
+#!   <C>GAP_jll.MPtr</C>.
 #!   The exception to that rule are immediate &GAP; objects,
 #!   more on that in the next section.
 #! </Item>
@@ -82,7 +82,7 @@
 #!  (see <Ref Chap="Immediate Integers and FFEs" BookName="dev"/>).
 #!  Since these are not valid pointers, &Julia; cannot treat them like other
 #!  &GAP; objects, which are simply &Julia; objects of type
-#!  <C>Main.ForeignGAP.MPtr</C>.
+#!  <C>GAP_jll.MPtr</C>.
 #!  Instead, a conversion is unavoidable, at least when immediate objects
 #!  are passed as stand-alone arguments to a function.
 #!  <P/>
@@ -133,7 +133,7 @@
 #!    &Julia; function wrapper to &Julia; function,
 #!  </Item>
 #!  <Item>
-#!    other &GAP; objects to <C>ForeignGAP.MPtr</C>.
+#!    other &GAP; objects to <C>GAP_jll.MPtr</C>.
 #!  </Item>
 #!  </List>
 #!
@@ -154,7 +154,7 @@
 #!    &Julia; <C>false</C> to &GAP; <K>false</K>,
 #!  </Item>
 #!  <Item>
-#!    <C>ForeignGAP.MPtr</C> to <C>Obj</C>,
+#!    <C>GAP_jll.MPtr</C> to <C>Obj</C>,
 #!  </Item>
 #!  <Item>
 #!    other &Julia; objects to &Julia; object wrapper.

--- a/src/types.jl
+++ b/src/types.jl
@@ -79,7 +79,7 @@ GAP: [ [ 1, 2 ], [ 3, 4 ] ]
 """
 const GapObj = GAP_jll.MPtr
 
-# TODO: should we document Obj? What about ForeignGAP.MPtr?
+# TODO: should we document Obj?
 const Obj = Union{GapObj,FFE,Int64,Bool,Nothing}
 
 export FFE, GapObj


### PR DESCRIPTION
These are now gone in the latest master branch. Instead we have `GAP_jll.MPtr` and `GAP.GapObj` is an alias for that (this is slightly annoying, actually, it'd be great if we could "rename" it, but that's for another day to worry about.

Perhaps instead of `GAP_jll.MPtr` this PR should use its synonym `GAP.GapObj`. However, Julia prints that as `GAP_jll.MPtr`, so I think for the user `GAP_jll.MPtr` might be better?

```
julia> GapObj
GAP_jll.MPtr

```