### PR TITLE
support using Julia's random sources in GAP

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -77,7 +77,7 @@ function compute_external_reference(link, meta, page, doc)
     return true
 end
 
-DocMeta.setdocmeta!(GAP, :DocTestSetup, :(using GAP); recursive = true)
+DocMeta.setdocmeta!(GAP, :DocTestSetup, :(using GAP, Random); recursive = true)
 
 makedocs(
     format = Documenter.HTML(),

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -139,6 +139,7 @@ setindex!
 getproperty
 setproperty!
 hasproperty
+wrap_rng
 ```
 
 For the following Julia functions, methods are provided that deal with the

--- a/pkg/JuliaInterface/gap/adapter.gi
+++ b/pkg/JuliaInterface/gap/adapter.gi
@@ -138,8 +138,9 @@ InstallMethod( Init,
     [ "IsRandomSourceJulia", "IsObject" ],
     function( rng, seed )
     ImportJuliaModuleIntoGAP( "Random" );
-    if IsInt( seed ) and 0 <= seed then
-      # This means a prescribed seed.
+    if IsInt( seed ) then
+      # This means a prescribed seed.  (Negative seeds are not supported.)
+      seed:= AbsInt( seed );
       if HasJuliaPointer( rng ) then
         Julia.Random.seed\!( JuliaPointer( rng ), GAPToJulia( seed ) );
       else

--- a/pkg/JuliaInterface/gap/adapter.gi
+++ b/pkg/JuliaInterface/gap/adapter.gi
@@ -139,7 +139,7 @@ InstallMethod( Init,
     function( rng, seed )
     ImportJuliaModuleIntoGAP( "Random" );
     if IsInt( seed ) then
-      # This means a prescribed seed.  (Negative seeds are not supported.)
+      # This means a prescribed seed.
       seed:= AbsInt( seed );
       if HasJuliaPointer( rng ) then
         Julia.Random.seed\!( JuliaPointer( rng ), GAPToJulia( seed ) );
@@ -180,8 +180,9 @@ InstallMethod( Reset,
 
     old:= State( rng );
     ImportJuliaModuleIntoGAP( "Random" );
-    if IsInt( seed ) and 0 <= seed then
+    if IsInt( seed ) then
       # This means a prescribed seed.
+      seed:= AbsInt( seed );
       Julia.Random.seed\!( JuliaPointer( rng ), GAPToJulia( seed ) );
     elif IsJuliaObject( seed ) and
          Julia.Base.isa( seed, Julia.Random.AbstractRNG ) then
@@ -194,10 +195,6 @@ InstallMethod( Reset,
 
     return old;
     end );
-
-InstallMethod( Random,
-    [ "IsRandomSourceJulia and HasJuliaPointer", "IsDenseList" ],
-    { rng, list } -> list[ Random( rng, 1, Length( list ) ) ] );
 
 InstallMethod( Random,
     [ "IsRandomSourceJulia and HasJuliaPointer", "IsInt and IsSmallIntRep",

--- a/pkg/JuliaInterface/gap/adapter.gi
+++ b/pkg/JuliaInterface/gap/adapter.gi
@@ -121,36 +121,90 @@ InstallOtherMethod( \.\:\=,
 ##
 ##  Create random numbers via Julia random number generators.
 ##
-##  The following filter is currently used mainly for printing the object.
-##  (We could use it as the first argument in a `RandomSource` method,
-##  but this would not really fit to the meaning of this operation;
-##  `RandomSource` could be turned into a constructor.)
-##
-DeclareCategory( "IsRandomSourceJulia", IsRandomSource );
+BindGlobal( "RandomSourceJulia",
+    rng -> RandomSource( IsRandomSourceJulia, rng ) );
 
-InstallGlobalFunction( "RandomSourceJulia",
-    function( julia_rng... )
-    if Length( julia_rng ) = 0 then
-      ImportJuliaModuleIntoGAP( "Random" );
-      julia_rng:= [ Julia.Random.default_rng() ];
+InstallMethod( State,
+    [ "IsRandomSourceJulia and HasJuliaPointer" ],
+    rng -> Julia.Base.copy( JuliaPointer( rng ) ) );
+
+# If the 'JuliaPointer' value is already set then we want to reset
+# an already initialized random source.
+# Then the pair given by 'rng' and its 'JuliaPointer' value may be cached
+# in the Julia session.
+# Thus we cannot replace the 'JuliaPointer' value by a copy.
+# Instead we change the value in place.
+InstallMethod( Init,
+    [ "IsRandomSourceJulia", "IsObject" ],
+    function( rng, seed )
+    ImportJuliaModuleIntoGAP( "Random" );
+    if IsInt( seed ) and 0 <= seed then
+      # This means a prescribed seed.
+      if HasJuliaPointer( rng ) then
+        Julia.Random.seed\!( JuliaPointer( rng ), GAPToJulia( seed ) );
+      else
+        SetFilterObj( rng, IsAttributeStoringRep );
+        # We did not get a Julia rng, thus we create one by taking
+        # a copy of the default one and then initializing it.
+        SetJuliaPointer( rng,
+            Julia.Random.seed\!( Julia.Base.copy( Julia.Random.default_rng() ),
+                                 GAPToJulia( seed ) ) );
+      fi;
+    elif IsJuliaObject( seed ) and
+         Julia.Base.isa( seed, Julia.Random.AbstractRNG ) then
+      # This means a prescribed state.
+      if HasJuliaPointer( rng ) then
+        Julia.Base.copy\!( JuliaPointer( rng ), seed );
+      else
+        SetFilterObj( rng, IsAttributeStoringRep );
+        # Here we do *not* copy the given Julia rng,
+        # in order to use exactly this rng.
+        SetJuliaPointer( rng, seed );
+      fi;
+    else
+      Error( "<seed> must be a nonnegative integer ",
+             "or a Julia random number generator" );
     fi;
-    return ObjectifyWithAttributes( rec(),
-               NewType( RandomSourcesFamily,
-                        IsRandomSourceJulia and IsAttributeStoringRep ),
-               JuliaPointer, julia_rng[1] );
+    return rng;
     end );
 
-InstallOtherMethod( Random,
+# The pair given by 'rng' and its 'JuliaPointer' value may be cached
+# in the Julia session.
+# Thus we cannot replace the 'JuliaPointer' value by a copy.
+# Instead we change the value in place.
+InstallMethod( Reset,
+    [ "IsRandomSourceJulia and HasJuliaPointer", "IsObject" ],
+    function( rng, seed )
+    local old;
+
+    old:= State( rng );
+    ImportJuliaModuleIntoGAP( "Random" );
+    if IsInt( seed ) and 0 <= seed then
+      # This means a prescribed seed.
+      Julia.Random.seed\!( JuliaPointer( rng ), GAPToJulia( seed ) );
+    elif IsJuliaObject( seed ) and
+         Julia.Base.isa( seed, Julia.Random.AbstractRNG ) then
+      # This means a prescribed state.
+      Julia.Base.copy\!( JuliaPointer( rng ), seed );
+    else
+      Error( "<seed> must be a nonnegative integer ",
+             "or a Julia random number generator" );
+    fi;
+
+    return old;
+    end );
+
+InstallMethod( Random,
     [ "IsRandomSourceJulia and HasJuliaPointer", "IsDenseList" ],
     { rng, list } -> list[ Random( rng, 1, Length( list ) ) ] );
 
-InstallOtherMethod( Random,
+InstallMethod( Random,
     [ "IsRandomSourceJulia and HasJuliaPointer", "IsInt and IsSmallIntRep",
       "IsInt and IsSmallIntRep" ],
     { rng, from, to } -> Julia.Base.rand( JuliaPointer( rng ),
                              Julia.Base.UnitRange( from, to ) ) );
 
-InstallOtherMethod( Random,
+InstallMethod( Random,
     [ "IsRandomSourceJulia and HasJuliaPointer", "IsInt", "IsInt" ],
     { rng, from, to } -> JuliaToGAP( IsInt,
         Julia.Base.rand( JuliaPointer( rng ),

--- a/pkg/JuliaInterface/gap/convert.gd
+++ b/pkg/JuliaInterface/gap/convert.gd
@@ -464,6 +464,42 @@ DeclareConstructor("JuliaToGAP", [IsObject, IsObject, IsBool]);
 #!</Example>
 DeclareGlobalFunction("GAPToJulia");
 
+#! @Section Using &Julia; random number generators in &GAP;
+#! @Arguments [julia_rng]
+#! @Description
+#!  Called with a &Julia; random number generator <A>julia_rng</A>,
+#!  this function returns a random source
+#!  (see <Ref Sect="Random Sources" BookName="ref"/>)
+#!  that uses <A>julia_rng</A> for creating the random numbers.
+#!  <P/>
+#!  Called without arguments, a &GAP; random source is constructed that
+#!  uses &Julia;'s default random number generator
+#!  <C>Julia.Random.default_rng()</C>.
+#!  Note that different calls without arguments yield different random
+#!  sources.
+#! @BeginExampleSession
+#! gap> rs1:= RandomSourceJulia();
+#! <RandomSource in IsRandomSourceJulia>
+#! gap> rs2:= RandomSourceJulia( Julia.Random.default_rng() );
+#! <RandomSource in IsRandomSourceJulia>
+#! gap> IsIdenticalObj( JuliaPointer( rs1 ), JuliaPointer( rs2 ) );
+#! false
+#! gap> repeat
+#! >   x:= Random( rs1, [ 1 .. 100 ] );
+#! >   y:= Random( rs2, [ 1 .. 100 ] );
+#! > until x <> y;
+#! gap> Random( rs1, 1, 100 ) in [ 1 .. 100 ];
+#! true
+#! gap> from:= 2^70;;  to:= from + 100;;
+#! gap> x:= Random( rs1, from, to );;
+#! gap> from <= x and x <= to;
+#! true
+#! gap> g:= SymmetricGroup( 10 );;
+#! gap> Random( rs1, g ) in g;
+#! true
+#! @EndExampleSession
+DeclareGlobalFunction( "RandomSourceJulia" );
+
 #! @Section Open items
 #! <List>
 #! <Item>

--- a/pkg/JuliaInterface/gap/convert.gd
+++ b/pkg/JuliaInterface/gap/convert.gd
@@ -465,25 +465,41 @@ DeclareConstructor("JuliaToGAP", [IsObject, IsObject, IsBool]);
 DeclareGlobalFunction("GAPToJulia");
 
 #! @Section Using &Julia; random number generators in &GAP;
-#! @Arguments [julia_rng]
+#! @Arguments obj
 #! @Description
-#!  Called with a &Julia; random number generator <A>julia_rng</A>,
-#!  this function returns a random source
-#!  (see <Ref Sect="Random Sources" BookName="ref"/>)
-#!  that uses <A>julia_rng</A> for creating the random numbers.
+#!  This filter allows one to use &Julia;'s random number generators in &GAP;,
+#!  see <Ref Sect="Random Sources" BookName="ref"/> for the background.
+#!  Calling <Ref Oper="RandomSource" BookName="ref"/> with only argument
+#!  <Ref Filt="IsRandomSourceJulia" Label="for IsRandomSource"/> yields a
+#!  &GAP; random source that uses a copy of &Julia;'s default random number
+#!  generator <C>Julia.Random.default_rng()</C>.
+#!  Note that different calls with only argument
+#!  <Ref Filt="IsRandomSourceJulia" Label="for IsRandomSource"/> yield
+#!  different random sources.
 #!  <P/>
-#!  Called without arguments, a &GAP; random source is constructed that
-#!  uses &Julia;'s default random number generator
-#!  <C>Julia.Random.default_rng()</C>.
-#!  Note that different calls without arguments yield different random
-#!  sources.
+#!  Called with <Ref Filt="IsRandomSourceJulia" Label="for IsRandomSource"/>
+#!  and a positive integer,
+#!  <Ref Oper="RandomSource" BookName="ref"/> returns a random source that is
+#!  based on a copy of <C>Julia.Random.default_rng()</C> but got initialized
+#!  with the given integer as a seed.
+#!  <P/>
+#!  Called with <Ref Filt="IsRandomSourceJulia" Label="for IsRandomSource"/>
+#!  and a &Julia; random number generator,
+#!  <Ref Oper="RandomSource" BookName="ref"/> returns a random source
+#!  that uses this random number generator.
+#!  Note that we do <E>not</E> make a copy of the second argument,
+#!  in order to be able to use the given random number generator both on the
+#!  &GAP; side and the &Julia; side.
+#!  <P/>
+#!  <Ref Oper="State" BookName="ref"/> for random sources in
+#!  <Ref Filt="IsRandomSourceJulia" Label="for IsRandomSource"/> returns
+#!  a copy of the underlying &Julia; random number generator.
 #! @BeginExampleSession
-#! gap> rs1:= RandomSourceJulia();
+#! gap> rs1:= RandomSource( IsRandomSourceJulia );
 #! <RandomSource in IsRandomSourceJulia>
-#! gap> rs2:= RandomSourceJulia( Julia.Random.default_rng() );
+#! gap> rs2:= RandomSource( IsRandomSourceJulia,
+#! >                        Julia.Random.default_rng() );
 #! <RandomSource in IsRandomSourceJulia>
-#! gap> IsIdenticalObj( JuliaPointer( rs1 ), JuliaPointer( rs2 ) );
-#! false
 #! gap> repeat
 #! >   x:= Random( rs1, [ 1 .. 100 ] );
 #! >   y:= Random( rs2, [ 1 .. 100 ] );
@@ -497,8 +513,10 @@ DeclareGlobalFunction("GAPToJulia");
 #! gap> g:= SymmetricGroup( 10 );;
 #! gap> Random( rs1, g ) in g;
 #! true
+#! gap> State( rs1 ) = JuliaPointer( rs1 );
+#! true
 #! @EndExampleSession
-DeclareGlobalFunction( "RandomSourceJulia" );
+DeclareCategory( "IsRandomSourceJulia", IsRandomSource );
 
 #! @Section Open items
 #! <List>

--- a/pkg/JuliaInterface/tst/adapter.tst
+++ b/pkg/JuliaInterface/tst/adapter.tst
@@ -201,9 +201,9 @@ gap> ForAll( [ 1 .. 100 ], i -> Random( rs, G ) = Random( rs2, G ) );
 true
 
 # possible errors
-gap> RandomSource( IsRandomSourceJulia, -1 );
+gap> RandomSource( IsRandomSourceJulia, "random" );
 Error, <seed> must be a nonnegative integer or a Julia random number generator
-gap> Reset( rs, -1 );;
+gap> Reset( rs, "random" );;
 Error, <seed> must be a nonnegative integer or a Julia random number generator
 
 #

--- a/test/doctest.jl
+++ b/test/doctest.jl
@@ -1,5 +1,5 @@
 using Documenter, GAP
 
-DocMeta.setdocmeta!(GAP, :DocTestSetup, :(using GAP); recursive = true)
+DocMeta.setdocmeta!(GAP, :DocTestSetup, :(using GAP, Random); recursive = true)
 
 doctest(GAP; doctestfilters = GAP.GAP_doctestfilters)


### PR DESCRIPTION
- `GAP.wrap_rng` creates a GAP random source that uses the given Julia rng
- cache the pairs of Julia/GAP random sources in a dictionary
- on the GAP side, provide `State`, `Reset`, `Init` methods as specified by the GAP documentation

an open question:

- Why is there no `WeakKeyIdDict` in Julia?
  (Perhaps @rfourquet knows about the background.)
  ~~I think it would be enough to store an `IdDict` in the field `ht` of a `WeakKeyDict`, but one can do better than duplicate `base/weakkeydict.jl`.~~
  No, the situation seems to be more tricky ...)
