### PR TITLE
force version 1.0 of Documenter.jl

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "^0.27.0"
+Documenter = "1.0"

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -17,7 +17,7 @@ DocTestSetup = :(using GAP)
   Ctrl-D) returns one to a Julia prompt. From the GAP prompt, one can access
   Julia variables via the `Julia` object, for example `Julia.binomial(5,3)`.
   For more details on how to access Julia from GAP, please consult
-  [the manual of the GAP package JuliaInterface](../assets/html/JuliaInterface/chap0_mj.html).
+  [the manual of the GAP package JuliaInterface](https://oscar-system.github.io/GAP.jl/stable/assets/html/JuliaInterface/chap0_mj.html).
 
 - Alternatively, one can start GAP in the traditional way,
   by executing a shell script.
@@ -38,7 +38,7 @@ GAP.create_gap_sh
 
 The GAP-Julia interface is fully bidirectional, so it is also possible to access all
 Julia functionality from GAP. To learn more about this, please consult
-[the manual of the GAP package JuliaInterface](../assets/html/JuliaInterface/chap0_mj.html).
+[the manual of the GAP package JuliaInterface](https://oscar-system.github.io/GAP.jl/stable/assets/html/JuliaInterface/chap0_mj.html).
 
 ## Types
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,7 +30,7 @@ as soon as GAP packages provide functionality that is based on
 using Julia code from the GAP side.
 
 The viewpoint of an interface from GAP to Julia is described in
-[the manual of the GAP package JuliaInterface](assets/html/JuliaInterface/chap0_mj.html).
+[the manual of the GAP package JuliaInterface](https://oscar-system.github.io/GAP.jl/stable/assets/html/JuliaInterface/chap0_mj.html).
 
 ## Table of contents
 


### PR DESCRIPTION
(as in AbstractAlgebra.jl and Nemo.jl)

For that, I have changed the three cross-references to the JuliaInterface manual from relative
(pointing to `../assets/html/JuliaInterface/chap0_mj.html`) to absolute
(pointing to `https://oscar-system.github.io/GAP.jl/stable/assets/html/JuliaInterface/chap0_mj.html`).

This is not really nice, but I did not find another solution. When Documenter.jl (in version 1.0 or higher) checks the document's structure, it does not accept relative links outside the build directory, and apparently there is no option to suppress this check.

(One could think of encoding the links in question as `https://..` URLs in the document, and inserting a new step into the build process, after the checks of course, which just replaces these URLs by the intended relative ones.  I think this would be absurd.
If it would be possible to insert inline HTML code then the solution would be easy, but apparently this is not intended.)