### PR TITLE
added `deepcopy` and `copy` for `GapObj`

### DIFF
--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -296,3 +296,20 @@ function Base.iterate(obj::GapObj, iter::GapObj)
         (x, iter)
     end
 end
+
+# copy and deepcopy:
+# The following is just a preliminary solution,
+# in order to avoid Julia crashes when one calls `deepcopy` for a `GapObj`.
+# Eventually we want to handle also nested objects such as GAP lists of
+# Julia objects having GAP subobjects,
+# see 'https://github.com/oscar-system/GAP.jl/issues/197'.
+Base.copy(obj::GapObj) = GAP.Globals.ShallowCopy(obj)
+
+function Base.deepcopy_internal(obj::GapObj, stackdict::IdDict)
+    if haskey(stackdict, obj)
+        return stackdict[obj]
+    end
+    sc = GAP.Globals.StructuralCopy(obj)
+    stackdict[obj] = sc
+    return sc
+end

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -306,10 +306,7 @@ end
 Base.copy(obj::GapObj) = GAP.Globals.ShallowCopy(obj)
 
 function Base.deepcopy_internal(obj::GapObj, stackdict::IdDict)
-    if haskey(stackdict, obj)
-        return stackdict[obj]
+    return get!(stackdict, obj) do
+        GAP.Globals.StructuralCopy(obj)
     end
-    sc = GAP.Globals.StructuralCopy(obj)
-    stackdict[obj] = sc
-    return sc
 end

--- a/test/adapter.jl
+++ b/test/adapter.jl
@@ -14,3 +14,30 @@
     end
     @test length(xs) == 6
 end
+
+@testset "deepcopy" begin
+    p = GAP.evalstr("(1,2,3)")
+    @test copy(p) === p
+
+    l = GAP.evalstr("[[]]")
+    @test !(copy(l) === l)
+    @test copy(l)[1] === l[1]
+    @test !(deepcopy(l)[1] === l[1])
+
+    l = [p, p]
+    cp = deepcopy(l)
+    @test !(l === cp)
+    @test cp[1] === cp[2]
+
+    # The following is NOT what we want,
+    # eventually we want that `deepcopy` to be applied
+    # also to Julia subobjects of GAP objects.
+    # As soon as this changed behaviour is available,
+    # `deepcopy` for GAP objects should become documented.
+    l = GAP.evalstr("[]")
+    li = [1, 2, 3]
+    l[1] = li
+    cp = deepcopy(l)
+    @test !(deepcopy( li ) === li)
+    @test cp[1] === l[1]
+end


### PR DESCRIPTION
This is the "easy" first step for issue #197.