### PR TITLE
Ship our own copy of julia-config.jl

### DIFF
--- a/src/julia-config.jl
+++ b/src/julia-config.jl
@@ -1,0 +1,67 @@
+# This file is based on the file `contrib/julia-config.jl` which is a
+# part of Julia. License is MIT: https://julialang.org/license
+
+import Libdl
+
+function shell_escape(str)
+    str = replace(str, "'" => "'\''")
+    return "'$str'"
+end
+
+function libDir()
+    return if ccall(:jl_is_debugbuild, Cint, ()) != 0
+        if Base.DARWIN_FRAMEWORK
+            joinpath(dirname(abspath(Libdl.dlpath(Base.DARWIN_FRAMEWORK_NAME * "_debug"))),"lib")
+        else
+            dirname(abspath(Libdl.dlpath("libjulia-debug")))
+        end
+    else
+        if Base.DARWIN_FRAMEWORK
+            joinpath(dirname(abspath(Libdl.dlpath(Base.DARWIN_FRAMEWORK_NAME))),"lib")
+        else
+            dirname(abspath(Libdl.dlpath("libjulia")))
+        end
+    end
+end
+
+private_libDir() = abspath(Sys.BINDIR, Base.PRIVATE_LIBDIR)
+
+function includeDir()
+    return abspath(Sys.BINDIR, Base.INCLUDEDIR, "julia")
+end
+
+function ldflags()
+    fl = "-L$(shell_escape(libDir()))"
+    if Sys.iswindows()
+        fl = fl * " -Wl,--stack,8388608"
+    elseif !Sys.isapple()
+        fl = fl * " -Wl,--export-dynamic"
+    end
+    return fl
+end
+
+function ldlibs()
+    libname = if ccall(:jl_is_debugbuild, Cint, ()) != 0
+        "julia-debug"
+    else
+        "julia"
+    end
+    if Sys.isunix()
+        return "-Wl,-rpath,$(shell_escape(libDir())) " *
+            (Sys.isapple() ? string() : "-Wl,-rpath,$(shell_escape(private_libDir())) ") *
+            "-l$libname"
+    else
+        return "-l$libname -lopenlibm"
+    end
+end
+
+function cflags()
+    flags = IOBuffer()
+    print(flags, "-std=gnu99")
+    include = shell_escape(includeDir())
+    print(flags, " -I", include)
+    if Sys.isunix()
+        print(flags, " -fPIC")
+    end
+    return String(take!(flags))
+end

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -62,10 +62,7 @@ function select_compiler(lang, candidates, extension)
     return nothing
 end
 
-# load the code in julia-config.jl (but strip the call to main() at the end,
-# so that no code is executed, and so that it doesn't call exit())
-julia_config_jl = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "julia-config.jl")
-include_string(@__MODULE__, replace(read(julia_config_jl, String), "\nmain()\n" => "\n"))
+include("julia-config.jl")
 
 function regenerate_gaproot()
     gaproot_gapjl = abspath(@__DIR__, "..")
@@ -85,9 +82,9 @@ function regenerate_gaproot()
     # paths involve spaces, but then we likely will haves problem in other
     # places; in any case, if anybody ever cares about this, we can work on
     # finding a better solution.
-    sysinfo["JULIA_CPPFLAGS"] = filter(c -> c != '\'', cflags(false))
-    sysinfo["JULIA_LDFLAGS"] = filter(c -> c != '\'', ldflags(false))
-    sysinfo["JULIA_LIBS"] = filter(c -> c != '\'', ldlibs(false))
+    sysinfo["JULIA_CPPFLAGS"] = filter(c -> c != '\'', cflags())
+    sysinfo["JULIA_LDFLAGS"] = filter(c -> c != '\'', ldflags())
+    sysinfo["JULIA_LIBS"] = filter(c -> c != '\'', ldlibs())
 
     # path to the currently used Julia executable 
     sysinfo["JULIA"] = joinpath(Sys.BINDIR, Base.julia_exename())


### PR DESCRIPTION
Unfortunately, several Linux distributions do not ship julia-config.jl
in their default Julia package (e.g. Debian, Ubuntu, Manjaro). While
for Debian and Ubuntu, this can be resolved by installing `libjulia-dev`,
for Manjaro we found no way at all to get it. Regardless, in either case
this is an annoying obstacle for people.

I checked, and julia-config.jl has been unchanged since at least Julia 1.3;
so it should be reasonably safe to include our own copy.

Resolves #623 