### PR TITLE
compat: allow GAP_pkg_juliainterface_jll 0.800.202

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 [compat]
 GAP_jll = "~400.1200.101"
 GAP_lib_jll = "~400.1201.100"
-GAP_pkg_juliainterface_jll = "=0.800.201"
+GAP_pkg_juliainterface_jll = "=0.800.201, =0.800.202"
 MacroTools = "0.5"
 Scratch = "1.1"
 julia = "1.6"


### PR DESCRIPTION
Not sure if this is correct, or why the previous 0.800.202 was not allowed so far.
But something like this is needed to allow the new rebuild for julia nightly, maybe the restriction can be loosened up a bit?

The nightly build will probably still fail as the new releases are not in the julia registry yet.