### PR TITLE
fixed `@gapattribute`

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -288,7 +288,7 @@ macro gapattribute(ex)
 
         Return `true` if the value for `$($julianame)(x)` has already been computed.
         """
-        @gapwrap $testername(x) = GAP.Globals.$gaptester(x)::Bool
+        @gapwrap $testername($juliaarg) = GAP.Globals.$gaptester($gaparg)::Bool
 
         """
             $($settername)(x, v)
@@ -296,7 +296,7 @@ macro gapattribute(ex)
         Set the value for `$($julianame)(x)` to `v` if it has't been
         set already.
         """
-        @gapwrap $settername(x,v) = GAP.Globals.$gapsetter(x,v)::Nothing
+        @gapwrap $settername($juliaarg,v) = GAP.Globals.$gapsetter($gaparg,v)::Nothing
     end
 
     # ensure correct line numbers are used on all three methods, so that

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -19,6 +19,22 @@
     @test !occursin("No documentation found", string(doc))
     @test occursin("Set the value", string(doc))
 
+    # Do tester and setter refer to the right objects?
+    @gapattribute dersub(G::GapObj) = GAP.Globals.DerivedSubgroup(G)
+    @gapattribute cendersub(G::GapObj) = GAP.Globals.Centre(dersub(G))
+    G = GAP.Globals.SmallGroup(72, 15)
+    @test GAP.Globals.Size(GAP.Globals.Centre(G)) == 1
+    G = GAP.Globals.SmallGroup(72, 15)  # create the group anew
+    @test ! GAP.Globals.HasCentre(G)
+    @test ! hasdersub(G)
+    @test ! hascendersub(G)
+    @test hasdersub(G)  # the previous call has set the value
+    ggens = GAP.Globals.GeneratorsOfGroup(G)
+    setcendersub(G, GAP.Globals.Subgroup(G, GAP.GapObj([ggens[3]])))
+    @test hascendersub(G)
+    @test GAP.Globals.HasCentre(GAP.Globals.DerivedSubgroup(G))
+    @test GAP.Globals.Size(GAP.Globals.Centre(G)) == 1
+
 end
 
 @testset "compat" begin

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1,3 +1,5 @@
+@gapattribute dersub(G::GapObj) = GAP.Globals.DerivedSubgroup(G)
+
 @testset "@gapattribute" begin
 
     """
@@ -20,7 +22,6 @@
     @test occursin("Set the value", string(doc))
 
     # Do tester and setter refer to the right objects?
-    @gapattribute dersub(G::GapObj) = GAP.Globals.DerivedSubgroup(G)
     @gapattribute cendersub(G::GapObj) = GAP.Globals.Centre(dersub(G))
     G = GAP.Globals.SmallGroup(72, 15)
     @test GAP.Globals.Size(GAP.Globals.Centre(G)) == 1


### PR DESCRIPTION
In the construction of setter and tester, we have to distinguish the Julia object (called `juliaarg`) and the corresponding GAP object (called `gaparg`).
The two names are equal in the test example, but in typical Oscar situations,
the GAP object corresponding to the Julia object `G` is `G.X`.

Perhaps the problem has not been observed before because setters and testers are not really used in Oscar.