### PR TITLE
Allow GAP.Obj(x,true) for recursive conversion

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -6,6 +6,9 @@ GapObj(x::GapObj) = x
 Obj(obj; recursive::Bool = false) = julia_to_gap(obj, IdDict(); recursive)::Obj
 GapObj(obj; recursive::Bool = false) = julia_to_gap(obj, IdDict(); recursive)::GapObj
 
+Obj(obj, recursive::Bool) = julia_to_gap(obj, IdDict(); recursive)::Obj
+GapObj(obj, recursive::Bool) = julia_to_gap(obj, IdDict(); recursive)::GapObj
+
 """
     BigInt(obj::GapObj)
 


### PR DESCRIPTION
This makes it much more convenient to use from GAP: `Julia.GAP.Obj(x,true)`

TODO: document it somewhere, add a test
