### PR TITLE
Use `jl_reinit_foreign_type` if available

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Version 0.9.2-DEV (released YYYY-MM-DD)
 
+- Silence scary warning about missing compiler
+- Prepare for an upcoming change to serialization in Julia 1.10
+
 ## Version 0.9.1 (released 2022-11-23)
 
 - Added a longer example for using GAP.jl, based around the Rubik's cube

--- a/pkg/JuliaInterface/example/function_perform.jl
+++ b/pkg/JuliaInterface/example/function_perform.jl
@@ -1,6 +1,6 @@
 module GapFunctionPerform
 
-import GAP_jll: GapObj
+import GAP: GapObj
 
 function typed_func(a::GapObj, b::GapObj)
     return a

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,24 @@
+if use_jl_reinit_foreign_type()
+    const GapObj = ccall((:GAP_DeclareGapObj, libgap),
+                            Any,
+                            (Symbol, Module, Any),
+                            :GapObj, GAP, Any)
+
+    const SmallBag = ccall((:GAP_DeclareBag, libgap),
+                            Any,
+                            (Symbol, Module, Any, Cint),
+                            :SmallBag, GAP, Any, 0)
+
+    const LargeBag = ccall((:GAP_DeclareBag, libgap),
+                            Any,
+                            (Symbol, Module, Any, Cint),
+                            :LargeBag, GAP, Any, 1)
+
+else
+
 import GAP_jll: GapObj
+
+end
 
 
 """

--- a/test/adapter.jl
+++ b/test/adapter.jl
@@ -53,5 +53,9 @@ end
 
     ioc = IOContext(io, :module => nothing);
     print(ioc, GAP.GapObj)
-    @test String(take!(io)) == "GAP_jll.GapObj"
+    if GAP.use_jl_reinit_foreign_type()
+        @test String(take!(io)) == "GAP.GapObj"
+    else
+        @test String(take!(io)) == "GAP_jll.GapObj"
+    end
 end


### PR DESCRIPTION
This prepares us for an upcoming change to serialization in Julia 1.10, see issue #846.