### PR TITLE
Align banner printing code to other Oscar packages

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -204,8 +204,8 @@ function __init__()
         append!(cmdline_options, ["--nointeract"])
     end
 
-    if haskey(ENV, "GAP_SHOW_BANNER")
-        show_banner = ENV["GAP_SHOW_BANNER"] == "true"
+    if haskey(ENV, "GAP_PRINT_BANNER")
+        show_banner = ENV["GAP_PRINT_BANNER"] == "true"
     else
         show_banner =
             isinteractive() && !any(x -> x.name in ["Oscar"], keys(Base.package_locks))

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -248,7 +248,7 @@ function regenerate_gaproot()
         =#
 
         # pass command line arguments to GAP.jl via a small hack
-        ENV["GAP_SHOW_BANNER"] = "true"
+        ENV["GAP_PRINT_BANNER"] = "true"
         __GAP_ARGS__ = ARGS
         using GAP
 


### PR DESCRIPTION
Rename GAP_SHOW_BANNER to GAP_PRINT_BANNER which matches the names
used in Nemo, Hecke, Singular.