### PR TITLE
Use julia 1.10 as default in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,8 +26,8 @@ jobs:
       matrix:
         julia-version:
           - '1.6'
-          - '1.9'
-          - '~1.10.0-0'
+          - '1.9'    # to be removed in the near future
+          - '1.10'
           - 'nightly'
         julia-arch:
           - x64
@@ -35,7 +35,7 @@ jobs:
           - ubuntu-latest
         include:
           # Add a few macOS jobs (not too many, the number we can run in parallel is limited)
-          - julia-version: '1.9'
+          - julia-version: '1.10'
             julia-arch: x64
             os: macOS-latest
           - julia-version: 'nightly'

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -29,7 +29,7 @@ jobs:
     - name: "Set up Julia"
       uses: julia-actions/setup-julia@v1
       with:
-        version: '~1.9.0-0'
+        version: '1.10'
     - name: OscarDevTools - CI
       if: github.repository == 'oscar-system/OscarDevTools.jl'
       run: |


### PR DESCRIPTION
Merging this needs also an update to the list of required CI jobs.