### PR TITLE
Refactor initialization of GAP error handling

### DIFF
--- a/pkg/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/JuliaInterface/src/JuliaInterface.c
@@ -329,6 +329,16 @@ static void MarkJuliaObject(Bag bag)
 #endif
 }
 
+//
+extern Obj setup_ERROR_OUTPUT(void)
+{
+    Obj buf = MakeString("");
+    Obj stream = CALL_2ARGS(ValGVar(GVarName("OutputTextString")), buf, True);
+    CALL_2ARGS(ValGVar(GVarName("SetPrintFormattingStatus")), stream, False);
+    AssGVarWithoutReadOnlyCheck(GVarName("ERROR_OUTPUT"), stream);
+    return buf;
+}
+
 // Table of functions to export
 static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(_JuliaFunction, 1, "string"),

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -70,10 +70,10 @@ function evalstr(cmd::String)
     res = evalstr_ex(cmd * ";")
     if any(x->x[1] == false, res)
       # error
-      global last_error
+      global last_error, last_error_gap
       # HACK HACK HACK: if there is an error string on the GAP side, call
       # error_handler to copy it into `last_error`
-      if !GAP.Globals.IsEmpty(GAP.Globals._JULIAINTERFACE_ERROR_OUTPUT)
+      if !GAP.Globals.IsEmpty(last_error_gap[])
         error_handler()
       end
       error("Error thrown by GAP: $(last_error[])")

--- a/src/prompt.jl
+++ b/src/prompt.jl
@@ -27,7 +27,7 @@ function prompt()
     ccall((:SyInstallAnswerIntr, libgap), Cvoid, ())
 
     # restore GAP's error output
-    disable_error_handler = true
+    disable_error_handler[] = true
     Globals.MakeReadWriteGlobal(GapObj("ERROR_OUTPUT"))
     evalstr("""ERROR_OUTPUT:= "*errout*";""")
     Globals.MakeReadOnlyGlobal(GapObj("ERROR_OUTPUT"))
@@ -45,6 +45,6 @@ function prompt()
     ccall(:signal, Ptr{Cvoid}, (Cint, Ptr{Cvoid}), Base.SIGINT, old_sigint)
 
     # restore GAP.jl error handler
-    disable_error_handler = false
+    disable_error_handler[] = false
     reset_GAP_ERROR_OUTPUT()
 end


### PR DESCRIPTION
This way, we don't need to call "high-level" functions like evalstr
from inside __init__, which otherwise complicates certain code refactoring.

Also improve type inference for `disable_error_handler` by turning it into a `Ref`
