### PR TITLE
avoid warnings shown by `TerminalMenus`

### DIFF
--- a/src/help.jl
+++ b/src/help.jl
@@ -3,7 +3,8 @@
 using REPL
 
 function gap_help_string(topic::String, onlyexact::Bool = false,
-    term::REPL.Terminals.TTYTerminal = REPL.TerminalMenus.terminal)
+    term::REPL.Terminals.TTYTerminal = REPL.TerminalMenus.terminal;
+    suppress_output::Bool = false)
     # Let GAP collect the information.
     info = Globals.HELP_Info(GapObj(topic), onlyexact)
 
@@ -21,7 +22,8 @@ function gap_help_string(topic::String, onlyexact::Bool = false,
                 choice = REPL.TerminalMenus.request(
                     term,
                     "Choose an entry (out of $len) to view, 'q' for none:",
-                    REPL.TerminalMenus.RadioMenu(options, pagesize = pagesize, charset = :ascii))
+                    REPL.TerminalMenus.RadioMenu(options, pagesize = pagesize, charset = :ascii),
+                    suppress_output = suppress_output)
                 if choice == -1
                     # canceled
                     return ""

--- a/test/help.jl
+++ b/test/help.jl
@@ -5,12 +5,9 @@
     function test_gap_help(topic::String)
         inp = Base.IOBuffer("qq") # exit the menu if applicable
         term = REPL.Terminals.TTYTerminal( "dumb", inp, tt.out_stream, tt.err_stream)
-        return isa(GAP.gap_help_string(topic, false, term), String) &&
-               isa(GAP.gap_help_string(topic, true, term), String)
+        return isa(GAP.gap_help_string(topic, false, term, suppress_output = true), String) &&
+               isa(GAP.gap_help_string(topic, true, term, suppress_output = true), String)
     end
-
-    # Do not print the menus.
-    REPL.TerminalMenus.config(supress_output = true)
 
     @test test_gap_help("")
     @test test_gap_help("&")


### PR DESCRIPTION
resolves #872

According to `?REPL.TerminalMenus.config`, the argument `supress_output` (sic!) is not supported anymore. The proposed change follows the advice to call `request` with a `suppress_output` keyword argument.