### PR TITLE
admit prescribing a package version ...

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 - Silence scary warning about missing compiler
 - Prepare for an upcoming change to serialization in Julia 1.10
+- `Packages.install` and thus also `Packages.load` with argument
+  `install = true` admit prescribing a version number of the package
+  to be loaded/installed
 
 ## Version 0.9.1 (released 2022-11-23)
 


### PR DESCRIPTION
... in `GAP.Packages.install`.
This is meanwhile supported by GAP's PackageManager package.

The most interesting application is perhaps `GAP.Packages.load` with argument `install = true`, because now we can ask for loading a good enough version of a perhaps previously not installed package, and get `false` if this is not possible.

(Also fixed now: `GAP.Packages.load` had returned `fail` in some situations, now `false` is returned in these cases.)

Resolves issue #627.