### PR TITLE
Better tab complection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
   bundled C code, thus for basic use of GAP.jl no C/C++ compiler is needed
   anymore; this also avoids compatibility issues when switching back and forth
   between Julia 1.6 and 1.7
+- Add support for REPL tab completion on members of `GAP.Globals`; e.g. if you
+  enter `GAP.Globals.MTX.Is` into the REPL and press the TAB key twice, you
+  should be offered a list of members of the record `GAP.Globals.MTX` whose
+  name starts with `Is`.
 
 ## Version 0.7.1 (released 2021-10-29)
 

--- a/src/globals.jl
+++ b/src/globals.jl
@@ -37,9 +37,7 @@ const Globals = GlobalsType()
 
 function getproperty(::GlobalsType, name::Symbol)
     v = _ValueGlobalVariable(name)
-    if v === C_NULL
-        error("GAP variable $name not bound")
-    end
+    v === C_NULL && error("GAP variable $name not bound")
     return _GAP_TO_JULIA(v)
 end
 
@@ -48,11 +46,27 @@ function hasproperty(::GlobalsType, name::Symbol)
 end
 
 function setproperty!(::GlobalsType, name::Symbol, val::Any)
-    if !CanAssignGlobalVariable(name)
-        error("cannot assing to $name in GAP")
-    end
+    CanAssignGlobalVariable(name) || error("cannot assing to $name in GAP")
     tmp = (val === nothing) ? C_NULL : _JULIA_TO_GAP(val)
     _AssignGlobalVariable(name, tmp)
 end
 
 propertynames(::GlobalsType) = Vector{Symbol}(Globals.NamesGVars())
+
+
+# HACK to get tab completion to work for GAP globals accessed via GAP.Globals;
+# e.g. if the REPL already shows `GAP.Globals.MTX.Is` and the user presses
+# TAB, they should be shown a list of members of the GAP global variable `MTX`
+# (which is a record) starting with `Is`. The easy part for supporting this is
+# to implement `propertynames` for `GapObj` (at least those which are GAP
+# records). Unfortunately that's not quite enough; we also have add methods
+# for the `get_value` method below
+import REPL.REPLCompletions: get_value
+function get_value(sym::Symbol, ::GAP.GlobalsType)
+    v = _ValueGlobalVariable(sym)
+    v === C_NULL && return (nothing, false)
+    return (_GAP_TO_JULIA(v), true)
+end
+get_value(sym::QuoteNode, fn::GAP.GlobalsType) = get_value(sym.value, fn)
+
+propertynames(r::GapObj) = Wrappers.IsRecord(r) ? Vector{Symbol}(Wrappers.RecNames(r)) : Vector{Symbol}()

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -1,0 +1,47 @@
+# the test setup and code in this file are based on stdlib/REPL/test/replcompletions.jl
+using REPL.REPLCompletions
+using REPL
+
+function map_completion_text(completions)
+    c, r, res = completions
+    return map(completion_text, c), r, res
+end
+
+test_complete(s) = map_completion_text(@inferred(completions(s,lastindex(s))))
+
+@testset "REPL completions" begin
+
+# completing on GAP.Globals works out of the box
+let s = "GAP.Globals.MT"
+    c, r = test_complete(s)
+    @test "MTX" in c
+    @test r == 13:14
+    @test s[r] == "MT"
+end
+
+# completing on members of GAP.Globals requires some hacking (see `globals.jl`)
+let s = "GAP.Globals.MTX.IsI"
+    c, r = test_complete(s)
+    @test length(c) == 2
+    @test "IsIndecomposable" in c
+    @test r == 17:19
+    @test s[r] == "IsI"
+end
+
+let s = "GAP.Globals.MTX.IsInd"
+    c, r = test_complete(s)
+    @test length(c) == 1
+    @test "IsIndecomposable" in c
+    @test r == 17:21
+    @test s[r] == "IsInd"
+end
+
+# completing a non-record does nothing
+let s = "GAP.Globals.fail."
+    c, r = test_complete(s)
+    @test isempty(c)
+    @test r == 18:17
+    @test s[r] == ""
+end
+
+end


### PR DESCRIPTION
Now you can tab-complete e.g. 'GAP.Globals.MTX.Is'. While trying to tab complete e.g. `GAP.Globals.fail.` (i.e. doing this for a non-record object) will correctly do nothing. 

Resolves #752 

Might make @fieker less unhappy :-)

