### PR TITLE
Quote @gap and g_str results

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -59,7 +59,7 @@ GAP: (1,2)(3,4)
 ```
 """
 macro gap(str)
-    return evalstr(string(str))
+    return :(evalstr($(string(str))))
 end
 
 export @gap
@@ -101,7 +101,7 @@ not all strings representing valid GAP strings can be processed.
 
 ```jldoctest
 julia> g"\\\\"
-ERROR: LoadError: Error thrown by GAP: Syntax error: String must end with " before end of file in stream:1
+ERROR: Error thrown by GAP: Syntax error: String must end with " before end of file in stream:1
 [...]
 
 ```
@@ -116,7 +116,7 @@ GAP: "\\c"
 ```
 """
 macro g_str(str)
-    return gap_string_macro_helper(str)
+    return :(gap_string_macro_helper($str))
 end
 
 export @g_str

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -48,16 +48,12 @@ end
     @test x == GAP.evalstr("[1,2,3]")
     x = @gap(SymmetricGroup)(3)
     @test GAP.Globals.Size(x) == 6
-    # Errors thrown by the GAP.@gap macro cannot be tested directly,
-    # the following test does not work as intended.
-    # @test_throws ErrorException @gap (1,2)(3,4)
+    @test_throws ErrorException @gap (1,2)(3,4)
 
     x = GAP.g"foo"
     @test x == GAP.julia_to_gap("foo")
     x = GAP.g"1:\n, 2:\", 3:\\, 4:\b, 5:\r, 6:\c, 7:\001"
     @test x == GAP.julia_to_gap("1:\n, 2:\", 3:\\, 4:\b, 5:\r, 6:\003, 7:\001")
-    # Errors thrown by the GAP.@g_str macro cannot be tested directly,
-    # and the string "\\" can be handed over in the macro.
-    @test_throws ErrorException GAP.gap_string_macro_helper("\\")
+    @test_throws ErrorException g"\\"
 
 end


### PR DESCRIPTION
This way they get executed when the code containing them is executed, and not already during parse time, which is unexpected.

Resolves #903 

CC @kalmarek 