### PR TITLE
explain why `SameMutability` variants are chosen

### DIFF
--- a/docs/src/other.md
+++ b/docs/src/other.md
@@ -54,6 +54,17 @@ GAP operations.
 | `<`          | `LT`     |
 | `==`         | `EQ`     |
 
+The reason why four `SameMutability` operations are chosen in this list
+is as follows.
+In GAP, *binary* arithmetic operations return immutable results if and only if
+the two arguments are immutable.
+Thus it is consistent if *unary* arithmetic operations return a result
+with the same mutability as the argument.
+Note that GAP provides several variants of these unary operations,
+regarding the mutability of the result
+(`ZeroMutable`, `ZeroImmutable`, `ZeroSameMutability`, etc.),
+but here we have to choose one behaviour for the Julia function.
+
 ```jldoctest
 julia> l = GAP.julia_to_gap( [ 1, 3, 7, 15 ] )
 GAP: [ 1, 3, 7, 15 ]


### PR DESCRIPTION
on the GAP side for the unary Julia operations `zero`, `one`, `-`, `inv`

(This question came up in the discussion of #782.)