### PR TITLE
Add more `Random.Sampler` disambiguation

### DIFF
--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -416,6 +416,9 @@ Random.Sampler(::Type{<:AbstractGAPRNG}, x::AbstractUnitRange, ::Random.Repetiti
     Random.SamplerTrivial(x)
 
 # avoid ambiguities
+Random.Sampler(::Type{<:AbstractGAPRNG}, x::AbstractUnitRange{BigInt}, ::Random.Repetition) =
+    Random.SamplerTrivial(x)
+
 for U in (Base.BitInteger64, Union{Int128,UInt128})
     @eval Random.Sampler(::Type{<:AbstractGAPRNG}, x::AbstractUnitRange{T}, ::Random.Repetition
                          ) where {T<:$U} = Random.SamplerTrivial(x)


### PR DESCRIPTION
This contains a trivial disambiguity change from #936. It is similar to the loop below. Adding it to the loop, however, didn't succeed.

The rest of #936 seemed to escalate a bit. I will try to cut in down to as less changes as possible, but that will need a bit more time. This change here is independent from the rest, so I am happy to have it out of my way sooner than later.