### PR TITLE
Use Scratch.jl for GAP root

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,12 +15,14 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 
 [compat]
 GAP_jll = "~400.1192.001"
 GAP_lib_jll = "~400.1192.002"
 GAP_pkg_juliainterface_jll = "=0.800.000"
 MacroTools = "0.5"
+Scratch = "1.1"
 julia = "1.6"
 
 [extras]

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -4,11 +4,13 @@ module Packages
 using Downloads
 import ...GAP: Globals, GapObj, sysinfo
 
-const DEFAULT_PKGDIR = sysinfo["DEFAULT_PKGDIR"]
+const DEFAULT_PKGDIR = Ref{String}()
 
 function init_packagemanager()
     res = load("PackageManager")
     @assert res
+
+    global DEFAULT_PKGDIR[] = sysinfo["DEFAULT_PKGDIR"]
 
     # overwrite PKGMAN_DownloadURL
     Globals.MakeReadWriteGlobal(GapObj("PKGMAN_DownloadURL"))
@@ -58,7 +60,7 @@ end
 
 """
     install(spec::String; interactive::Bool = true, quiet::Bool = false,
-                          pkgdir::AbstractString = GAP.Packages.DEFAULT_PKGDIR)
+                          pkgdir::AbstractString = GAP.Packages.DEFAULT_PKGDIR[])
 
 Download and install the newest released version of the GAP package
 given by `spec` into the `pkgdir` directory.
@@ -76,7 +78,7 @@ prevent `PackageManager` from prompting the user for input interactively.
 For details, please refer to its documentation.
 """
 function install(spec::String; interactive::Bool = true, quiet::Bool = false,
-                               pkgdir::AbstractString = DEFAULT_PKGDIR)
+                               pkgdir::AbstractString = DEFAULT_PKGDIR[])
     # point PackageManager to the given pkg dir
     Globals.PKGMAN_CustomPackageDir = GapObj(pkgdir)
     mkpath(pkgdir)
@@ -101,7 +103,7 @@ end
 
 """
     update(spec::String; interactive::Bool = true, quiet::Bool = false,
-                         pkgdir::AbstractString = GAP.Packages.DEFAULT_PKGDIR)
+                         pkgdir::AbstractString = GAP.Packages.DEFAULT_PKGDIR[])
 
 Update the GAP package given by `spec` that is installed in the
 `pkgdir` directory, to the latest version.
@@ -119,7 +121,7 @@ prevent `PackageManager` from prompting the user for input interactively.
 For details, please refer to its documentation.
 """
 function update(spec::String; interactive::Bool = true, quiet::Bool = false,
-                              pkgdir::AbstractString = DEFAULT_PKGDIR)
+                              pkgdir::AbstractString = DEFAULT_PKGDIR[])
     # point PackageManager to the given pkg dir
     Globals.PKGMAN_CustomPackageDir = GapObj(pkgdir)
     mkpath(pkgdir)
@@ -140,7 +142,7 @@ end
 
 """
     remove(spec::String; interactive::Bool = true, quiet::Bool = false,
-                         pkgdir::AbstractString = GAP.Packages.DEFAULT_PKGDIR)
+                         pkgdir::AbstractString = GAP.Packages.DEFAULT_PKGDIR[])
 
 Remove the GAP package with name `spec` that is installed in the
 `pkgdir` directory.
@@ -154,7 +156,7 @@ prevent `PackageManager` from prompting the user for input interactively.
 For details, please refer to its documentation.
 """
 function remove(spec::String; interactive::Bool = true, quiet::Bool = false,
-                              pkgdir::AbstractString = DEFAULT_PKGDIR)
+                              pkgdir::AbstractString = DEFAULT_PKGDIR[])
     # point PackageManager to the given pkg dir
     Globals.PKGMAN_CustomPackageDir = GapObj(pkgdir)
     mkpath(pkgdir)


### PR DESCRIPTION
This also forces a full regeneration of our custom GAP root dir each time the package loads, instead of only during precompilation. This adds ~130 milliseconds startup overhead for me, of which 90% are spent in finding working C/C++ compilers... Not great, but with Scratch.jl any of the directories could move, so we kinda have to do it this way, as far as I can tell (Polymake.jl also does it this way). Perhaps I could at least cache the C/C++ compiler values somehow, but for now I just want to have this working.

Resolves #822
Resolves #728