### PR TITLE
Fix `GAP.prompt()`

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -36,12 +36,23 @@ end
 
 const last_error = Ref{String}("")
 
+disable_error_handler = false
+
 function error_handler()
+    global disable_error_handler
+    if disable_error_handler
+        return
+    end
     last_error[] = String(Globals._JULIAINTERFACE_ERROR_OUTPUT)
     ccall((:SET_LEN_STRING, libgap), Cvoid, (GapObj, Cuint), Globals._JULIAINTERFACE_ERROR_OUTPUT, 0)
 end
 
 function ThrowObserver(depth::Cint)
+    global disable_error_handler
+    if disable_error_handler
+        return
+    end
+
     # signal to the GAP interpreter that errors are handled
     ccall((:ClearError, libgap), Cvoid, ())
     # reset global execution context

--- a/src/prompt.jl
+++ b/src/prompt.jl
@@ -15,6 +15,8 @@ This GAP prompt allows to quickly switch between writing Julia and GAP code in
 a session where all data is shared.
 """
 function prompt()
+    global disable_error_handler
+
     # save the current SIGINT handler
     # (we pass NULL as signal handler; strictly speaking, we should be passing `SIG_DFL`
     # but it's not clearly how to access this from here, and anyway on the list
@@ -25,6 +27,7 @@ function prompt()
     ccall((:SyInstallAnswerIntr, libgap), Cvoid, ())
 
     # restore GAP's error output
+    disable_error_handler = true
     Globals.MakeReadWriteGlobal(GapObj("ERROR_OUTPUT"))
     evalstr("""ERROR_OUTPUT:= "*errout*";""")
     Globals.MakeReadOnlyGlobal(GapObj("ERROR_OUTPUT"))
@@ -42,5 +45,6 @@ function prompt()
     ccall(:signal, Ptr{Cvoid}, (Cint, Ptr{Cvoid}), Base.SIGINT, old_sigint)
 
     # restore GAP.jl error handler
+    disable_error_handler = false
     reset_GAP_ERROR_OUTPUT()
 end


### PR DESCRIPTION
The revised error handling broke error handling inside of `GAP.prompt()`.
I noticed when I tried this, from issue #528:

    julia> GAP.prompt()
    gap> AlwaysPrintTracebackOnError:= true;;
    gap> Test( Filename( DirectoriesLibrary( "tst" ), "testinstall/zmodnz.tst" ) );

... which aborted the GAP prompt mode. Trying to re-enter it resulted
in a hanging Julia (not even Ctrl-C worked).
