### PR TITLE
Replace some calls to low-level GAP functions

### DIFF
--- a/docs/src/other.md
+++ b/docs/src/other.md
@@ -40,9 +40,10 @@ GAP operations.
 |--------------|----------|
 | `length`     | `Length` |
 | `in`         | `\in`    |
-| `zero`       | `ZERO`   |
-| `one`        | `ONE`    |
-| `-` (unary)  | `AINV`   |
+| `zero`       | `ZeroSameMutability`   |
+| `one`        | `OneSameMutability`    |
+| `-` (unary)  | `AdditiveInverseSameMutability`   |
+| `inv`        | `InverseSameMutability`    |
 | `+`          | `SUM`    |
 | `-` (binary) | `DIFF`   |
 | `*`          | `PROD`   |

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -217,10 +217,10 @@ Base.hasproperty(x::GapObj, f::Union{AbstractString,Int64}) =
     Wrappers.ISB_REC(x, RNamObj(f))
 
 #
-Base.zero(x::Union{GapObj,FFE}) = Wrappers.ZERO(x)   # same mutability
-Base.one(x::Union{GapObj,FFE}) = Wrappers.ONE_MUT(x) # same mutability
-Base.inv(x::Union{GapObj,FFE}) = Wrappers.INV_MUT(x) # same mutability
-Base.:-(x::Union{GapObj,FFE}) = Wrappers.AINV(x)     # same mutability
+Base.zero(x::Union{GapObj,FFE}) = Wrappers.ZeroSameMutability(x)
+Base.one(x::Union{GapObj,FFE}) = Wrappers.OneSameMutability(x)
+Base.inv(x::Union{GapObj,FFE}) = Wrappers.InverseSameMutability(x)
+Base.:-(x::Union{GapObj,FFE}) = Wrappers.AdditiveInverseSameMutability(x)
 
 #
 Base.in(x::Any, y::GapObj) = Wrappers.IN(x, y)
@@ -325,11 +325,11 @@ Random.Sampler(::Type{<:AbstractGAPRNG}, x::AbstractVector, ::Random.Repetition)
     Random.SamplerTrivial(julia_to_gap(x, recursive=false))
 
 
-# The following bypasses GAP's redirection of `x^-1` to `INV_MUT(x)`.
+# The following bypasses GAP's redirection of `x^-1` to `InverseSameMutability(x)`.
 # Installing analogous methods for `x^0` and `x^1` would *not* be allowed,
-# these terms are equivalent to `ONE_MUT(x)` and `x`, respectively,
+# these terms are equivalent to `OneSameMutability(x)` and `x`, respectively,
 # only if `x` is a multiplicative element in the sense of GAP.
-Base.literal_pow(::typeof(^), x::GapObj, ::Val{-1}) = Wrappers.INV_MUT(x)
+Base.literal_pow(::typeof(^), x::GapObj, ::Val{-1}) = Wrappers.InverseSameMutability(x)
 
 # iteration
 

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -3,7 +3,7 @@ module Wrappers
 using GAP
 import GAP: @wrap
 
-@wrap AINV(x::Any)::Any
+@wrap AdditiveInverseSameMutability(x::Any)::Any
 @wrap ASS_LIST(x::Any, i::Int, v::Any)::Nothing
 @wrap ASS_MAT(x::Any, i::Int, j::Int, v::Any)::Nothing
 @wrap ASS_REC(x::Any, y::Int, v::Any)::Nothing
@@ -21,7 +21,7 @@ import GAP: @wrap
 @wrap EQ(x::Any, y::Any)::Bool
 @wrap IN(x::Any, y::Any)::Bool
 @wrap INT_CHAR(x::Any)::Int
-@wrap INV_MUT(x::Any)::Any
+@wrap InverseSameMutability(x::Any)::Any
 @wrap IS_JULIA_FUNC(x::Any)::Bool
 @wrap ISB_LIST(x::Any, i::Int)::Bool
 @wrap ISB_REC(x::Any, y::Int)::Bool
@@ -49,7 +49,7 @@ import GAP: @wrap
 @wrap NumberColumns(x::Any)::GapInt
 @wrap NumberRows(x::Any)::GapInt
 @wrap NumeratorRat(x::Any)::GapInt
-@wrap ONE_MUT(x::Any)::Any
+@wrap OneSameMutability(x::Any)::Any
 @wrap PopOptions()::Nothing
 @wrap POW(x::Any, y::Any)::Any
 @wrap PROD(x::Any, y::Any)::Any
@@ -63,6 +63,6 @@ import GAP: @wrap
 @wrap StringViewObj(x::Any)::Any
 @wrap StructuralCopy(x::Any)::Any
 @wrap SUM(x::Any, y::Any)::Any
-@wrap ZERO(x::Any)::Any
+@wrap ZeroSameMutability(x::Any)::Any
 
 end


### PR DESCRIPTION
... by high-level synonyms, which are easier to understand, and also
stable under changes to the GAP kernel.
