### PR TITLE
Enable `Aqua.jl`'s ambiguity check

### DIFF
--- a/pkg/JuliaInterface/tst/convert.tst
+++ b/pkg/JuliaInterface/tst/convert.tst
@@ -169,7 +169,7 @@ gap> ForAll([0..64], n -> Julia.GAP.Obj( -big2^n ) = -2^n);
 true
 
 #
-gap> string := GAPToJulia( Julia.Base.AbstractString, "bla" );
+gap> string := GAPToJulia( Julia.Base.String, "bla" );
 <Julia: "bla">
 gap> JuliaToGAP( IsString, string );
 "bla"
@@ -221,7 +221,7 @@ Error, <obj> must be a Julia range
 ##  empty list vs. empty string
 gap> emptylist:= GAPToJulia( JuliaEvalString( "Vector{Any}"), [] );
 <Julia: Any[]>
-gap> emptystring:= GAPToJulia( Julia.Base.AbstractString, "" );
+gap> emptystring:= GAPToJulia( Julia.Base.String, "" );
 <Julia: "">
 gap> JuliaToGAP( IsList, emptylist );
 [  ]

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -212,7 +212,6 @@ function String(obj::GapObj)
     Wrappers.IsString(obj) && return CSTR_STRING(Wrappers.CopyToStringRep(obj))
     throw(ConversionError(obj, String))
 end
-(::Type{T})(obj::GapObj) where {T<:AbstractString} = convert(T, String(obj))
 
 """
     Symbol(obj::GapObj)

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -141,7 +141,6 @@ gap_to_julia(::Type{Cuchar}, obj::GapObj) = Cuchar(obj)
 
 ## Strings
 gap_to_julia(::Type{String}, obj::GapObj) = String(obj)
-gap_to_julia(::Type{T}, obj::GapObj) where {T<:AbstractString} = T(obj)
 
 ## Symbols
 gap_to_julia(::Type{Symbol}, obj::GapObj) = Symbol(obj)
@@ -333,7 +332,7 @@ function gap_to_julia(x::GapObj; recursive::Bool = true)
     GAP_IS_MACFLOAT(x) && return gap_to_julia(Float64, x)
     GAP_IS_CHAR(x) && return gap_to_julia(Cuchar, x)
     # Do not choose this conversion for other lists in 'IsString'.
-    Wrappers.IsStringRep(x) && return gap_to_julia(AbstractString, x)
+    Wrappers.IsStringRep(x) && return gap_to_julia(String, x)
     # Do not choose this conversion for other lists in 'IsRange'.
     Wrappers.IsRangeRep(x) && return gap_to_julia(StepRange{Int64,Int64}, x)
     # Do not choose this conversion for other lists in 'IsBlist'.

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -3,7 +3,7 @@ using Aqua
 @testset "Aqua.jl" begin
     Aqua.test_all(
         GAP;
-        ambiguities=false,      # TODO: fix ambiguities
+        ambiguities=true,
         unbound_args=true,
         undefined_exports=true,
         project_extras=true,

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -53,7 +53,7 @@ end
 
     @test_throws ErrorException GAP.Globals.FOOBARQUX
 
-    str = GAP.gap_to_julia(AbstractString, GAP.ValueGlobalVariable("IdentifierLetters"))
+    str = GAP.gap_to_julia(String, GAP.ValueGlobalVariable("IdentifierLetters"))
     @test str == "0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"
 
     @test GAP.CanAssignGlobalVariable("Read") == false

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -77,14 +77,13 @@
     @test (@inferred String(x)) == "abc"
     x = GAP.evalstr("\"foo\"")
     @test (@inferred String(x)) == "foo"
-    @test AbstractString(x) == "foo"
   end
 
   @testset "Symbols" begin
     x = GAP.evalstr("\"foo\"")
     @test (@inferred Symbol(x)) == :foo
     x = GAP.evalstr("(1,2,3)")
-    @test_throws GAP.ConversionError AbstractString(x)
+    @test_throws GAP.ConversionError String(x)
 
     # Convert GAP string to Vector{UInt8} (==Vector{UInt8})
     x = GAP.evalstr("\"foo\"")

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -90,7 +90,6 @@
     @test (@inferred GAP.gap_to_julia(String, x)) == "abc"
     x = GAP.evalstr("\"foo\"")
     @test (@inferred GAP.gap_to_julia(String, x)) == "foo"
-    @test GAP.gap_to_julia(AbstractString, x) == "foo"
     @test GAP.gap_to_julia(x) == "foo"
     x = "abc\000def"
     @test GAP.gap_to_julia(GAP.julia_to_gap(x)) == x
@@ -102,7 +101,7 @@
     x = GAP.evalstr("\"foo\"")
     @test (@inferred GAP.gap_to_julia(Symbol, x)) == :foo
     x = GAP.evalstr("(1,2,3)")
-    @test_throws GAP.ConversionError GAP.gap_to_julia(AbstractString, x)
+    @test_throws GAP.ConversionError GAP.gap_to_julia(String, x)
 
     # Convert GAP string to Vector{UInt8} (==Vector{UInt8})
     x = GAP.evalstr("\"foo\"")


### PR DESCRIPTION
Parts of this have already been merged as https://github.com/oscar-system/GAP.jl/pull/937.

- 470bde701eb1ea095079c470ff62fb4af0604847 removes `(::Type{<:AbstractString})(::GapObj)`. This led to ambiguities with `Test.GenericString`, `LazyString`, `Core.Compiler.LazyString`. The only real removals here are for `SubString` and `SubstitutionString` as the other subtypes of `AbstractString` either have their specialized function or didn't work anyway due to ambiguities.
  It furthermore removes the unclear `gap_to_julia(AbstractString, ...)` (as it didn't specify what exactly to return). The implementation chose to return a simple `String`. I made that a bit more clear. Even the documentation says that one should put `String` as the first argument (cf. https://github.com/oscar-system/GAP.jl/blob/01b5c135392374124246e9a99d526f281a5e6e59/src/gap_to_julia.jl#L78). 
- 1291ab09b307d0aebc98d0fb837b191f12a7cdb6 fixes all calls of it and the corresponding tests.

Due to the AbstractString stuff above, I would technically consider this breaking. (E.g. `SubString(GAP.evalstr("\"foo\""))` used to work, but now needs to be `SubString(String(GAP.evalstr("\"foo\"")))`.)

Once this is merged, `GAP.jl` fulfills all of `Aqua.jl`'s tests! :tada: 