### PR TITLE
CI: limit concurrency for PR builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,13 @@ on:
   - push
   - pull_request
 
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   test:
     name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }}


### PR DESCRIPTION
With this change, for each PR only the most recent version will be
tested by CI; if an update is pushed for the PR, any already running
tests for that PR are cancelled.

Some trickery is needed to ensure that for the master branch, concurrent
builds are still possible.