### PR TITLE
Reduce implicit dependencies on GAP packages

### DIFF
--- a/pkg/JuliaInterface/gap/helpstring.g
+++ b/pkg/JuliaInterface/gap/helpstring.g
@@ -323,6 +323,11 @@ BindGlobal( "HELP_GET_MATCHES2", function( books, topic, frombegin )
   return [exact, match];
 end);
 
+BindGlobal( "HELP_SCREEN_WIDTH_LINE", function()
+  local s;
+  s := ListWithIdenticalEntries(SizeScreen()[1], "─");
+  return Concatenation(s);
+end );
 
 #############################################################################
 ##
@@ -344,7 +349,7 @@ BindGlobal( "HELP_DESC_MATCHES", function( books, topic, frombegin, onlyexact...
   if 0 = Length(match) and 0 = Length(exact)  then
     return [ false, [ "Help: no matching entry found" ] ];
   else
-    sep:= [ "", RepeatedUTF8String( "─", SizeScreen()[1] ), "" ];
+    sep:= [ "", HELP_SCREEN_WIDTH_LINE(), "" ];
     HELP_LAST.TOPICS:=[];
     # show exact matches first
     match := Concatenation(exact, match);
@@ -569,7 +574,7 @@ InstallGlobalFunction( HELP_String, function( str, onlyexact )
       return info;
     fi;
 
-    sep:= [ "", RepeatedUTF8String( "─", SizeScreen()[1] ), "" ];
+    sep:= [ "", HELP_SCREEN_WIDTH_LINE(), "" ];
     lines:= [];
     for i in [ 1 .. Length( info.entries ) ] do
       Add( lines, Concatenation( info.entries[i][1].bookname, ":" ) );
@@ -627,7 +632,7 @@ BindGlobal( "ComposedHelpString", function( entry )
     desc:= HELP_DESC_MATCH( entry )[2];
     Add( lines, Concatenation( entry[1].bookname, ":" ) );
     Append( lines, desc );
-    sep:= [ "", RepeatedUTF8String( "─", SizeScreen()[1] ), "" ];
+    sep:= [ "", HELP_SCREEN_WIDTH_LINE(), "" ];
     Append( lines, sep );
     res:= "";
     if IsBound( entry[1].start ) then

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -251,17 +251,11 @@ For convenience, one can use the syntax `func(args...; kwargs...)`.
 julia> GAP.Globals.Factors( 12 )
 GAP: [ 2, 2, 3 ]
 
-julia> g = GAP.Globals.SylowSubgroup( GAP.Globals.SymmetricGroup( 6 ), 2 )
-GAP: Group([ (1,2), (3,4), (1,3)(2,4), (5,6) ])
+julia> GAP.Globals.Cyc(GAP.Obj(1.41421356))
+GAP: 35355339/25000000
 
-julia> GAP.Globals.StructureDescription( g )
-GAP: "C2 x D8"
-
-julia> g = GAP.Globals.SylowSubgroup( GAP.Globals.SymmetricGroup( 6 ), 2 );
-
-julia> GAP.Globals.StructureDescription( g, short = true )
-GAP: "2xD8"
-
+julia> GAP.Globals.Cyc(GAP.Obj(1.41421356); bits=20)
+GAP: E(8)-E(8)^3
 ```
 """
 function call_gap_func(func::GapObj, args...; kwargs...)

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -22,16 +22,18 @@
     @test occursin("Set the value", string(doc))
 
     # Do tester and setter refer to the right objects?
+    # (Choose a group `G` whose center is different from the center
+    # of its derived subgroup.)
     @gapattribute cendersub(G::GapObj) = GAP.Globals.Centre(dersub(G))
-    G = GAP.Globals.SmallGroup(72, 15)
+    G = GAP.Globals.SymmetricGroup(3)
     @test GAP.Globals.Size(GAP.Globals.Centre(G)) == 1
-    G = GAP.Globals.SmallGroup(72, 15)  # create the group anew
+    G = GAP.Globals.SymmetricGroup(3)  # create the group anew
     @test ! GAP.Globals.HasCentre(G)
     @test ! has_dersub(G)
     @test ! has_cendersub(G)
     @test has_dersub(G)  # the previous call has set the value
     ggens = GAP.Globals.GeneratorsOfGroup(G)
-    set_cendersub(G, GAP.Globals.Subgroup(G, GAP.GapObj([ggens[3]])))
+    set_cendersub(G, GAP.Globals.Subgroup(G, GAP.GapObj([ggens[1]])))
     @test has_cendersub(G)
     @test GAP.Globals.HasCentre(GAP.Globals.DerivedSubgroup(G))
     @test GAP.Globals.Size(GAP.Globals.Centre(G)) == 1

--- a/test/packages.jl
+++ b/test/packages.jl
@@ -13,7 +13,7 @@
 
     # Load packages via their local paths.
     # - a package that was already loaded, with the same path
-    path = string(GAP.Globals.GAPInfo.PackagesLoaded.ctbllib[1])
+    path = string(GAP.Globals.GAPInfo.PackagesLoaded.juliainterface[1])
     @test GAP.Packages.load(path)
 
     # - a package that was already loaded, with another installation path


### PR DESCRIPTION
These changes avoid some direct or indirect access to functionality
provided by GAP packages (namely CTblLib, GAPDoc, SmallGrp).

The ultimate goal is to switch GAP.jl to start GAP with `-A` or even
`--bare` (or something equivalent) and then leave it to users to load
packages. We could also have a `GAP_full.jl` or so which loads `GAP.jl`
and all default packages etc., but that's all very hypothetical: These
changes are harmless either way, even if everything else stays as it is.