### PR TITLE
CI: switch to codecov/codecov-action@v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: "Upload coverage data to Codecov"
         continue-on-error: true
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
 
   docs:
     name: "Documentation"


### PR DESCRIPTION
The v1 script will be disabled in February 2022
