### PR TITLE
changed the definition of `UnwrapJuliaFunc`

### DIFF
--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -133,8 +133,25 @@ NEW_MACFLOAT(x::Float64) = ccall((:NEW_MACFLOAT, libgap), GapObj, (Cdouble,), x)
 ValueMacFloat(x::GapObj) = ccall((:GAP_ValueMacFloat, libgap), Cdouble, (Any,), x)
 CharWithValue(x::Cuchar) = ccall((:GAP_CharWithValue, libgap), GapObj, (Cuchar,), x)
 
+# `WrapJuliaFunc` and `UnwrapJuliaFunc` are intended to create a GAP function
+# object that wraps a given Julia function, and to unwrap such a GAP function,
+# respectively.
+# Note that we do not *automatically* wrap Julia functions into GAP functions
+# when they are accessed from the GAP side,
+# and do not automatically unwrap Julia functions that are wrapped into
+# GAP functions when they are accessed from the GAP side.
+# For convenience, also non-`Function` Julia objects can be passed to
+# `WrapJuliaFunc`, which then returns the input;
+# the idea is that many callable Julia objects aren't `Function`s
+# (and in general also aren't `Base.Callable`s),
+# and that these objects can be called on the GAP side like functions.
+# Thus the result of `WrapJuliaFunc` for a callable object is something
+# that can be called on the GAP side.
+# In the other direction, `UnwrapJuliaFunc` extracts the underlying Julia
+# function from its argument if applicable, and otherwise returns the input.
+WrapJuliaFunc(x::Any) = x
 WrapJuliaFunc(x::Function) = ccall((:WrapJuliaFunc, JuliaInterface_path), GapObj, (Any,), x)
-UnwrapJuliaFunc(x::Any) = x  # Note that callable Julia objects (for which `UnwrapJuliaFunc` is likely to be applied) need not have the type `Function`.
+UnwrapJuliaFunc(x::Any) = x
 UnwrapJuliaFunc(x::GapObj) = ccall((:UnwrapJuliaFunc, JuliaInterface_path), Function, (GapObj,), x)
 
 function ElmList(x::GapObj, position)

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -134,7 +134,7 @@ ValueMacFloat(x::GapObj) = ccall((:GAP_ValueMacFloat, libgap), Cdouble, (Any,), 
 CharWithValue(x::Cuchar) = ccall((:GAP_CharWithValue, libgap), GapObj, (Cuchar,), x)
 
 WrapJuliaFunc(x::Function) = ccall((:WrapJuliaFunc, JuliaInterface_path), GapObj, (Any,), x)
-UnwrapJuliaFunc(x::Function) = x
+UnwrapJuliaFunc(x::Any) = x  # Note that callable Julia objects (for which `UnwrapJuliaFunc` is likely to be applied) need not have the type `Function`.
 UnwrapJuliaFunc(x::GapObj) = ccall((:UnwrapJuliaFunc, JuliaInterface_path), Function, (GapObj,), x)
 
 function ElmList(x::GapObj, position)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -438,10 +438,22 @@ end
 end
 
 @testset "(Un)WrapJuliaFunc" begin
+    # wrap a Julia function
     f = x -> x^2
     g = GAP.WrapJuliaFunc(f)
     @test g isa GapObj
     @test GAP.TNUM_OBJ(g) == GAP.T_FUNCTION
     @test g(2) == 4
     @test GAP.UnwrapJuliaFunc(g) === f
+
+    # "wrap" a callable Julia object that is not a function
+    struct Callable data::Int end
+    (obj::Callable)() = obj.data
+    x = Callable(17)
+    @test x() == 17
+    @test !(x isa Function)
+    @test !(x isa Base.Callable)
+    wx = GAP.WrapJuliaFunc(x)
+    @test x === GAP.UnwrapJuliaFunc(wx)
+    @test GAP.Globals.CallFuncList(wx, GAP.evalstr("[]")) == x()
 end


### PR DESCRIPTION
Up to now, we defined `UnwrapJuliaFunc(x::Function) = x` and then
added a method for `GapObj`.
This is not good enough, since there are callable Julia objects
which do not have the type `Function`.

Concretely:
`Polymake.polytope.Polytope` is a callable Julia object
which is not a `Function` and which admits keyword arguments.
When we call it from GAP via `CallJuliaFunctionWithKeywordArguments`,
we get an error with the old version.