### PR TITLE
admit `gap_to_julia` conversion to `Vector{GAP.Obj}`

### DIFF
--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -186,7 +186,11 @@ function gap_to_julia(
             end
             if recursive && !isbitstype(typeof(current_obj))
                 new_array[i] = get!(recursion_dict, current_obj) do
+                  if T == GapObj || T == Obj
+                    julia_to_gap(current_obj, recursion_dict; recursive = true)
+                  else
                     gap_to_julia(T, current_obj, recursion_dict; recursive = true)
+                  end
                 end
             else
                 new_array[i] = current_obj

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -284,6 +284,9 @@
     @test [(1,)] == yy
     @test typeof(yy) == Vector{Tuple{Int64}}
 
+    x = BigInt(2)^64
+    L = GAP.evalstr("List([1..10], i -> Julia.Main.x + i)")
+    @test Vector{GAP.GapObj}(L) == [GAP.GapObj(x) for x in L]
 end
 
 @testset "conversion to GAP" begin


### PR DESCRIPTION
This addresses issue #740, but I am still not sure what would be a good solution.