### PR TITLE
Add DirectoriesPackageProgramsOverrides

### DIFF
--- a/lib/pkg.g
+++ b/lib/pkg.g
@@ -1,0 +1,12 @@
+BindGlobal("DirectoriesPackageProgramsOverrides", rec());
+BindGlobal("DirectoriesPackageProgramsOriginal", DirectoriesPackagePrograms);
+
+MakeReadWriteGlobal("DirectoriesPackagePrograms");
+DirectoriesPackagePrograms := function(name)
+    name:= LowercaseString(name);
+    if IsBound(DirectoriesPackageProgramsOverrides.(name)) then
+        return [ Directory( DirectoriesPackageProgramsOverrides.(name) ) ];
+    fi;
+    return DirectoriesPackageProgramsOriginal(name);
+end;
+MakeReadOnlyGlobal("DirectoriesPackagePrograms");

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -156,6 +156,8 @@ function initialize(argv::Vector{String})
         error("JuliaInterface could not be loaded")
     end
 
+    GAP.Globals.Read(GapObj(joinpath(@__DIR__, "..", "lib", "pkg.g")))
+
     # If we are in "stand-alone mode", stop here
     if handle_signals
         ccall((:SyInstallAnswerIntr, libgap), Cvoid, ())


### PR DESCRIPTION
For use in Julia wrapper packages for GAP packages that included a
kernel extension or otherwise compiled code: they carry the (GAP) source
code for a GAP package in one Julia artifact, and the compiled binary in
another (via a JLL). It is easy enough to point GAP at the former, via
`SetPackagePath`; but we need this patch to also handle the latter.
