### PR TITLE
Only load bare deps if env var GAP_BARE_DEPS is set

### DIFF
--- a/gap/systemfile.g
+++ b/gap/systemfile.g
@@ -6,6 +6,9 @@
     # and such that it is available when user files get read
     # via the GAP command line.
     deps:= SHALLOW_COPY_OBJ( GAPInfo.Dependencies.NeededOtherPackages );
+    if IsBound(GAPInfo.KernelInfo.ENVIRONMENT.GAP_BARE_DEPS) then
+        deps:= [];
+    fi;
     APPEND_LIST_INTR( deps, [ [ "JuliaInterface", ">=0.9.8-DEV" ] ] );
     GAPInfo.Dependencies:= MakeImmutable( rec( NeededOtherPackages:= deps ) );
 

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -286,6 +286,10 @@ function __init__()
         push!(cmdline_options, "-b")
     end
 
+    if haskey(ENV, "GAP_BARE_DEPS")
+        push!(cmdline_options, "-A")
+    end
+
     initialize(cmdline_options)
 
     if !show_banner


### PR DESCRIPTION
This may or may not become default in a future (breaking) release. But for now it is simply useful for debugging the `GAP_pkg_*` work at https://github.com/oscar-system/GAP_pkg