### PR TITLE
use `Pidfile.mkpidlock` in `GAP.Packages.install`

### DIFF
--- a/pkg/JuliaExperimental/julia/realcyc.jl
+++ b/pkg/JuliaExperimental/julia/realcyc.jl
@@ -42,7 +42,7 @@ function isPositiveRealPartCyc( coeffs::Vector )
       x::Nemo.arb = arbCyc( coeffs, R )
       if Nemo.ispositive( x )
         return ( true, prec )
-      elseif Nemo.isnegative( x )
+      elseif Nemo.is_negative( x )
         return ( false, prec )
       end
       prec = 2 * prec


### PR DESCRIPTION
... in order to make sure that only one process can try to install a GAP package at the same time

(One could set different locks for different GAP packages, but GAP's PackageManager installs also dependencies, and `GAP.Packages.install` does not know about them.)

See oscar-system/Oscar.jl/issues/3089 and #561.