### PR TITLE
Replace .tar.bz2 by .tar.gz archive

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2,5 +2,5 @@
 git-tree-sha1 = "848f0f318405266896d24d11e4baf5cf7bf3f203"
 
     [[gap.download]]
-    sha256 = "8bb16ff9fc48c260be38c0953b3321df1d6d42ad1f71e0999d379497cca44c05"
-    url = "https://github.com/oscar-system/GAP.jl/releases/download/v0.3.5/gap-4.11.0.tar.bz2"
+    sha256 = "604f9d7f1c259334f3041060b3e2163efbba44f7dc8760dc4e2d73a31596a209"
+    url = "https://github.com/oscar-system/GAP.jl/releases/download/archive-tag/gap-4.11.0.tar.gz"


### PR DESCRIPTION
Resolves #589

Note that this is just a stop gap measure, we really want a new package archive resp. switch to a minimal set of packages *BUT* for now I want to minimize risk; hence for this PR I simply took the existing .tar.bz2, recompressed it to .tar.gz, and uploaded it to a new tag I made just for this purpose (on an otherwise empty dummy branch). I'll also upload some newer package archives for further experiments.