### PR TITLE
Hack the typename of GAP.GapObj

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -207,6 +207,11 @@ function __init__()
         windows_error()
     end
 
+    # HACK HACK HACK: ensure the type GapObj (which is just an alias
+    # for `GAP_jll.MPtr`) is printed as ours
+    GapObj.name.module = GAP
+    GapObj.name.name = :GapObj
+
     # regenerate GAPROOT if it was removed
     if !isdir(GAPROOT) || isempty(readdir(GAPROOT))
         Setup.regenerate_gaproot(GAPROOT)

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -18,22 +18,6 @@ function show_string(io::IO, obj::Union{GapObj,FFE})
     return stri
 end
 
-# Show `GapObj` as `GAP.GapObj` or `GapObj` not as `GAP_jll.MPtr`.
-# Use the same criteria as (the currently undocumented) `show_type_name`
-function Base.show(io::IO, ::Type{GapObj})
-    if !get(io, :compact, false)
-        # Print module prefix unless type is visible from module passed to
-        # IOContext If :module is not set, default to Main. nothing can be used
-        # to force printing prefix
-        from = get(io, :module, Main)
-        if from === nothing || !Base.isvisible(:GapObj, GAP, from)
-            show(io, GAP)
-            print(io, ".")
-        end
-    end
-    print(io, "GapObj")
-end
-
 function Base.show(io::IO, obj::Union{GapObj,FFE})
     stri = show_string(io, obj)
     print(io, "GAP: $stri")

--- a/src/types.jl
+++ b/src/types.jl
@@ -86,7 +86,6 @@ ERROR: TypeError: in typeassert, expected GapObj, got a value of type Int64
 """
 const GapObj = GAP_jll.MPtr
 
-
 """
     GAP.Obj
 

--- a/test/adapter.jl
+++ b/test/adapter.jl
@@ -46,6 +46,11 @@ end
     io = IOBuffer();
     print(io, GAP.GapObj)
     @test String(take!(io)) == "GapObj"
+
+    L = [ GAP.evalstr( "()" ) ]
+    print(io, L)
+    @test String(take!(io)) == "GapObj[GAP: ()]"
+
     ioc = IOContext(io, :module => nothing);
     print(ioc, GAP.GapObj)
     @test String(take!(io)) == "GAP.GapObj"


### PR DESCRIPTION
... to ensure uniform printing

Resolves #756