### PR TITLE
Remove OverrideTypeNameAndModule hack

### DIFF
--- a/pkg/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/JuliaInterface/src/JuliaInterface.c
@@ -157,35 +157,6 @@ void ResetUserHasQUIT(void)
 }
 
 
-// HACK: this helper function is called from Julia to override the parent
-// module and name of the type used for GAP objects. We used to achieve the
-// same via pure Julia like this:
-//
-//    GapObj.name.module = GAP
-//    GapObj.name.name = :GapObj
-//
-// However in recent Julia 1.8-DEV builds, a feature was introduced to mark
-// individual fields of mutable structs const, and this was used to make those
-// field of type `TypeName` const, so that code doesn't work anymore. For now,
-// it is still safe to override the type on the C kernel level, but we should
-// start thinking about long-term alternatives.
-void OverrideTypeNameAndModule(jl_value_t * type,
-                               jl_value_t * module,
-                               jl_value_t * name)
-{
-    if (!jl_is_datatype(type))
-        jl_error("<type> is not a DataType");
-    if (!jl_is_module(module))
-        jl_error("<module> is not a module");
-    if (!jl_is_symbol(name))
-        jl_error("<name> is not a symbol");
-
-    jl_datatype_t * t = (jl_datatype_t *)type;
-    t->name->name = (jl_sym_t *)name;
-    t->name->module = (jl_module_t *)module;
-}
-
-
 /*
  * Returns the function from the Object <func>
  * or the function with name <func> from

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -211,10 +211,6 @@ function __init__()
         windows_error()
     end
 
-    # HACK HACK HACK: ensure the type GapObj (which is just an alias
-    # for `GAP_jll.MPtr`) is printed as ours
-    ccall((:OverrideTypeNameAndModule, JuliaInterface_path()), Cvoid, (Any, Any, Any), GapObj, GAP, :GapObj)
-
     # regenerate GAPROOT if it was removed
     if !isdir(GAPROOT) || isempty(readdir(GAPROOT))
         Setup.regenerate_gaproot(GAPROOT)

--- a/test/adapter.jl
+++ b/test/adapter.jl
@@ -53,5 +53,5 @@ end
 
     ioc = IOContext(io, :module => nothing);
     print(ioc, GAP.GapObj)
-    @test String(take!(io)) == "GAP.GapObj"
+    @test String(take!(io)) == "GAP_jll.GapObj"
 end


### PR DESCRIPTION
This means that type `GapObj` is no longer printed as `GapObj` resp.
`GAP.GapObj` (depending on context) but rather as `GAP_jll.GapObj`.

But it avoids a deep hack in the Julia kernel that could cause lots
of pain for us in the future.

Closes #804 (for which this PR is an alternative)
