### PR TITLE
JuliaInterface: remove some macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,6 +24,3 @@ PointerBindsToType: Middle
 SpacesBeforeTrailingComments: 4
 UseTab: Never
 SortIncludes: false
-
-MacroBlockBegin: "^BEGIN_JULIA$"
-MacroBlockEnd: "^END_JULIA$"

--- a/pkg/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/JuliaInterface/src/JuliaInterface.c
@@ -43,11 +43,10 @@ void handle_jl_exception(void)
 
 static jl_module_t * get_module(const char * name)
 {
-    // It suffices to use JULIAINTERFACE_EXCEPTION_HANDLER here, as
-    // jl_eval_string is part of the jlapi, so don't have to be wrapped in
-    // JL_TRY/JL_CATCH.
     jl_value_t * module_value = jl_eval_string(name);
-    JULIAINTERFACE_EXCEPTION_HANDLER
+    if (jl_exception_occurred()) {
+        handle_jl_exception();
+    }
     if (!jl_is_module(module_value)) {
         BEGIN_GAP_SYNC();
         ErrorQuit("Not a module", 0, 0);
@@ -211,12 +210,11 @@ static Obj FuncJuliaEvalString(Obj self, Obj string)
     BEGIN_GAP_SYNC();
     RequireStringRep("JuliaEvalString", string);
 
-    // It suffices to use JULIAINTERFACE_EXCEPTION_HANDLER here, as
-    // jl_eval_string is part of the jlapi, so don't have to be wrapped in
-    // JL_TRY/JL_CATCH.
     jl_value_t * result = jl_eval_string(CONST_CSTR_STRING(string));
     END_GAP_SYNC();
-    JULIAINTERFACE_EXCEPTION_HANDLER
+    if (jl_exception_occurred()) {
+        handle_jl_exception();
+    }
     return gap_julia(result);
 }
 
@@ -309,13 +307,12 @@ static Obj FuncJuliaGetFieldOfObject(Obj self, Obj super_obj, Obj field_name)
 
     jl_value_t * extracted_superobj = GET_JULIA_OBJ(super_obj);
 
-    // It suffices to use JULIAINTERFACE_EXCEPTION_HANDLER here, as
-    // jl_get_field is part of the jlapi, so don't have to be wrapped in
-    // JL_TRY/JL_CATCH.
     jl_value_t * field_value =
         jl_get_field(extracted_superobj, CONST_CSTR_STRING(field_name));
     END_GAP_SYNC();
-    JULIAINTERFACE_EXCEPTION_HANDLER
+    if (jl_exception_occurred()) {
+        handle_jl_exception();
+    }
     return gap_julia(field_value);
 }
 

--- a/pkg/JuliaInterface/src/JuliaInterface.h
+++ b/pkg/JuliaInterface/src/JuliaInterface.h
@@ -11,40 +11,6 @@ extern Obj JULIAINTERFACE_JuliaPointer;
 // internal helper
 NOINLINE void handle_jl_exception(void);
 
-//
-// Exception handler for a few high-level Julia functions, namely
-// jl_eval_string, jl_call, jl_call0, ..., jl_call3, jl_get_field.
-// For any other jl_FOO APIs, you must use BEGIN_JULIA / END_JULIA
-// (see below).
-//
-#define JULIAINTERFACE_EXCEPTION_HANDLER                                     \
-    if (jl_exception_occurred()) {                                           \
-        handle_jl_exception();                                               \
-    }
-
-//
-// Exception handling for code calling into Julia: wrap any code calling
-// into Julia functions that might throw exceptions between BEGIN_JULIA
-// and END_JULIA. This will insert code that catches Julia exceptions, and
-// converts them into GAP errors.
-//
-// WARNING: You must not use 'return' inside a BEGIN_JULIA/END_JULIA block;
-// likewise, you must not exit it prematurely via any other means, so don't
-// use 'ErrorQuit' or 'longjmp' inside.
-//
-#define BEGIN_JULIA                                                          \
-    JL_TRY                                                                   \
-    {
-#define END_JULIA                                                            \
-    jl_exception_clear();                                                    \
-    }                                                                        \
-    JL_CATCH                                                                 \
-    {                                                                        \
-        jl_get_ptls_states()->previous_exception = jl_current_exception();   \
-    }                                                                        \
-    JULIAINTERFACE_EXCEPTION_HANDLER
-
-
 // Internal Julia access functions
 
 // GET_JULIA_OBJ(o)

--- a/pkg/JuliaInterface/src/calls.c
+++ b/pkg/JuliaInterface/src/calls.c
@@ -119,10 +119,9 @@ static ALWAYS_INLINE Obj DoCallJuliaFunc(Obj func, const int narg, Obj * a)
     default:
         result = jl_call(f, (jl_value_t **)a, narg);
     }
-    // It suffices to use JULIAINTERFACE_EXCEPTION_HANDLER here, as jl_call
-    // and its variants are part of the jlapi, so don't have to be wrapped in
-    // JL_TRY/JL_CATCH.
-    JULIAINTERFACE_EXCEPTION_HANDLER
+    if (jl_exception_occurred()) {
+        handle_jl_exception();
+    }
     return gap_julia(result);
 }
 


### PR DESCRIPTION
BEGIN_JULIA & END_JULIA were unused; while JULIAINTERFACE_EXCEPTION_HANDLER was trivial and using it just obfuscated the code
