### PR TITLE
Remove GAP function `ImportJuliaModuleIntoGAP`, prepare for better tab completion of Julia modules on the GAP side

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,9 +12,11 @@ changes compared to the 0.6.x release:
   you can use `GapObj(val)` or `julia_to_gap(val)` instead. If you were
   using `convert(T,gapobj)`, use `T(gapobj)` or `julia_to_gap(gapobj)`
   instead.
-- Remove `IsArgumentForJuliaFunction` from the GAP side. There was no
-  actual use case, so hopefully nobody was using it
 - Remove `GAP.gap_exe()`. Instead please use `GAP.create_gap_sh(path)`.
+- Remove GAP function `IsArgumentForJuliaFunction`. No replacement should
+  be necessary.
+- Remove GAP function `ImportJuliaModuleIntoGAP`. As a replacement, use
+  `JuliaEvalString("import MODULENAME")`.
 
 Other changes:
 

--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -166,10 +166,7 @@ DeclareAttribute( "JuliaPointer", IsJuliaWrapper );
 #! @Arguments obj
 #! @Description
 #!  This filter is set in those &GAP; objects that represent &Julia; modules.
-#!  A submodule of a module can be accessed like a record component,
-#!  provided that this submodule has already been imported,
-#!  see <Ref Func="ImportJuliaModuleIntoGAP"/>.
-#!  &Julia; variables from a module can be accessed like record components.
+#!  Members of a &Julia; module can be accessed like record components.
 #! @BeginExampleSession
 #! gap> IsJuliaModule( Julia );
 #! true
