### PR TITLE
Fix ImportJuliaModuleIntoGAP if there is no global GAP

### DIFF
--- a/pkg/JuliaInterface/gap/JuliaInterface.gi
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gi
@@ -165,7 +165,7 @@ InstallGlobalFunction( ImportJuliaModuleIntoGAP,
     fi;
 
     current_module := Julia.(name);
-    julia_list_func := JuliaFunction( "get_symbols_in_module", "GAP" );
+    julia_list_func := JuliaFunction( "get_symbols_in_module", "__JULIAGAPMODULE" );
     list := JuliaToGAP( IsList, julia_list_func( JuliaPointer( current_module ) ), true );
     for i in list do
         \.( current_module, RNamObj( i ) );


### PR DESCRIPTION
ImportJuliaModuleIntoGAP assumed that GAP was available on the top
level in Julia, but it may not be.
