### PR TITLE
Tweak OverrideTypeNameAndModule to only change the module

### DIFF
--- a/pkg/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/JuliaInterface/src/JuliaInterface.c
@@ -158,30 +158,24 @@ void ResetUserHasQUIT(void)
 
 
 // HACK: this helper function is called from Julia to override the parent
-// module and name of the type used for GAP objects. We used to achieve the
-// same via pure Julia like this:
+// module of the type used for GAP objects. We used to achieve the same via
+// pure Julia like this:
 //
 //    GapObj.name.module = GAP
-//    GapObj.name.name = :GapObj
 //
 // However in recent Julia 1.8-DEV builds, a feature was introduced to mark
-// individual fields of mutable structs const, and this was used to make those
+// individual fields of mutable structs const, and this was used to make this
 // field of type `TypeName` const, so that code doesn't work anymore. For now,
-// it is still safe to override the type on the C kernel level, but we should
-// start thinking about long-term alternatives.
-void OverrideTypeNameAndModule(jl_value_t * type,
-                               jl_value_t * module,
-                               jl_value_t * name)
+// it seems to be still safe to override the type on the C kernel level, but
+// we should start thinking about long-term alternatives.
+void OverrideTypeNameAndModule(jl_value_t * type, jl_value_t * module)
 {
     if (!jl_is_datatype(type))
         jl_error("<type> is not a DataType");
     if (!jl_is_module(module))
         jl_error("<module> is not a module");
-    if (!jl_is_symbol(name))
-        jl_error("<name> is not a symbol");
 
     jl_datatype_t * t = (jl_datatype_t *)type;
-    t->name->name = (jl_sym_t *)name;
     t->name->module = (jl_module_t *)module;
 }
 

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -212,8 +212,8 @@ function __init__()
     end
 
     # HACK HACK HACK: ensure the type GapObj (which is just an alias
-    # for `GAP_jll.MPtr`) is printed as ours
-    ccall((:OverrideTypeNameAndModule, JuliaInterface_path()), Cvoid, (Any, Any, Any), GapObj, GAP, :GapObj)
+    # for `GAP_jll.GapObj`) is printed as ours
+    ccall((:OverrideTypeNameAndModule, JuliaInterface_path()), Cvoid, (Any, Any), GapObj, GAP)
 
     # regenerate GAPROOT if it was removed
     if !isdir(GAPROOT) || isempty(readdir(GAPROOT))


### PR DESCRIPTION
... not the name, as that is already the way we want it these days.

Alternatively, we could just remove this outright: then users will see `GAP_jll.GapObj` instead of `GapObj` or `GAP.GapObj`. But for Oscar.jl that shouldn't matter, as end users should not normally see such objects "naked". And in any case, it is not *that* bad, is it?

Closes #805 (for which this PR is an alternative)