### PR TITLE
Switch GAP.Packages test to use `fga` instead of `io`

### DIFF
--- a/test/packages.jl
+++ b/test/packages.jl
@@ -4,11 +4,11 @@
     @test ! GAP.Packages.load("no such package")
     @test ! GAP.Packages.load("no such package", install = true)
 
-    @test GAP.Packages.install("io", interactive = false)
-    @test GAP.Packages.remove("io", interactive = false)
+    @test GAP.Packages.install("fga", interactive = false)
+    @test GAP.Packages.remove("fga", interactive = false)
 
 #    pkgdir = mktempdir()
-#    @test GAP.Packages.install("io", interactive = false, pkgdir = pkgdir)
-#    @test GAP.Packages.remove("io", interactive = false, pkgdir = pkgdir)
+#    @test GAP.Packages.install("fga", interactive = false, pkgdir = pkgdir)
+#    @test GAP.Packages.remove("fga", interactive = false, pkgdir = pkgdir)
 
 end


### PR DESCRIPTION
... as a test package to install and remove. This should help us pass tests
when run inside environments without a C compiler, such as NanoSoldier.
