### PR TITLE
Remove `(::<AbstractString)(::GapObj)`

### DIFF
--- a/pkg/JuliaInterface/tst/convert.tst
+++ b/pkg/JuliaInterface/tst/convert.tst
@@ -169,7 +169,7 @@ gap> ForAll([0..64], n -> Julia.GAP.Obj( -big2^n ) = -2^n);
 true
 
 #
-gap> string := GAPToJulia( Julia.Base.AbstractString, "bla" );
+gap> string := GAPToJulia( Julia.Base.String, "bla" );
 <Julia: "bla">
 gap> JuliaToGAP( IsString, string );
 "bla"
@@ -221,7 +221,7 @@ Error, <obj> must be a Julia range
 ##  empty list vs. empty string
 gap> emptylist:= GAPToJulia( JuliaEvalString( "Vector{Any}"), [] );
 <Julia: Any[]>
-gap> emptystring:= GAPToJulia( Julia.Base.AbstractString, "" );
+gap> emptystring:= GAPToJulia( Julia.Base.String, "" );
 <Julia: "">
 gap> JuliaToGAP( IsList, emptylist );
 [  ]

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -212,7 +212,6 @@ function String(obj::GapObj)
     Wrappers.IsString(obj) && return CSTR_STRING(Wrappers.CopyToStringRep(obj))
     throw(ConversionError(obj, String))
 end
-(::Type{T})(obj::GapObj) where {T<:AbstractString} = convert(T, String(obj))
 
 """
     Symbol(obj::GapObj)

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -141,7 +141,6 @@ gap_to_julia(::Type{Cuchar}, obj::GapObj) = Cuchar(obj)
 
 ## Strings
 gap_to_julia(::Type{String}, obj::GapObj) = String(obj)
-gap_to_julia(::Type{T}, obj::GapObj) where {T<:AbstractString} = T(obj)
 
 ## Symbols
 gap_to_julia(::Type{Symbol}, obj::GapObj) = Symbol(obj)
@@ -333,7 +332,7 @@ function gap_to_julia(x::GapObj; recursive::Bool = true)
     GAP_IS_MACFLOAT(x) && return gap_to_julia(Float64, x)
     GAP_IS_CHAR(x) && return gap_to_julia(Cuchar, x)
     # Do not choose this conversion for other lists in 'IsString'.
-    Wrappers.IsStringRep(x) && return gap_to_julia(AbstractString, x)
+    Wrappers.IsStringRep(x) && return gap_to_julia(String, x)
     # Do not choose this conversion for other lists in 'IsRange'.
     Wrappers.IsRangeRep(x) && return gap_to_julia(StepRange{Int64,Int64}, x)
     # Do not choose this conversion for other lists in 'IsBlist'.

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -53,7 +53,7 @@ end
 
     @test_throws ErrorException GAP.Globals.FOOBARQUX
 
-    str = GAP.gap_to_julia(AbstractString, GAP.ValueGlobalVariable("IdentifierLetters"))
+    str = GAP.gap_to_julia(String, GAP.ValueGlobalVariable("IdentifierLetters"))
     @test str == "0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"
 
     @test GAP.CanAssignGlobalVariable("Read") == false

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -77,14 +77,13 @@
     @test (@inferred String(x)) == "abc"
     x = GAP.evalstr("\"foo\"")
     @test (@inferred String(x)) == "foo"
-    @test AbstractString(x) == "foo"
   end
 
   @testset "Symbols" begin
     x = GAP.evalstr("\"foo\"")
     @test (@inferred Symbol(x)) == :foo
     x = GAP.evalstr("(1,2,3)")
-    @test_throws GAP.ConversionError AbstractString(x)
+    @test_throws GAP.ConversionError String(x)
 
     # Convert GAP string to Vector{UInt8} (==Vector{UInt8})
     x = GAP.evalstr("\"foo\"")

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -90,7 +90,6 @@
     @test (@inferred GAP.gap_to_julia(String, x)) == "abc"
     x = GAP.evalstr("\"foo\"")
     @test (@inferred GAP.gap_to_julia(String, x)) == "foo"
-    @test GAP.gap_to_julia(AbstractString, x) == "foo"
     @test GAP.gap_to_julia(x) == "foo"
     x = "abc\000def"
     @test GAP.gap_to_julia(GAP.julia_to_gap(x)) == x
@@ -102,7 +101,7 @@
     x = GAP.evalstr("\"foo\"")
     @test (@inferred GAP.gap_to_julia(Symbol, x)) == :foo
     x = GAP.evalstr("(1,2,3)")
-    @test_throws GAP.ConversionError GAP.gap_to_julia(AbstractString, x)
+    @test_throws GAP.ConversionError GAP.gap_to_julia(String, x)
 
     # Convert GAP string to Vector{UInt8} (==Vector{UInt8})
     x = GAP.evalstr("\"foo\"")


### PR DESCRIPTION
This is part of PR #936 by @lgoettgens and already mergable by itself.

It is also technically a breaking change, I guess, although I don't know of any code relying on this... but who knows....