### PR TITLE
Replace GAP's `ExecuteProcess` by Julia code

### DIFF
--- a/gap/exec.g
+++ b/gap/exec.g
@@ -1,0 +1,4 @@
+BindGlobal("_ORIG_ExecuteProcess", ExecuteProcess);
+MakeReadWriteGlobal("ExecuteProcess");
+ExecuteProcess := Julia.GAP.GAP_ExecuteProcess;
+MakeReadOnlyGlobal("ExecuteProcess");

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -177,6 +177,7 @@ function initialize(argv::Vector{String})
     end
 
     GAP.Globals.Read(GapObj(joinpath(@__DIR__, "..", "gap", "pkg.g")))
+    GAP.Globals.Read(GapObj(joinpath(@__DIR__, "..", "gap", "exec.g")))
 
     # If we are in "stand-alone mode", stop here
     if handle_signals
@@ -314,6 +315,7 @@ include("utils.jl")
 include("help.jl")
 include("packages.jl")
 include("prompt.jl")
+include("exec.jl")
 include("doctestfilters.jl")
 
 end

--- a/src/exec.jl
+++ b/src/exec.jl
@@ -1,0 +1,38 @@
+# Replacement for the GAP kernel function ExecuteProcess
+const use_orig_ExecuteProcess = Ref{Bool}(false)
+function GAP_ExecuteProcess(dir::GapObj, prg::GapObj, in::Int, out::Int, args::GapObj)
+    if use_orig_ExecuteProcess[]
+        return GAP.Globals._ORIG_ExecuteProcess(dir, prg, in, out, args)
+    end
+    return GAP_ExecuteProcess(String(dir), String(prg), in, out, Vector{String}(args))
+end
+
+function GAP_ExecuteProcess(dir::String, prg::String, fin::Int, fout::Int, args::Vector{String})
+    # Note: the GAP kernel function `ExecuteProcess` also handles so-called
+    # "window mode", for use in xgap and Gap.app -- we do not emulate this here.
+    if fin < 0
+        fin = Base.devnull
+    else
+        fin = ccall((:SyBufFileno, libgap), Int, (Culong, ), fin)
+        if fin == -1
+            error("fin invalid")
+        end
+        fin = RawFD(fin)
+    end
+
+    if fout < 0
+        fout = Base.devnull
+    else
+        fout = ccall((:SyBufFileno, libgap), Int, (Culong, ), fout)
+        if fout == -1
+            error("fout invalid")
+        end
+        fout = RawFD(fout)
+    end
+
+    # TODO: verify `dir` is a valid dir?
+    cd(dir) do
+        res = run(pipeline(ignorestatus(`$prg $args`), stdin=fin, stdout=fout))
+        return res.exitcode == 255 ? GAP.Globals.Fail : res.exitcode
+    end
+end


### PR DESCRIPTION
This is a step towards getting rid of the GAP SIGCHLD handler

I only did the most basic test (run `Exec("ls")` from a GAP prompt()), so more tests are absolutely missing, also using this with packages.

On the other hand, things seem to work surprisingly well even without this patch. But SIGCHLD handling in GAP is something we really should try to get rid of (CC @benlorenz)

Resolve #240