### PR TITLE
Prefer 'import' over 'using'

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -4,7 +4,7 @@
   For more information about GAP see https://www.gap-system.org/
 """ module GAP
 
-using GAP_jll
+import GAP_jll: GAP_jll, libgap
 
 include("setup.jl")
 
@@ -284,7 +284,7 @@ For a fixed seed, the stream of generated numbers is allowed to change between
 different versions of GAP.
 """
 function randseed!(seed::Union{Integer,Nothing}=nothing)
-    seed = something(seed, rand(UInt128))
+    seed = something(seed, Random.rand(UInt128))
     Globals.Reset(Globals.GlobalMersenneTwister, seed)
     # when GlobalRandomSource is reset, the seed is taken modulo 2^28, so we just
     # pass an already reduced seed here

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -269,9 +269,9 @@ Base.hash(::FFE, h::UInt) = h
 
 ### RNGs
 
-using Random: Random, AbstractRNG, rand
+import Random
 
-abstract type AbstractGAPRNG <: AbstractRNG end
+abstract type AbstractGAPRNG <: Random.AbstractRNG end
 
 struct MersenneTwisterState state end
 

--- a/src/help.jl
+++ b/src/help.jl
@@ -1,6 +1,6 @@
 ## enable access to GAP help system from Julia
 
-using REPL
+import REPL
 
 function gap_help_string(topic::String, onlyexact::Bool = false,
     term::REPL.Terminals.TTYTerminal = REPL.TerminalMenus.terminal)

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -1,7 +1,7 @@
 ## dealing with GAP packages
 module Packages
 
-using Downloads
+import Downloads
 import ...GAP: Globals, GapObj, sysinfo
 
 const DEFAULT_PKGDIR = sysinfo["DEFAULT_PKGDIR"]

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -1,11 +1,10 @@
 module Setup
 
-using Pkg
-using Pkg.Artifacts
-using GAP_jll
-using GAP_lib_jll
-using GAP_pkg_juliainterface_jll
-using GMP_jll
+import Pkg: Pkg, Artifacts
+import GAP_jll
+import GAP_lib_jll
+import GAP_pkg_juliainterface_jll
+import GMP_jll
 
 #############################################################################
 #
@@ -73,13 +72,13 @@ function gmp_artifact_dir()
 
     # If this file exists, it's a stdlib JLL and we must download the artifact ourselves
     if isfile(artifacts_toml)
-        meta = artifact_meta("GMP", artifacts_toml)
+        meta = Artifacts.artifact_meta("GMP", artifacts_toml)
         hash = Base.SHA1(meta["git-tree-sha1"])
-        if !artifact_exists(hash)
+        if !Artifacts.artifact_exists(hash)
             dl_info = first(meta["download"])
-            download_artifact(hash, dl_info["url"], dl_info["sha256"])
+            Artifacts.download_artifact(hash, dl_info["url"], dl_info["sha256"])
         end
-        return artifact_path(hash)
+        return Artifacts.artifact_path(hash)
     end
 
     # Otherwise, we can just use the artifact directory given to us by GMP_jll
@@ -242,7 +241,7 @@ function regenerate_gaproot(gaproot_mutable)
                       joinpath("bin", "BuildPackages.sh"))
 
         # create a `pkg` symlink to the GAP packages artifact
-        force_symlink(artifact"gap_packages", "pkg")
+        force_symlink(Artifacts.artifact"gap_packages", "pkg")
 
     end # cd(gaproot_mutable)
 


### PR DESCRIPTION
With 'using' a change in the export list of a package can cause unexpected breakage
