### PR TITLE
access to internals of positional and component objects

### DIFF
--- a/docs/src/other.md
+++ b/docs/src/other.md
@@ -25,9 +25,13 @@ call_gap_func
 call_with_catch
 getindex
 setindex!
+getbangindex
+setbangindex!
 getproperty
 setproperty!
 hasproperty
+getbangproperty
+setbangproperty!
 wrap_rng
 randseed!
 ```

--- a/pkg/JuliaInterface/gap/utils.gi
+++ b/pkg/JuliaInterface/gap/utils.gi
@@ -4,6 +4,21 @@
 ##
 #############################################################################
 
+## Access data from component and positional objects
+BindGlobal( "BangComponent", { obj, nam } -> obj!.( nam ) );
+
+BindGlobal( "SetBangComponent",
+  function( obj, nam, val )
+    obj!.( nam ):= val;
+  end );
+
+BindGlobal( "BangPosition", { obj, pos } -> obj![ pos ] );
+
+BindGlobal( "SetBangPosition",
+  function( obj, pos, val )
+    obj![ pos ]:= val;
+  end );
+
 ## Create a record from key value lists
 BindGlobal( "CreateRecFromKeyValuePairList",
   function( keys, vals )


### PR DESCRIPTION
added `getbangindex`, `setbangindex!`, `getbangproperty`, `setbangproperty!`

This addresses issue #771.

Eventually the GAP side functionality (`BangComponent`, `SetBangComponent`, `BangPosition`, `SetBangPosition`) should become available in libgap.