### PR TITLE
Don't create `gap.sh` anymore and remove `GAP.gap_exe();` instead users can call `GAP.create_gap_sh(path)`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,8 +61,8 @@ jobs:
         run: julia --color=yes -e 'using Pkg ; Pkg.add(["Singular", "Nemo"])'
       - name: "GAP tests"
         run: |
-          gap_sh=$(julia --project=. -e 'import GAP; print(GAP.gap_exe())');
-          export GAP="$gap_sh -A --quitonbreak --norepl"
+          julia --project=. -e 'import GAP; GAP.create_gap_sh("/tmp")'
+          export GAP="/tmp/gap.sh -A --quitonbreak --norepl"
           etc/ci_test.sh
 
       - name: "Process Julia code coverage"
@@ -73,8 +73,7 @@ jobs:
             using GAP
             GAP.Packages.install("profiling", interactive = false) || exit(1)
             '
-          gap_sh=$(julia --project=. -e 'import GAP; print(GAP.gap_exe())');
-          $gap_sh -A --quitonbreak --norepl etc/gather_coverage.g
+          /tmp/gap.sh -A --quitonbreak --norepl etc/gather_coverage.g
           cat gap-lcov.info >> lcov.info
 
       - name: "Upload coverage data to Codecov"
@@ -111,9 +110,9 @@ jobs:
           julia --project=docs --color=yes test/doctest.jl
       - name: "Build GAP manual"
         run: |
-          gap_sh=$(julia --project=. -e 'import GAP; print(GAP.gap_exe())');
+          julia --project=. -e 'import GAP; GAP.create_gap_sh("/tmp")'
           cd pkg/JuliaInterface
