### PR TITLE
Don't unwrap IS_JULIA_FUNC objects automatically

### DIFF
--- a/pkg/JuliaInterface/gap/JuliaInterface.gi
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gi
@@ -191,8 +191,13 @@ end );
 
 
 InstallGlobalFunction( JuliaTypeInfo,
-    juliaobj -> JuliaToGAP( IsString,
-                    Julia.Base.string( Julia.Core.typeof( juliaobj ) ) ) );
+    function( juliaobj )
+    if IsFunction( juliaobj ) then
+      juliaobj:= Julia.GAP.UnwrapJuliaFunc( juliaobj );
+    fi;
+    return JuliaToGAP( IsString,
+                       Julia.Base.string( Julia.Core.typeof( juliaobj ) ) );
+end );
 
 
 InstallGlobalFunction( JuliaModule,

--- a/pkg/JuliaInterface/gap/calls.gi
+++ b/pkg/JuliaInterface/gap/calls.gi
@@ -26,6 +26,9 @@ InstallGlobalFunction( CallJuliaFunctionWithCatch,
     local res;
 
     args := GAPToJulia( _JL_Vector_Any, args, false );
+    if IsFunction( julia_obj ) then
+      julia_obj:= Julia.GAP.UnwrapJuliaFunc( julia_obj );
+    fi;
     res:= Julia.GAP.call_with_catch( julia_obj, args );
     if res[1] then
       return rec( ok:= true, value:= res[2] );

--- a/pkg/JuliaInterface/src/convert.c
+++ b/pkg/JuliaInterface/src/convert.c
@@ -19,9 +19,6 @@ jl_value_t * julia_gap(Obj obj)
     if (IS_JULIA_OBJ(obj)) {
         return GET_JULIA_OBJ(obj);
     }
-    if (IS_JULIA_FUNC(obj)) {
-        return GET_JULIA_FUNC(obj);
-    }
     if (obj == True) {
         return jl_true;
     }

--- a/pkg/JuliaInterface/tst/convert.tst
+++ b/pkg/JuliaInterface/tst/convert.tst
@@ -183,7 +183,8 @@ gap> JuliaToGAP( IsString, emptystring );
 ""
 
 ##  'GAPToJulia' for Julia functions (inside arrays)
-gap> parse:= JuliaFunction( "parse", "Base" );;
+gap> parse:= JuliaFunction( "parse", "Base" );
+<Julia: parse>
 gap> list:= GAPToJulia( JuliaEvalString( "Array{Any,1}"), [ 1, parse, 3 ] );
 <Julia: Any[1, parse, 3]>
 gap> list2:= JuliaToGAP( IsList, list );

--- a/pkg/JuliaInterface/tst/wrapper.tst
+++ b/pkg/JuliaInterface/tst/wrapper.tst
@@ -18,7 +18,7 @@ Error, MethodError: objects of type BigInt are not callable
 ## wrap a Julia function
 gap> f := Objectify(type, rec());;
 gap> SetJuliaPointer(f, Julia.Base.sqrt);
-gap> Julia.Base.typeof(f);
+gap> Julia.Base.typeof(Julia.GAP.UnwrapJuliaFunc(f));
 <Julia: typeof(sqrt)>
 gap> f(4);
 <Julia: 2.0>

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -12,7 +12,7 @@ function _GAP_TO_JULIA(ptr::Ptr{Cvoid})
     as_int & 1 == 1 && return as_int >> 2
     as_int & 2 == 2 && return reinterpret(FFE, ptr)
     tnum = TNUM_OBJ(ptr)
-    if tnum < FIRST_EXTERNAL_TNUM && tnum != T_FUNCTION
+    if tnum < FIRST_EXTERNAL_TNUM
         if tnum == T_BOOL
             ptr == unsafe_load(cglobal((:GAP_True, libgap), Ptr{Cvoid})) && return true
             ptr == unsafe_load(cglobal((:GAP_False, libgap), Ptr{Cvoid})) && return false

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -403,6 +403,7 @@ function gap_to_julia(x::GapObj; recursive = true)
     Globals.IsMatrixObj(x) && return gap_to_julia(Array{Any,2}, x; recursive = recursive)
     Globals.IsVectorObj(x) && return gap_to_julia(Vector{Any}, x; recursive = recursive)
     Globals.IsRecord(x) && return gap_to_julia(Dict{Symbol,Any}, x; recursive = recursive)
+    Globals.IS_JULIA_FUNC(x) && return UnwrapJuliaFunc(x)
     throw(ConversionError(x, "any known type"))
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -65,6 +65,7 @@ julia> GAP.kwarg_wrapper( range, [ 2 ], Dict( :length => 5, :step => 2 ) )
 ```
 """
 function kwarg_wrapper(func, args::Array{T1,1}, kwargs::Dict{Symbol,T2}) where {T1,T2}
+    func = UnwrapJuliaFunc(func)
     return func(args...; [k => kwargs[k] for k in keys(kwargs)]...)
 end
 


### PR DESCRIPTION
... when moving them to the Julia side.

This way, Julia code can store them and pass them later on to GAP code again,
e.g. as action function for G-set related computations.

This also fits better into our philosophy regarding conversions: the principle
of only doing necessary or "obvious" AND cheap conversions. But this automatic
unwrapping was neither necessary (as long as we provide an explicit unwrap
function on the Julia side), nor necessarily cheap (as discarding the wrapper
meant that one may have to recreate many such wrappers). Moreover, it impeded
the usefulness of these wrappers.

Resolves #629
```
julia> GAP.Globals.JuliaFunction(g"sqrt")
GAP: <Julia: sqrt>
```

TODO:
- add a Julia function for unwrapping a wrapped Julia function
  -  the hardest problem here is to determine what to call it :-) so suggestions welcome
- add a Julia function for testing if a given GAP object is a Julia function (just calling `GAP.Globals.IS_JULIA_FUNC` should be sufficient unless speed is of utmost concern)
- add tests to cover this
- possibly update any relevant documentation, if there is any?