### PR TITLE
adjust `docs/make.jl` to changes in Documenter.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,43 +18,96 @@ using GAP.Markdown
 ## of the function `Documenter.Selectors.order` for these subtypes,
 ## and executing the step for the subtype `T` means to call
 ## `Documenter.Selectors.runner` with `T` and the document object.
-##
-## The code was adapted from the package
-## https://github.com/ali-ramadhan/DocumenterBibliographyTest.jl,
-## the hint to use this approach came up in the discussion of
-## https://github.com/JuliaDocs/Documenter.jl/issues/1343.
 
 ## Declare a new subtype for our step,
 ## the evaluation of external references.
 abstract type ExternalReference <: Documenter.Builder.DocumentPipeline end
 
-## Execute our step after the computation of cross-references (3.0)
-## and before the check of the document (4.0).
-Documenter.Selectors.order(::Type{ExternalReference}) = 3.1
+## Distinguish different versions of Documenter.jl.
+if isdefined(Documenter, :Document)
+  # version at least 1.0
+  # The code was adapted from `expand_citations`
+  # in DocumenterCitations.jl/src/citations.jl.
+  Document = Documenter.Document
 
-## When executing our step, print an info line
-## and call the function that does the work.
-function Documenter.Selectors.runner(::Type{ExternalReference}, doc::Documenter.Documents.Document)
-    @info "ExternalReference: building external references."
-    compute_external_references(doc)
-end
+  # Execute our step before the computation of cross-references (3.0)
+  # because otherwise the syntax of external references leads to errors.
+  Documenter.Selectors.order(::Type{ExternalReference}) = 2.99
 
-function compute_external_references(doc::Documenter.Documents.Document)
+  function compute_external_references(doc::Document)
+    for (src, page) in doc.blueprint.pages
+      @debug "ExternalReference: compute for entries in $(src)"
+      empty!(page.globals.meta)
+      compute_external_reference(doc, page, page.mdast)
+    end
+  end
+
+  function compute_external_reference(doc::Document, page, mdast::Documenter.MarkdownAST.Node)
+    for node in Documenter.AbstractTrees.PreOrderDFS(mdast)
+      if node.element isa Documenter.DocsNode
+        # The docstring AST trees are not part of the tree of the page, so
+        # we need to expand them explicitly
+        for (docstr, meta) in zip(node.element.mdasts, node.element.metas)
+          compute_external_reference(doc, page, docstr)
+        end
+      elseif node.element isa Documenter.MarkdownAST.Link
+        compute_external_reference(node, page.globals.meta, page, doc)
+      end
+    end
+  end
+
+  function compute_external_reference(node::Documenter.MarkdownAST.Node, meta, page, doc)
+    # Do something only if the current element is a `MarkdownAST.Link`.
+    link = node.element
+    isa(link, Documenter.MarkdownAST.Link) || return true
+    url = link.destination
+    startswith(url, "GAP_ref") || return true
+    @info "Computing external reference: $(url)."
+    reference = match(r"GAP_ref\((.*)\)", url)
+    (! isnothing(reference) && length(reference.captures) == 1) || return true
+    reference = string(reference.captures[1])
+    key = split(reference, ":")
+    length(key) == 2 || return true
+    key = GapObj(string(key[2]))
+    # Find all matches of `"<bookname>:<label>"`.
+    urls = GAP.Globals.MatchURLs(GapObj(reference),
+               GapObj("https://www.gap-system.org/Manuals/"))
+    # Take only exact matches, this should be unique.
+    urls = GAP.Globals.Filtered(urls, x -> x[2] == key)
+    if length(urls) == 1
+      # Replace the URL in the link.
+      link.destination = String(urls[1][3])
+    end
+    return true
+  end
+else
+  # old version
+  # The code was adapted from the package
+  # https://github.com/ali-ramadhan/DocumenterBibliographyTest.jl,
+  # the hint to use this approach came up in the discussion of
+  # https://github.com/JuliaDocs/Documenter.jl/issues/1343.
+  Document = Documenter.Documents.Document
+
+  # Execute our step after the computation of cross-references (3.0)
+  # and before the check of the document (4.0).
+  Documenter.Selectors.order(::Type{ExternalReference}) = 3.1
+
+  function compute_external_references(doc::Document)
     for (src, page) in doc.blueprint.pages
         empty!(page.globals.meta)
         for element in page.elements
             compute_external_reference(page.mapping[element], page, doc)
         end
     end
-end
+  end
 
-function compute_external_reference(elem, page, doc)
+  function compute_external_reference(elem, page, doc)
     Documenter.Documents.walk(page.globals.meta, elem) do link
         compute_external_reference(link, page.globals.meta, page, doc)
     end
-end
+  end
 
-function compute_external_reference(link, meta, page, doc)
+  function compute_external_reference(link, meta, page, doc)
     # Do something only if the current element has the type `Markdown.Link`.
     if isa(link, Markdown.Link) && startswith(link.url, "GAP_ref")
         @info "Computing external reference: $(link.url)."
@@ -77,6 +130,14 @@ function compute_external_reference(link, meta, page, doc)
         end
     end
     return true
+  end
+end
+
+## When executing our step, print an info line
+## and call the function that does the work.
+function Documenter.Selectors.runner(::Type{ExternalReference}, doc::Document)
+    @info "ExternalReference: building external references."
+    compute_external_references(doc)
 end
 
 DocMeta.setdocmeta!(GAP, :DocTestSetup, :(using GAP, GAP.Random); recursive = true)

--- a/docs/src/internal.md
+++ b/docs/src/internal.md
@@ -1,0 +1,13 @@
+```@meta
+CurrentModule = GAP
+DocTestSetup = :(using GAP)
+```
+
+# Internal
+
+```@docs
+GAP.get_symbols_in_module
+GAP.GAP
+GAP.RecDict
+GAP.kwarg_wrapper
+```

--- a/docs/src/other.md
+++ b/docs/src/other.md
@@ -173,12 +173,3 @@ true
 ```@docs
 show_gap_help
 ```
-
-## Objects that must be documented, otherwise Documenter.jl throws an error.
-
-```@docs
-GAP.get_symbols_in_module
-GAP.GAP
-GAP.RecDict
-GAP.kwarg_wrapper
-```

--- a/docs/src/other.md
+++ b/docs/src/other.md
@@ -173,3 +173,12 @@ true
 ```@docs
 show_gap_help
 ```
+
+## Objects that must be documented, otherwise Documenter.jl throws an error.
+
+```@docs
+GAP.get_symbols_in_module
+GAP.GAP
+GAP.RecDict
+GAP.kwarg_wrapper
+```

--- a/src/doctestfilters.jl
+++ b/src/doctestfilters.jl
@@ -25,5 +25,6 @@ GAP_docs_pages = [
         "packages.md",
         "other.md",
         "examples.md",
+        "internal.md",
         "manualindex.md",
         ]


### PR DESCRIPTION
Now we can *almost* process the documentation with Documenter.jl 1.0.

- The creation of hyperlinks to the GAP documentation works again.
- The errors because of docstrings that are not referenced in `docs/src/*.md` are gone because the docstrings are now referenced. (I do not like this at all. Why is it an error not to include all available docstrings?)
- There are still errors because three explicit cross-references to the JuliaInterface manual (in the directory `assets/html/JuliaInterface`) are not accepted because they are local links outside the build directory.