-          $gap_sh -A --quitonbreak --norepl makedoc.g
+          /tmp/gap.sh -A --quitonbreak --norepl makedoc.g
           cd ../..
           mkdir -p docs/src/assets/html/JuliaInterface/
           cp pkg/JuliaInterface/doc/*.{html,css,js} docs/src/assets/html/JuliaInterface/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,13 +6,15 @@
 This is the first release of the 0.7.x series. It contains the following breaking
 changes compared to the 0.6.x release:
 
-- `LoadPackageAndExposeGlobals` was removed. If you are using this, see
+- Remove `LoadPackageAndExposeGlobals`. If you are using this, see
   <https://github.com/oscar-system/GAP.jl/pull/696> for alternatives.
 - Remove all `convert` methods. If you were using `convert(GapObj, val)`,
   you can use `GapObj(val)` or `julia_to_gap(val)` instead. If you were
   using `convert(T,gapobj)`, use `T(gapobj)` or `julia_to_gap(gapobj)`
   instead.
-- Remove `IsArgumentForJuliaFunction` from the GAP side.
+- Remove `IsArgumentForJuliaFunction` from the GAP side. There was no
+  actual use case, so hopefully nobody was using it
+- Remove `GAP.gap_exe()`. Instead please use `GAP.create_gap_sh(path)`.
 
 Other changes:
 

--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -77,12 +77,11 @@
 #!  afterwards the package <Package>JuliaInterface</Package> is already
 #!  installed and loaded.
 #!
-#!  Alternatively, one can start &GAP; in the traditional way,
-#!  by executing a shell script.
-#!  Such a script is generated automatically during the installation of
-#!  &GAP; via &Julia;,
-#!  its location is returned in a &Julia; session by
-#!  <Listing Type="Julia">using GAP; GAP.gap_exe()</Listing>
+#!  Alternatively, one can start &GAP; in the traditional way, by executing
+#!  a shell script. Such a script can be created in a location of your choice
+#!  via the following &Julia; command, where <F>dstdir</F> is a directory
+#!  path in which a <F>gap.sh</F> script plus some auxiliary files will be placed:
+#!  <Listing Type="Julia">using GAP; GAP.create_gap_sh(dstdir)</Listing>
 #!
 #!  Note that the <Package>JuliaInterface</Package> code belongs to
 #!  <URL><Link>https://github.com/oscar-system/GAP.jl</Link>

--- a/src/prompt.jl
+++ b/src/prompt.jl
@@ -1,9 +1,3 @@
-function gap_exe()
-    return joinpath(GAPROOT, "bin", "gap.sh")
-end
-
-export gap_exe
-
 """
     prompt()
 

--- a/src/prompt.jl
+++ b/src/prompt.jl
@@ -50,3 +50,24 @@ function prompt()
     Globals.ERROR_OUTPUT = Globals._JULIAINTERFACE_ERROR_OUTPUT
     Globals.MakeReadOnlyGlobal(GapObj("ERROR_OUTPUT"))
 end
+
+# helper function for `gap.sh` scripts created by create_gap_sh()
+function run_session()
+
+    # Read the files from the GAP command line.
+    ccall((:Call0ArgsInNewReader, GAP_jll.libgap), Cvoid, (Any,), Globals.GAPInfo.LoadInitFiles_GAP_JL)
+
+    # GAP.jl forces the norepl option, which means that init.g never
+    # starts a GAP session; we now run one "manually". Note that this
+    # may throw a "GAP exception", which we need to catch; thus we
+    # use Call0ArgsInNewReader to perform the actual call.
+    if !Globals.GAPInfo.CommandLineOptions_original.norepl
+        ccall((:Call0ArgsInNewReader, GAP_jll.libgap), Cvoid, (Any,), Globals.SESSION)
+    end
+
+    # call GAP's "atexit" cleanup functions
+    ccall((:Call0ArgsInNewReader, GAP_jll.libgap), Cvoid, (Any,), Globals.PROGRAM_CLEAN_UP)
+
+    # Finally exit
+    return exit_code()
+end

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -301,7 +301,7 @@ function create_gap_sh(dstdir::String)
         # But you can always instead load this file as if it was a .jl file via any
         # other Julia executable.
         #=
-        exec $(joinpath(Sys.BINDIR, Base.julia_exename())) --startup-file=no --project=$(dstdir) -- "$(gap_sh_path)" "\$@"
+        exec $(joinpath(Sys.BINDIR, Base.julia_exename())) --startup-file=no --project=$(dstdir) -i -- "$(gap_sh_path)" "\$@"
         =#
 
         # pass command line arguments to GAP.jl via a small hack

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -255,11 +255,6 @@ function regenerate_gaproot(gaproot_mutable)
         run(pipeline(`make V=1 -j$(Sys.CPU_THREADS)`, stdout="build.log", append=true))
     end
 
-    ##
-    ## Create custom gap.sh
-    ##
-    create_gap_sh(joinpath(gaproot_mutable, "bin"))
-
     return gaproot_mutable
 end # function
 

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -308,23 +308,7 @@ function create_gap_sh(dstdir::String)
         ENV["GAP_PRINT_BANNER"] = "true"
         __GAP_ARGS__ = ARGS
         using GAP
-
-        # Read the files from the GAP command line.
-        ccall((:Call0ArgsInNewReader, GAP.GAP_jll.libgap), Cvoid, (Any,), GAP.Globals.GAPInfo.LoadInitFiles_GAP_JL)
-
-        # GAP.jl forces the norepl option, which means that init.g never
-        # starts a GAP session; we now run one "manually". Note that this
-        # may throw a "GAP exception", which we need to catch; thus we
-        # use Call0ArgsInNewReader to perform the actual call.
-        if !GAP.Globals.GAPInfo.CommandLineOptions_original.norepl
-            ccall((:Call0ArgsInNewReader, GAP.GAP_jll.libgap), Cvoid, (Any,), GAP.Globals.SESSION)
-        end
-
-        # call GAP's "atexit" cleanup functions
-        ccall((:Call0ArgsInNewReader, GAP.GAP_jll.libgap), Cvoid, (Any,), GAP.Globals.PROGRAM_CLEAN_UP)
-
-        # Finally exit
-        exit(GAP.exit_code())
+        exit(GAP.run_session())
         """,
         )
     chmod(gap_sh_path, 0o755)


### PR DESCRIPTION
This patch stops us from creating a `gap.sh` during precompilation; instead we instruct users to use `create_gap_sh()`. This also means removing `gap_exe()`.

But this is a breaking change for anybody using `gap_exe()` (I suspect @mohamed-barakat is one of these people). So, to allow for a clean transition, first we'll release GAP.jl 0.6.2 with `create_gap_sh` in it, at which point people can convert their code to use that. Then when we release 0.7, we can merge this PR shortly before.

UPDATE: Should also get rid of `src/obsolete.jl` for 0.7.0