### PR TITLE
Revise how we handle GAP errors.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,8 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-GAP_jll = "~400.1190.4"
-GAP_lib_jll = "~400.1190.4"
+GAP_jll = "~400.1190.100"
+GAP_lib_jll = "~400.1190.100"
 MacroTools = "0.5"
 julia = "1.3"
 

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -68,11 +68,18 @@ GAP: [ 1 ]
 """
 function evalstr(cmd::String)
     res = evalstr_ex(cmd * ";")
-    res = res[end]
-    if res[1] == false
+    if any(x->x[1] == false, res)
       # error
-      GAP.error_handler()
-    elseif Globals.ISB_LIST(res, 2)
+      global last_error
+      # HACK HACK HACK: if there is an error string on the GAP side, call
+      # error_handler to copy it into `last_error`
+      if !GAP.Globals.IsEmpty(GAP.Globals._JULIAINTERFACE_ERROR_OUTPUT)
+        error_handler()
+      end
+      error("Error thrown by GAP: $(last_error[])")
+    end
+    res = res[end]
+    if Globals.ISB_LIST(res, 2)
       return res[2]
     else
       return

--- a/src/prompt.jl
+++ b/src/prompt.jl
@@ -15,8 +15,6 @@ This GAP prompt allows to quickly switch between writing Julia and GAP code in
 a session where all data is shared.
 """
 function prompt()
-    global disable_error_handler
-
     # save the current SIGINT handler
     # (we pass NULL as signal handler; strictly speaking, we should be passing `SIG_DFL`
     # but it's not clearly how to access this from here, and anyway on the list
@@ -27,7 +25,6 @@ function prompt()
     ccall((:SyInstallAnswerIntr, libgap), Cvoid, ())
 
     # restore GAP's error output
-    disable_error_handler = true
     Globals.MakeReadWriteGlobal(GapObj("ERROR_OUTPUT"))
     evalstr("""ERROR_OUTPUT:= "*errout*";""")
     Globals.MakeReadOnlyGlobal(GapObj("ERROR_OUTPUT"))
@@ -44,7 +41,6 @@ function prompt()
     # restore signal handler
     ccall(:signal, Ptr{Cvoid}, (Cint, Ptr{Cvoid}), Base.SIGINT, old_sigint)
 
-    # restore GAP error handler
-    disable_error_handler = false
+    # restore GAP.jl error handler
     reset_GAP_ERROR_OUTPUT()
 end


### PR DESCRIPTION
Previously, we threw a Julia exception in the `error_handler` function,
which is called by GAP's `JUMP_TO_CATCH`, which in turn is invoked by
GAP's `ErrorInner`.

The problem with that is that by throwing a Julia exception, we aborted the
GAP exception handling prematurely. As a result, any surrounding `GAP_CATCH`
blocks had no chance to run. This had primarily two noticeable effects:

1. Input/output redirection set up by surrounding GAP code via `OpenInput`,
   `OpenInputStream`, `OpenOutput`, `OpenOutputStream` was not reverted.

2. The pointer GAP uses to keep track of which code is currently being
   executed ("LVars") was not reset.

Effect 2 could be counteracted by calling `SWITCH_TO_BOTTOM_LVARS`.

Effect 1 in past GAP versions mostly lead to some output which was not showing
up, see <https://github.com/oscar-system/GAP.jl/issues/516>. With the current
GAP kernel code, though, the "stack of outputs" was changed into a "linked
list of outputs", with most outputs residing on the execution stack. As a
result, failing to close outputs now can lead to crashes or general weirdness.

To fix this, we need to let GAP follow its sequence of exception handlers, and
only throw a Julia exception at the very end. The standard way to do this is
to surround any calls into the GAP kernel by `GAP_TRY` and `GAP_CATCH`. But
the way these C macros work would mean that we couldn't simply use `ccall`
anymore. We'd have to add tons of wrapper functions. Plus, we'd loose
performance even in the common case were no exception is generated.

So instead, I modified the GAP kernel to track how many nested `GAP_TRY` there
are, and pass this value to the callback already present in `GAP_THROW`. We
now install such a callback in `GAP.jl` in addition to the `JUMP_TO_CATCH`
callback: the latter now only records the error message in a global variable,
and then returns (i.e., it doesn't throw an exception anymore). The
`ThrowObserver` callback then throws the actual exception using this error
messages. This is done in PR <https://github.com/gap-system/gap/pull/4617>.

All this together almost fixes "everything", except some GAP kernel code
failed to use `GAP_TRY` / `GAP_CATCH` and thus sometimes failed to clean
up its input/output stream overrides, even with our tricks. This is fixed
in PR <https://github.com/gap-system/gap/pull/4616>.

Of course to test all this, I also had to write scripts which makes it
"easy enough" to test a custom GAP build inside of GAP.jl; the result is
in PR <https://github.com/oscar-system/GAP.jl/pull/667>.

The final patch here is very small in the end; the difficult part was getting
there. Oh, and lots of time waiting for configure scripts, C compilers, Julia
precompatilation and more, cf. <https://xkcd.com/303/>.

----

This PR requires a new `GAP_jll`, so first the GAP PRs linked above need to
be merged, then <https://github.com/JuliaPackaging/Yggdrasil/pull/3316>
updated, then `Project.toml` here updated.