### PR TITLE
extend the `julia_to_gap` documentation

### DIFF
--- a/pkg/JuliaInterface/gap/convert.gd
+++ b/pkg/JuliaInterface/gap/convert.gd
@@ -316,7 +316,7 @@
 #!      <Item>strings</Item>
 #!    </Row>
 #!    <Row>
-#!      <Item>Symbol</Item>
+#!      <Item><C>Symbol</C></Item>
 #!      <Item><C>IsString</C></Item>
 #!      <Item>strings</Item>
 #!    </Row>

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -63,6 +63,25 @@ julia> GAP.gap_to_julia( Matrix{Int}, val )
  1  2
  3  4
 ```
+
+The following `gap_to_julia` conversions are supported by GAP.jl.
+(Other Julia packages may provide conversions for more GAP objects.)
+
+| GAP filter    | default Julia type       | other Julia types     |
+|---------------|--------------------------|-----------------------|
+| `IsInt`       | `BigInt`                 | `T <: Integer         |
+| `IsFFE`       | `GapFFE`                 |                       |
+| `IsBool`      | `Bool`                   |                       |
+| `IsRat`       | `Rational{BigInt}`       | `Rational{T}          |
+| `IsFloat`     | `Float64`                | `T <: AbstractFloat   |
+| `IsChar`      | `Cuchar`                 | `Char`                |
+| `IsStringRep` | `String`                 | `Symbol`, `Vector{T}` |
+| `IsRangeRep`  | `StepRange{Int64,Int64}` | `Vector{T}`           |
+| `IsBListRep`  | `BitVector`              | `Vector{T}`           |
+| `IsList`      | `Vector{Any}`            | `Vector{T}`           |
+| `IsVectorObj` | `Vector{Any}`            | `Vector{T}`           |
+| `IsMatrixObj` | `Matrix{Any}`            | `Matrix{T}`           |
+| `IsRecord`    | `Dict{Symbol, Any}`      | `Dict{Symbol, T}`     |
 """
 function gap_to_julia(t::T, x::Any) where {T<:Type}
     ## Default for conversion:
@@ -127,7 +146,7 @@ gap_to_julia(::Type{T}, obj::GapObj) where {T<:AbstractString} = T(obj)
 ## Symbols
 gap_to_julia(::Type{Symbol}, obj::GapObj) = Symbol(obj)
 
-## Convert GAP string to Vector{UInt8} (==Vector{UInt8})
+## Convert GAP string to Vector{UInt8}
 function gap_to_julia(::Type{Vector{UInt8}}, obj::GapObj)
     Wrappers.IsStringRep(obj) && return CSTR_STRING_AS_ARRAY(obj)
     Wrappers.IsList(obj) && return UInt8[gap_to_julia(UInt8, obj[i]) for i = 1:length(obj)]

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -24,6 +24,24 @@ julia> GAP.julia_to_gap([ [1, 2], [3, 4]], recursive = true)
 GAP: [ [ 1, 2 ], [ 3, 4 ] ]
 
 ```
+
+The following `julia_to_gap` conversions are supported by GAP.jl.
+(Other Julia packages may provide conversions for more Julia objects.)
+
+| Julia type                           | GAP filter |
+|--------------------------------------|------------|
+| `Int8`, `Int16`, ..., `BigInt`       | `IsInt`    |
+| `GapFFE`                             | `IsFFE`    |
+| `Bool`                               | `IsBool`   |
+| `Rational{T}`                        | `IsRat`    |
+| `Float16`, `Float32`, `Float64`      | `IsFloat`  |
+| `AbstractString`                     | `IsString` |
+| `Symbol`                             | `IsString` |
+| `Vector{T}`                          | `IsList`   |
+| `Vector{Bool}`, `BitVector`          | `IsBList`  |
+| `Tuple{T}`                           | `IsList`   |
+| `Dict{String, T}`, `Dict{Symbol, T}` | `IsRecord` |
+| `UnitRange{T}`, `StepRange{T}`       | `IsRange`  |
 """
 julia_to_gap(x::FFE) = x    # Default for actual GAP objects is to do nothing
 julia_to_gap(x::Bool) = x   # Default for actual GAP objects is to do nothing

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -28,20 +28,23 @@ GAP: [ [ 1, 2 ], [ 3, 4 ] ]
 The following `julia_to_gap` conversions are supported by GAP.jl.
 (Other Julia packages may provide conversions for more Julia objects.)
 
-| Julia type                           | GAP filter |
-|--------------------------------------|------------|
-| `Int8`, `Int16`, ..., `BigInt`       | `IsInt`    |
-| `GapFFE`                             | `IsFFE`    |
-| `Bool`                               | `IsBool`   |
-| `Rational{T}`                        | `IsRat`    |
-| `Float16`, `Float32`, `Float64`      | `IsFloat`  |
-| `AbstractString`                     | `IsString` |
-| `Symbol`                             | `IsString` |
-| `Vector{T}`                          | `IsList`   |
-| `Vector{Bool}`, `BitVector`          | `IsBList`  |
-| `Tuple{T}`                           | `IsList`   |
-| `Dict{String, T}`, `Dict{Symbol, T}` | `IsRecord` |
-| `UnitRange{T}`, `StepRange{T}`       | `IsRange`  |
+| Julia type                           | GAP filter   |
+|--------------------------------------|--------------|
+| `Int8`, `Int16`, ..., `BigInt`       | `IsInt`      |
+| `GapFFE`                             | `IsFFE`      |
+| `Bool`                               | `IsBool`     |
+| `Rational{T}`                        | `IsRat`      |
+| `Float16`, `Float32`, `Float64`      | `IsFloat`    |
+| `AbstractString`                     | `IsString`   |
+| `Symbol`                             | `IsString`   |
+| `Char`                               | `IsChar`     |
+| `Vector{T}`                          | `IsList`     |
+| `Vector{Bool}`, `BitVector`          | `IsBList`    |
+| `Tuple{T}`                           | `IsList`     |
+| `Matrix{T}`                          | `IsList`     |
+| `Dict{String, T}`, `Dict{Symbol, T}` | `IsRecord`   |
+| `UnitRange{T}`, `StepRange{T, S}`    | `IsRange`    |
+| `Function`                           | `IsFunction` |
 """
 julia_to_gap(x::FFE) = x    # Default for actual GAP objects is to do nothing
 julia_to_gap(x::Bool) = x   # Default for actual GAP objects is to do nothing


### PR DESCRIPTION
by the explicit list of types for which conversions are provided in GAP.jl (the list which was already in the JuliaInterface manual)

This addresses issue #823.