### PR TITLE
JuliaInterface: don't use GAP_SYNC macros before InitGapSync

### DIFF
--- a/pkg/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/JuliaInterface/src/JuliaInterface.c
@@ -314,17 +314,13 @@ static StructGVarFunc GVarFuncs[] = {
 static Int InitKernel(StructInitInfo * module)
 {
     if (!gap_module) {
-        BEGIN_GAP_SYNC();
         ErrorMayQuit("gap_module was not set", 0, 0);
-        END_GAP_SYNC();
     }
 
     JULIA_GAPFFE_type =
         (jl_datatype_t *)jl_get_global(gap_module, jl_symbol("FFE"));
     if (!JULIA_GAPFFE_type) {
-        BEGIN_GAP_SYNC();
         ErrorMayQuit("Could not locate the GAP.FFE datatype", 0, 0);
-        END_GAP_SYNC();
     }
 
     InitGapSync();


### PR DESCRIPTION
When this gets merged, `GAP_pkg_juliainterface_jll` should be updated right afterwards. Since it is not urgent at all (the whole GAP_SYNC code is currently disabled anyway), I'll rather wait with this to see if we need more kernel changes, and then merge them all at once.