### PR TITLE
`GapObj` now prints itself as `GapObj`

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -229,6 +229,10 @@ function __init__()
             ),
         )
     end
+
+    # hack: Let `GAP_jll.MPtr` print itself as `GAP.GapObj`.
+    GAP_jll.MPtr.name.module = GAP
+    GAP_jll.MPtr.name.name = :GapObj
 end
 
 """

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -229,10 +229,6 @@ function __init__()
             ),
         )
     end
-
-    # hack: Let `GAP_jll.MPtr` print itself as `GAP.GapObj`.
-    GAP_jll.MPtr.name.module = GAP
-    GAP_jll.MPtr.name.name = :GapObj
 end
 
 """

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -18,6 +18,22 @@ function show_string(io::IO, obj::Union{GapObj,FFE})
     return stri
 end
 
+# Show `GapObj` as `GAP.GapObj` or `GapObj` not as `GAP_jll.MPtr`.
+# Use the same criteria as (the currently undocumented) `show_type_name`
+function Base.show(io::IO, ::Type{GapObj})
+    if !get(io, :compact, false)
+        # Print module prefix unless type is visible from module passed to
+        # IOContext If :module is not set, default to Main. nothing can be used
+        # to force printing prefix
+        from = get(io, :module, Main)
+        if from === nothing || !Base.isvisible(:GapObj, GAP, from)
+            show(io, GAP)
+            print(io, ".")
+        end
+    end
+    print(io, "GapObj")
+end
+
 function Base.show(io::IO, obj::Union{GapObj,FFE})
     stri = show_string(io, obj)
     print(io, "GAP: $stri")

--- a/src/types.jl
+++ b/src/types.jl
@@ -76,17 +76,6 @@ julia> GapObj([1 2; 3 4])
 GAP: [ [ 1, 2 ], [ 3, 4 ] ]
 
 ```
-
-For technical reasons, `GapObj` is created inside the Julia module `GAP_jll`,
-before the module `GAP` gets loaded.
-Thus Julia prints it as `GAP_jll.MPtr`.
-
-# Examples
-```jldoctest
-julia> GapObj
-GAP_jll.MPtr
-
-```
 """
 const GapObj = GAP_jll.MPtr
 

--- a/test/adapter.jl
+++ b/test/adapter.jl
@@ -41,3 +41,7 @@ end
     @test !(deepcopy( li ) === li)
     @test cp[1] === l[1]
 end
+
+@testset "GapObj" begin
+    @test string(GAP.GapObj) == "GapObj"
+end

--- a/test/adapter.jl
+++ b/test/adapter.jl
@@ -43,5 +43,10 @@ end
 end
 
 @testset "GapObj" begin
-    @test string(GAP.GapObj) == "GapObj"
+    io = IOBuffer();
+    print(io, GAP.GapObj)
+    @test String(take!(io)) == "GapObj"
+    ioc = IOContext(io, :module => nothing);
+    print(ioc, GAP.GapObj)
+    @test String(take!(io)) == "GAP.GapObj"
 end


### PR DESCRIPTION
This addresses issue #660.
It is an ugly hack, and I do not know whether it will have unwanted side-effects.