### PR TITLE
Add newline before module statement to fix nightly

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -4,7 +4,8 @@
   For the package manual see https://oscar-system.github.io/GAP.jl/.
 
   For more information about GAP see https://www.gap-system.org/.
-""" module GAP
+"""
+module GAP
 
 # Show a more helpful error message for users on Windows.
 windows_error() = error("""


### PR DESCRIPTION
This broke nightly when https://github.com/JuliaLang/julia/pull/51635 was merged.
```
     Testing Running tests...
ERROR: LoadError: Package GAP [c863536a-3901-11e9-33e7-d5cd0df7b904] source file /Users/runner/.julia/packages/GAP/gliHT/src/GAP.jl does not contain a module declaration.
```
@benlorenz and I still think that it should also work as it was before, but the module statement not on a new line was ugly.

