### PR TITLE
regenerate_gaproot: remove Pkg.resolve

### DIFF
--- a/src/setup.jl
+++ b/src/setup.jl
@@ -249,7 +249,7 @@ function regenerate_gaproot(gaproot_mutable)
         @info "Generating custom Julia project ..."
         relative_pkgdir = joinpath("..", "..")
         @assert abspath(gaproot_mutable, relative_pkgdir) == gaproot_gapjl
-        run(pipeline(`$(Base.julia_cmd()) --startup-file=no --project=$(gaproot_mutable) -e "using Pkg; Pkg.develop(PackageSpec(path=\"$(relative_pkgdir)\")); Pkg.resolve()"`))
+        run(pipeline(`$(Base.julia_cmd()) --startup-file=no --project=$(gaproot_mutable) -e "using Pkg; Pkg.develop(PackageSpec(path=\"$(relative_pkgdir)\"))"`))
 
     end # cd
 


### PR DESCRIPTION
This seems unnecessary and removing it works around the Pkg.jl problem on nightly.
`Pkg.develop` already resolves all the dependencies.
I think `resolve` would only be necessary when there is an existing manifest that needs to be updated according to changes in the packages tracked via a path, but this gaproot is always fresh and clean when this command is run.

fixes #655