### PR TITLE
Refactor ERROR_OUTPUT handling *again*

### DIFF
--- a/lib/err.g
+++ b/lib/err.g
@@ -1,0 +1,10 @@
+# create output stream for use by JuliaInterface
+BindGlobal("_JULIAINTERFACE_ORIGINAL_ERROR_OUTPUT", ERROR_OUTPUT);
+BindGlobal("_JULIAINTERFACE_ERROR_BUFFER", "");
+BindGlobal("_JULIAINTERFACE_ERROR_OUTPUT", OutputTextString(_JULIAINTERFACE_ERROR_BUFFER, true));
+SetPrintFormattingStatus(_JULIAINTERFACE_ERROR_OUTPUT, false);
+
+# set it as GAP's default error output stream
+MakeReadWriteGlobal("ERROR_OUTPUT");
+ERROR_OUTPUT := _JULIAINTERFACE_ERROR_OUTPUT;
+MakeReadOnlyGlobal("ERROR_OUTPUT");

--- a/pkg/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/JuliaInterface/src/JuliaInterface.c
@@ -326,16 +326,6 @@ static void MarkJuliaObject(Bag bag)
 #endif
 }
 
-//
-extern Obj setup_ERROR_OUTPUT(void)
-{
-    Obj buf = MakeString("");
-    Obj stream = CALL_2ARGS(ValGVar(GVarName("OutputTextString")), buf, True);
-    CALL_2ARGS(ValGVar(GVarName("SetPrintFormattingStatus")), stream, False);
-    AssGVarWithoutReadOnlyCheck(GVarName("ERROR_OUTPUT"), stream);
-    return buf;
-}
-
 // Table of functions to export
 static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(_JuliaFunction, 1, "string"),

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -70,10 +70,10 @@ function evalstr(cmd::String)
     res = evalstr_ex(cmd * ";")
     if any(x->x[1] == false, res)
       # error
-      global last_error, last_error_gap
+      global last_error
       # HACK HACK HACK: if there is an error string on the GAP side, call
       # error_handler to copy it into `last_error`
-      if !GAP.Globals.IsEmpty(last_error_gap[])
+      if !GAP.Globals.IsEmpty(Globals._JULIAINTERFACE_ERROR_BUFFER)
         error_handler()
       end
       error("Error thrown by GAP: $(last_error[])")

--- a/src/prompt.jl
+++ b/src/prompt.jl
@@ -29,7 +29,7 @@ function prompt()
     # restore GAP's error output
     disable_error_handler[] = true
     Globals.MakeReadWriteGlobal(GapObj("ERROR_OUTPUT"))
-    evalstr("""ERROR_OUTPUT:= "*errout*";""")
+    Globals.ERROR_OUTPUT = Globals._JULIAINTERFACE_ORIGINAL_ERROR_OUTPUT
     Globals.MakeReadOnlyGlobal(GapObj("ERROR_OUTPUT"))
 
     # enable break loop
@@ -46,5 +46,7 @@ function prompt()
 
     # restore GAP.jl error handler
     disable_error_handler[] = false
-    reset_GAP_ERROR_OUTPUT()
+    Globals.MakeReadWriteGlobal(GapObj("ERROR_OUTPUT"))
+    Globals.ERROR_OUTPUT = Globals._JULIAINTERFACE_ERROR_OUTPUT
+    Globals.MakeReadOnlyGlobal(GapObj("ERROR_OUTPUT"))
 end


### PR DESCRIPTION
Hopefully this is done now: do most of the work with actual GAP code instead
of Julia or C code, and change GAP.prompt() so that the *same* output stream
is reused as ERROR_OUTPUT stream

Closes #702 as it also fixes GAP.prompt() but differently