@@ -212,8 +209,6 @@ BindGlobal( "TheTypeOfJuliaModules", NewType( TheFamilyOfJuliaModules, IsJuliaMo
 #!  This means that the &Julia; code in the file with name <A>filename</A>
 #!  gets executed in the current &Julia; session,
 #!  in the context of the &Julia; module <A>module_name</A>.
-#!  If the file defines a new &Julia; module then the next step will be
-#!  to import this module, see <Ref Func="ImportJuliaModuleIntoGAP"/>.
 DeclareGlobalFunction( "JuliaIncludeFile" );
 
 #! @Arguments pkgname
@@ -311,31 +306,10 @@ DeclareGlobalFunction( "JuliaFunction" );
 DeclareGlobalVariable( "Julia" );
 
 #! @Arguments name
-#! @Returns nothing.
-#! @Description
-#!  The aim of this function is to make the &Julia; module with name
-#!  <A>name</A> available in the current &GAP; session.
-#!  After the call,
-#!  the <A>name</A> component of the global object <Ref Var="Julia"/> will be
-#!  bound, and one can access the module as a component of <Ref Var="Julia"/>
-#!  or via <Ref Func="JuliaModule"/>.
-#! @BeginExampleSession
-#! gap> ImportJuliaModuleIntoGAP( "GAP" );
-#! gap> Julia.GAP;
-#! <Julia module GAP>
-#! @EndExampleSession
-#!  The &Julia; modules <C>Base</C>, <C>Core</C>, and <C>GAP</C>
-#!  have in fact already been imported when the
-#!  <Package>JuliaInterface</Package> package got loaded.
-DeclareGlobalFunction( "ImportJuliaModuleIntoGAP" );
-
-#! @Arguments name
 #! @Returns a &Julia; object
 #! @Description
 #!  Returns the &Julia; object that points to the &Julia; module
 #!  with name <A>name</A>.
-#!  Note that this module needs to be imported before being present,
-#!  see <Ref Func="ImportJuliaModuleIntoGAP"/>.
 #! @BeginExampleSession
 #! gap> gapmodule:= JuliaModule( "GAP" );
 #! <Julia: GAP>

--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -182,7 +182,7 @@ DeclareAttribute( "JuliaPointer", IsJuliaWrapper );
 #! gap> JuliaFunction( "julia_to_gap", "GAP" );  # the same function
 #! <Julia: julia_to_gap>
 #! @EndExampleSession
-DeclareCategory( "IsJuliaModule", IsJuliaWrapper  );
+DeclareCategory( "IsJuliaModule", IsJuliaWrapper and IsRecord  );
 
 BindGlobal( "TheFamilyOfJuliaModules", NewFamily( "TheFamilyOfJuliaModules" ) );
 BindGlobal( "TheTypeOfJuliaModules", NewType( TheFamilyOfJuliaModules, IsJuliaModule and IsAttributeStoringRep ) );

--- a/pkg/JuliaInterface/gap/JuliaInterface.gi
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gi
@@ -73,7 +73,6 @@ InstallMethod( \.\:\=,
     Error( "Manual assignment to module is not allowed" );
 end );
 
-
 InstallMethod( IsBound\.,
                [ "IsJuliaModule", "IsPosInt" ],
   function( module, rnum )
@@ -83,16 +82,18 @@ InstallMethod( IsBound\.,
     return fail <> _JuliaGetGlobalVariableByModule( NameRNam( rnum ), JuliaPointer( module ) );
 end );
 
-
 InstallMethod( Unbind\.,
                [ "IsJuliaModule", "IsPosInt" ],
   function( module, rnum )
     Error( "cannot unbind Julia variables" );
 end );
 
+InstallMethod(RecNames, [ "IsJuliaModule" ],
+function( obj )
+    return JuliaToGAP( IsList, Julia.GAP.get_symbols_in_module( JuliaPointer( obj ) ), true );
+end);
 
 InstallValue( Julia, _WrapJuliaModule( "Main", _JuliaGetGlobalVariable( "Main" ) ) );
-
 
 InstallOtherMethod( \[\],
     [ "IsJuliaObject", "IsPosInt and IsSmallIntRep" ],

--- a/pkg/JuliaInterface/gap/JuliaInterface.gi
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gi
@@ -138,34 +138,6 @@ InstallMethod( String,
 end );
 
 
-InstallGlobalFunction( ImportJuliaModuleIntoGAP,
-  function( name )
-    local callstring, list, variable_list, i,
-          current_module, is_module_present, no_import;
-
-    no_import := ValueOption( "NoImport" );
-    if no_import = fail then
-        no_import := false;
-    fi;
-
-    is_module_present := JuliaEvalString( Concatenation( "isdefined( Main, :", name, ")" ) );
-
-    if no_import = false then
-        if not is_module_present then
-            ## Local modules cannot be imported
-            callstring:= Concatenation( "import ", name );
-            JuliaEvalString( callstring );
-        fi;
-    fi;
-
-    current_module := Julia.(name);
-    list := JuliaToGAP( IsList, Julia.GAP.get_symbols_in_module( JuliaPointer( current_module ) ), true );
-    for i in list do
-        \.( current_module, RNamObj( i ) );
-    od;
-end );
-
-
 InstallGlobalFunction( JuliaImportPackage, function( pkgname )
     local callstring;
     if not IsString( pkgname ) then

--- a/pkg/JuliaInterface/gap/adapter.gi
+++ b/pkg/JuliaInterface/gap/adapter.gi
@@ -104,7 +104,7 @@ InstallMethod( State,
 InstallMethod( Init,
     [ "IsRandomSourceJulia", "IsObject" ],
     function( rng, seed )
-    ImportJuliaModuleIntoGAP( "Random" );
+    JuliaEvalString( "import Random" );
     if IsInt( seed ) then
       # This means a prescribed seed.
       seed:= AbsInt( seed );
@@ -146,7 +146,7 @@ InstallMethod( Reset,
     local old;
 
     old:= State( rng );
-    ImportJuliaModuleIntoGAP( "Random" );
+    JuliaEvalString( "import Random" );
     if IsInt( seed ) then
       # This means a prescribed seed.
       seed:= AbsInt( seed );

--- a/pkg/JuliaInterface/tst/import.tst
+++ b/pkg/JuliaInterface/tst/import.tst
@@ -13,15 +13,6 @@ gap> JuliaImportPackage( "No_Julia_Package_With_This_Name" );
 false
 
 ##
-gap> ImportJuliaModuleIntoGAP( "Core" );
-gap> ImportJuliaModuleIntoGAP( "No_Julia_Module_With_This_Name" );
-Error, ArgumentError: Package No_Julia_Module_With_This_Name not found in curr\
-ent path:
-- Run `import Pkg; Pkg.add("No_Julia_Module_With_This_Name")` to install the N\
-o_Julia_Module_With_This_Name package.
-
-
-##
 gap> Julia;
 <Julia module Main>
 gap> Julia.Base;

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,7 @@ import REPL.REPLCompletions: completions
     get_symbols_in_module(m::Module) :: Vector{Symbol}
 
 Return all symbols in the module `m`.
-This is used in the GAP function `ImportJuliaModuleIntoGAP`.
+This is used in a GAP method for `RecName`.
 """
 function get_symbols_in_module(m::Module)
     name = string(nameof(m))


### PR DESCRIPTION
# First commit: Put JuliaModule into IsRecord filter

Together with https://github.com/gap-system/gap/pull/4667 this provides an alternate way to get tab completion for Julia modules on the GAP side. I.e. so that one can type `Julia.GAP.e` into a GAP prompt shown by `GAP.prompt()`, then press TAB, and get good results.

Right now we achieved this via a trick in `ImportJuliaModuleIntoGAP`, but that leads to the next commit:

# Second commit: Remove `ImportJuliaModuleIntoGAP`

This function and its documentation were highly misleading, and as a
result a lot of code used it inappropriately. To wit, it was *not*
actually necessary to call it in order to use a Julia module in GAP;
*only* if that module was not imported into the Julia `Main` module, and
then of course only if the GAP code relied on that.

But in practice this lead to a lot of people (including myself in the
past) of writing brittle code that only worked if the user did
`Pkg.add("NAME")` for the module to be imported into GAP. But in
practical

For those who genuinely needed `ImportJuliaModuleIntoGAP("NAME")`, they
can replace this by `JuliaEvalString("import NAME")`. The only thing
missing then is that tab completion for `Julia.NAME` will not work
out of the box. We'll restore this by some other means eventually (namely the
preceding commit plus a GAP PR).

