### PR TITLE
Move code generating gap.sh into its own function

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -260,6 +260,7 @@ GAP.Packages.remove
 
 ```@docs
 GAP.prompt
+GAP.create_gap_sh
 ```
 
 


### PR DESCRIPTION
The next step would be to not create gap.sh by default anymore, but instead turn this into a user visible function. Then user's can create any number of `gap.sh` scripts they like, in a place of their choosing (but note that it'll be accompanied by a `Project.toml` and `Manifest.toml` in the same dir; that needs to be documented, too).

See also issue #611

CC @mohamed-barakat 