### PR TITLE
Remove nonsense finalize() method

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -46,7 +46,6 @@ end
 
 include("setup.jl")
 
-import Base: length, finalize
 import Libdl
 import Markdown
 import Random
@@ -213,10 +212,6 @@ function initialize(argv::Vector{String})
     GAP.Globals.Read(GapObj(joinpath(@__DIR__, "..", "gap", "err.g")))
 
     return nothing
-end
-
-function finalize()
-    ccall((:GAP_finalize, libgap), Cvoid, ())
 end
 
 function exit_code()


### PR DESCRIPTION
I don't know if this ever did something, but it certainly doesn't now.
Found via the Aqua package.
