### PR TITLE
new macro @gapattribute

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -50,6 +50,7 @@ GapObj
 @gap
 @g_str
 @gapwrap
+@gapattribute
 ```
 
 ## Conversions


### PR DESCRIPTION
This is intended to address oscar-system/Oscar.jl/issues/128. ~~but it does not work as expected~~
~~Apparently something is wrong with the code: When I try to call the macro inside an Oscar source file then Julia crashes with a segmentation fault.~~

~~However, the following works.~~
Here is an example how to use the new macro.

1. Create a file `testmodule.jl` with a Julia module that calls the macro in the way we want to use it.
```
module enclose
  
import GAP
import Oscar
GAP.@gapattribute isfinite(G::Oscar.GAPGroup) = GAP.Globals.IsFinite(G.X)
GAP.@gapattribute issolvable(G::Oscar.GAPGroup) = GAP.Globals.IsSolvableGroup(G.X)
end # module
```
2. Use the functions created by the macro.
```
julia> using Oscar
[...]

julia> include( "testmodule.jl" )
Main.enclose

julia> g = symmetric_group(5);

julia> Main.enclose.hasissolvable(g)
false

julia> Main.enclose.issolvable(g)
false

julia> Main.enclose.hasissolvable(g)
true

julia> g = symmetric_group(5);

julia> Main.enclose.hasissolvable(g)
false

julia> Main.enclose.setissolvable(g, false)

julia> Main.enclose.hasissolvable(g)
true
```
