### PR TITLE
Re-enable REPL completion for GAP records in Julia 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.9.8-DEV"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 GAP_jll = "5cd7a574-2c56-5be2-91dc-c8bc375b9ddf"
 GAP_lib_jll = "de1ad85e-c930-5cd4-919d-ccd3fcafd1a3"
@@ -21,6 +22,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 
 [compat]
+Compat = "4.4.0"
 GAP_jll = "~400.1200.101"
 GAP_lib_jll = "~400.1201.100"
 GAP_pkg_juliainterface_jll = "=0.800.300"

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -1,11 +1,12 @@
 ## Internal ccall's
+import Compat # for Base.@assume_effects emulation in Julia <= 1.7
 
 import Base: getproperty, hasproperty, setproperty!, propertynames
 
 #
 # low-level GAP -> Julia conversion
 #
-function _GAP_TO_JULIA(ptr::Ptr{Cvoid})
+Compat.@assume_effects :effect_free :terminates_globally function _GAP_TO_JULIA(ptr::Ptr{Cvoid})
     ptr == C_NULL && return nothing
     # convert immediate ints and FFEs directly, to avoid (un)boxing
     as_int = reinterpret(Int, ptr)
@@ -155,7 +156,7 @@ end
 
 # Retrieve the value of a global GAP variable given its name. This function
 # returns a raw Ptr value, and should only be called by plumbing code.
-function _ValueGlobalVariable(name::Union{AbstractString,Symbol})
+Compat.@assume_effects :effect_free :terminates_globally function _ValueGlobalVariable(name::Union{AbstractString,Symbol})
     return ccall((:GAP_ValueGlobalVariable, libgap), Ptr{Cvoid}, (Cstring,), name)
 end
 

--- a/src/globals.jl
+++ b/src/globals.jl
@@ -70,10 +70,6 @@ propertynames(::GlobalsType, private::Bool=false) = Vector{Symbol}(Globals.Names
       return (_GAP_TO_JULIA(v), true)
   end
   get_value(sym::QuoteNode, fn::GAP.GlobalsType) = get_value(sym.value, fn)
-
-else
-  # TODO: the above HACK does not work anymore in Julia 1.10; someone needs
-  # to find out how to make it work there
 end
 
 propertynames(r::GapObj, private::Bool=false) = Wrappers.IsRecord(r) ? Vector{Symbol}(Wrappers.RecNames(r)) : Vector{Symbol}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,9 +13,11 @@ include("macros.jl")
 include("packages.jl")
 include("help.jl")
 
-@static if VERSION < v"1.10-DEV"
-  # TODO: re-enable this test in Julia 1.10 once we get REPL completion
-  # working there
+@static if VERSION < v"1.10-DEV" || Base.JLOptions().code_coverage == 0
+  # REPL completion doesn't work in Julia >= 1.10 when code coverage
+  # tracking is active. For more details see the discussions at
+  # <https://github.com/oscar-system/GAP.jl/pull/914> and
+  # <https://github.com/JuliaLang/julia/issues/49978>.
   include("replcompletions.jl")
 end
 


### PR DESCRIPTION
The added annotation might also benefit performance of some code.

Thanks to @aviatesk who helpfully suggested this in [this comment](https://github.com/oscar-system/GAP.jl/pull/866#issuecomment-1628181299).