### PR TITLE
install a `GAP.Globals.Download` method if possible

### DIFF
--- a/src/packages.jl
+++ b/src/packages.jl
@@ -35,13 +35,18 @@ function init_packagemanager()
            :name => "via Julia's Downloads.download",
            :isAvailable => Globals.ReturnTrue,
            :download => function(url, opt)
-             # exception handling is omitted by concept, i.e. errors occuring during the download are shown to the user
-             if hasproperty(opt, :target)
-               Downloads.download(String(url), String(opt.target))
-               return GapObj(Dict{Symbol, Any}(:success => true), recursive=true)
-             else
-               buffer = Downloads.download(String(url), IOBuffer())
-               return GapObj(Dict{Symbol, Any}(:success => true, :result => String(take!(buffer))), recursive=true)
+             try
+               if hasproperty(opt, :target)
+                 Downloads.download(String(url), String(opt.target))
+                 return GapObj(Dict{Symbol, Any}(:success => true), recursive=true)
+               else
+                 buffer = Downloads.download(String(url), IOBuffer())
+                 return GapObj(Dict{Symbol, Any}(:success => true, :result => String(take!(buffer))), recursive=true)
+               end
+             catch(e)
+               return GapObj(Dict{Symbol, Any}(:success => false,
+                                               :error => GapObj(string(e))),
+                             recursive=true)
              end
            end)
 

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -43,7 +43,7 @@ function init_packagemanager()
                  buffer = Downloads.download(String(url), IOBuffer())
                  return GapObj(Dict{Symbol, Any}(:success => true, :result => String(take!(buffer))), recursive=true)
                end
-             catch(e)
+             catch e
                return GapObj(Dict{Symbol, Any}(:success => false,
                                                :error => GapObj(string(e))),
                              recursive=true)

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -7,6 +7,10 @@ import ...GAP: Globals, GapObj, sysinfo
 const DEFAULT_PKGDIR = sysinfo["DEFAULT_PKGDIR"]
 
 function init_packagemanager()
+#TODO:
+# As soon as PackageManager uses utils' Download function,
+# we need not replace code from PackageManager anymore.
+# (And the function should be renamed.)
     res = load("PackageManager")
     @assert res
 
@@ -18,6 +22,33 @@ function init_packagemanager()
         return GapObj(Dict{Symbol, Any}(:success => true, :result => String(take!(buffer))), recursive=true)
     end
     Globals.MakeReadOnlyGlobal(GapObj("PKGMAN_DownloadURL"))
+
+    # Install a method (based on Julia's Downloads package) as the first choice
+    # for the `Download` function from GAP's utils package,
+    # in order to make this function independent of the availability of some
+    # external program that is not guaranteed by an explicit dependency.
+    res = load("utils")
+    @assert res
+    if hasproperty(Globals, :Download_Methods)
+      # provide a Julia function as a `Download` method
+      r = Dict{Symbol, Any}(
+           :name => "via Julia's Downloads.download",
+           :isAvailable => Globals.ReturnTrue,
+           :download => function(url, opt)
+             # exception handling is omitted by concept, i.e. errors occuring during the download are shown to the user
+             if hasproperty(opt, :target)
+               Downloads.download(String(url), String(opt.target))
+               return GapObj(Dict{Symbol, Any}(:success => true), recursive=true)
+             else
+               buffer = Downloads.download(String(url), IOBuffer())
+               return GapObj(Dict{Symbol, Any}(:success => true, :result => String(take!(buffer))), recursive=true)
+             end
+           end)
+
+      # put the new method in the first position
+      meths = Globals.Download_Methods
+      Globals.Add(meths, GapObj(r, recursive=true), 1)
+    end
 end
 
 """
@@ -82,6 +113,9 @@ function install(spec::String; interactive::Bool = true, quiet::Bool = false,
     mkpath(pkgdir)
 
     try
+#T When a new PackageManager version will be available,
+#T this try/catch is no longer necessary,
+#T because no GAP error is thrown when one is offline or so.
       if quiet
         oldlevel = Globals.InfoLevel(Globals.InfoPackageManager)
         Globals.SetInfoLevel(Globals.InfoPackageManager, 0)


### PR DESCRIPTION
If GAP knows the global list `Download_Methods` then add a new `Download` method in the first place, such that Julia's `Downloads.download` is used.
This way, we do no longer rely on whether or not some GAP package or external program is available that provides download functionality.

This pull request should not be merged at the moment because it relies on gap-packages/utils/pull/48, which may change before it gets merged.