### PR TITLE
ccall: explicitly state the source of each symbol we call

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -48,14 +48,9 @@ end
 # The following hack is needed only in Julia 1.3, not in later versions.
 error_handlerwrap() = Base.invokelatest(error_handler)
 
-# This will be filled out by __init__(), as it must be done at runtime
-JuliaInterface_path = ""
-
-# This will be filled out by __init__()
-JuliaInterface_handle = C_NULL
-
 # This must be `const` so that we can use it with `ccall()`
 const JuliaInterface = "JuliaInterface.so"
+const JuliaInterface_path = normpath(joinpath(@__DIR__, "..", "pkg", "JuliaInterface", "bin", sysinfo["GAParch"], JuliaInterface))
 
 function initialize(argv::Array{String,1})
     handle_signals = isdefined(Main, :__GAP_ARGS__)  # a bit of a hack...
@@ -158,11 +153,6 @@ function initialize(argv::Array{String,1})
         ccall((:SyInstallAnswerIntr, libgap), Cvoid, ())
         return
     end
-
-    # open JuliaInterface.so, too
-    #global JuliaInterface_path = CSTR_STRING(EvalString("""Filename(DirectoriesPackagePrograms("JuliaInterface"), "JuliaInterface.so");"""))
-    global JuliaInterface_path = normpath(joinpath(@__DIR__, "..", "pkg", "JuliaInterface", "bin", sysinfo["GAParch"], JuliaInterface))
-    global JuliaInterface_handle = Libdl.dlopen(JuliaInterface_path)
 
     # Redirect error messages, in order not to print them to the screen.
     Base.invokelatest(reset_GAP_ERROR_OUTPUT)

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -19,13 +19,13 @@ function _GAP_TO_JULIA(ptr::Ptr{Cvoid})
         end
         return unsafe_pointer_to_objref(ptr)
     end
-    return ccall(:julia_gap, Any, (Ptr{Cvoid},), ptr)
+    return ccall((:julia_gap, JuliaInterface_path), Any, (Ptr{Cvoid},), ptr)
 end
 
 #
 # low-level Julia -> GAP conversion
 #
-_JULIA_TO_GAP(val::Any) = ccall(:gap_julia, Ptr{Cvoid}, (Any,), val)
+_JULIA_TO_GAP(val::Any) = ccall((:gap_julia, JuliaInterface_path), Ptr{Cvoid}, (Any,), val)
 #_JULIA_TO_GAP(x::Bool) = x ? gap_true : gap_false
 _JULIA_TO_GAP(x::FFE) = reinterpret(Ptr{Cvoid}, x)
 _JULIA_TO_GAP(x::GapObj) = pointer_from_objref(x)
@@ -133,9 +133,9 @@ NEW_MACFLOAT(x::Float64) = ccall((:NEW_MACFLOAT, libgap), GapObj, (Cdouble,), x)
 ValueMacFloat(x::GapObj) = ccall((:GAP_ValueMacFloat, libgap), Cdouble, (Any,), x)
 CharWithValue(x::Cuchar) = ccall((:GAP_CharWithValue, libgap), GapObj, (Cuchar,), x)
 
-WrapJuliaFunc(x::Function) = ccall(:WrapJuliaFunc, GapObj, (Any,), x)
+WrapJuliaFunc(x::Function) = ccall((:WrapJuliaFunc, JuliaInterface_path), GapObj, (Any,), x)
 UnwrapJuliaFunc(x::Function) = x
-UnwrapJuliaFunc(x::GapObj) = ccall(:GET_JULIA_FUNC, Function, (GapObj,), x)
+UnwrapJuliaFunc(x::GapObj) = ccall((:GET_JULIA_FUNC, JuliaInterface_path), Function, (GapObj,), x)
 
 function ElmList(x::GapObj, position)
     o = ccall((:GAP_ElmList, libgap), Ptr{Cvoid}, (Any, Culong), x, Culong(position))
@@ -187,7 +187,7 @@ function call_gap_func(func::GapObj, args...; kwargs...)
         if TNUM_OBJ(func) == T_FUNCTION && length(args) <= 6
             result = _call_gap_func(func, args...)
         else
-            result = ccall(:call_gap_func, Any, (Any, Any), func, args)
+            result = ccall((:call_gap_func, JuliaInterface_path), Any, (Any, Any), func, args)
         end
         if options
             Globals.PopOptions()
@@ -206,7 +206,7 @@ function call_gap_func_nokw(func::GapObj, args...)
     if TNUM_OBJ(func) == T_FUNCTION && length(args) <= 6
         _call_gap_func(func, args...)
     else
-        ccall(:call_gap_func, Any, (Any, Any), func, args)
+        ccall((:call_gap_func, JuliaInterface_path), Any, (Any, Any), func, args)
     end
 end
 

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -103,13 +103,13 @@ function gap_to_julia(::Type{BigInt}, x::GapObj)
     Globals.IsInt(x) || throw(ConversionError(x, BigInt))
     ## get size of GAP BigInt (in limbs), multiply
     ## by 64 to get bits
-    size_limbs = ccall(:GAP_SizeInt, Cint, (Any,), x)
+    size_limbs = ccall((:GAP_SizeInt, libgap), Cint, (Any,), x)
     size = abs(size_limbs * sizeof(UInt) * 8)
     ## allocate new GMP
     new_bigint = Base.GMP.MPZ.realloc2(size)
     new_bigint.size = size_limbs
     ## Get limb address ptr
-    addr = ccall(:GAP_AddrInt, Ptr{UInt}, (Any,), x)
+    addr = ccall((:GAP_AddrInt, libgap), Ptr{UInt}, (Any,), x)
     ## Copy limbs
     unsafe_copyto!(new_bigint.d, addr, abs(size_limbs))
     return new_bigint

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -53,7 +53,7 @@ julia_to_gap(x::UInt8) = Int64(x)
 ## BigInts are converted via a ccall
 function julia_to_gap(x::BigInt)
     x in -1<<60:(1<<60-1) && return Int64(x)
-    return GC.@preserve x ccall(:MakeObjInt, GapObj, (Ptr{UInt64}, Cint), x.d, x.size)
+    return GC.@preserve x ccall((:MakeObjInt, libgap), GapObj, (Ptr{UInt64}, Cint), x.d, x.size)
 end
 
 ## Rationals


### PR DESCRIPTION
This prevents a class of bugs, and also prepares us for GAP 4.12,
which opens loadable modules with `RTLD_LOCAL`, so the old code
doesn't work with that anymore (because the symbols from JuliaInterface
aren't found anymore)
