### PR TITLE
Explicit types in ConversionError & default gap_to_julia

### DIFF
--- a/pkg/JuliaExperimental/gap/numfield.g
+++ b/pkg/JuliaExperimental/gap/numfield.g
@@ -579,7 +579,7 @@ InstallMethod( ContextGAPNemo,
         numden:= Julia.GAPNumberFields.CoefficientVectorsNumDenOfNumberFieldElement(
                      obj, Dimension( C!.GAPDomain ) );
 
-        convert:= Julia.Base.convert;
+        convert:= JuliaEvalString( "Vector{Int}" );
         num:= JuliaToGAP( IsList,
               convert( JuliaEvalString( "Vector{Int}" ), numden[1] ), true );
         den:= JuliaToGAP( IsList,

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -1,8 +1,8 @@
 
 ## Show a specific error on conversion failure.
 struct ConversionError <: Base.Exception
-    obj::Any
-    jl_type::Any
+    obj::Obj
+    jl_type::Union{String,Type}
 end
 
 Base.showerror(io::IO, e::ConversionError) =
@@ -48,7 +48,8 @@ julia> GAP.gap_to_julia( val, recursive = false )
 
 ```
 """
-function gap_to_julia(t::T, x::Any) where {T<:Type}
+function gap_to_julia(T::Type, x::Any)
+    @nospecialize T, x
     ## Default for conversion:
     ## Base case for conversion (least specialized method): Allow converting any
     ## Julia object x to type T, provided that the type of x is a subtype of T;
@@ -62,15 +63,12 @@ function gap_to_julia(t::T, x::Any) where {T<:Type}
     ## (::Type{Vector{T}}, :: GapObj) is invoked, with T = Tuple{Int64}; this then
     ## invokes gap_to_julia recursively with signature (::Tuple{Int64},::Any),
     ## which ends up selecting the method below.
-    if !(typeof(x) <: t)
+    if !(typeof(x) <: T)
         throw(ErrorException(
-            "Don't know how to convert value of type " *
-            string(typeof(x)) *
-            " to type " *
-            string(t),
+            "Don't know how to convert value of type $(typeof(x)) to type $(T)"
         ))
     end
-    return x
+    return x::T
 end
 
 ## Switch recursion on by default.


### PR DESCRIPTION
I also wonder if the default `gap_to_julia` method should be changed to call `convert` ?  But that's another question. CC @thofma @ThomasBreuer 