### PR TITLE
CI: use concrete action versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,9 +56,9 @@ jobs:
       - name: "Cache artifacts"
         uses: julia-actions/cache@v1
       - name: "Build package"
-        uses: julia-actions/julia-buildpkg@latest
+        uses: julia-actions/julia-buildpkg@v1
       - name: "Run tests"
-        uses: julia-actions/julia-runtest@latest
+        uses: julia-actions/julia-runtest@v1
         with:
           depwarn: error
       - name: "Add optional Julia dependencies for GAP tests"
@@ -94,7 +94,7 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/cache@v1
-      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-buildpkg@v1
       - name: "Install package"
         run: |
           julia --project=docs --color=yes -e '


### PR DESCRIPTION
https://github.com/oscar-system/Oscar.jl/pull/2770 for GAP.jl. This is recommended by the [readme](https://github.com/julia-actions/julia-buildpkg#usage).