### PR TITLE
fix GAP help access for Julia nightly

### DIFF
--- a/src/help.jl
+++ b/src/help.jl
@@ -5,7 +5,6 @@ import REPL
 
 if isdefined(REPL.TerminalMenus, :default_terminal)
   import REPL.TerminalMenus: default_terminal
-# default_terminal = REPL.TerminalMenus.default_terminal
 else
   # before Julia 1.12
   function default_terminal()

--- a/src/help.jl
+++ b/src/help.jl
@@ -3,7 +3,7 @@
 import Markdown
 import REPL
 
-if isdefined( REPL.TerminalMenus, :default_terminal)
+if isdefined(REPL.TerminalMenus, :default_terminal)
   import REPL.TerminalMenus: default_terminal
 # default_terminal = REPL.TerminalMenus.default_terminal
 else

--- a/src/help.jl
+++ b/src/help.jl
@@ -3,8 +3,17 @@
 import Markdown
 import REPL
 
+if isdefined( REPL.TerminalMenus, :default_terminal)
+  default_terminal = REPL.TerminalMenus.default_terminal
+else
+  # before Julia 1.12
+  function default_terminal()
+    return REPL.TerminalMenus.terminal
+  end
+end
+
 function gap_help_string(topic::String, onlyexact::Bool = false,
-    term::REPL.Terminals.TTYTerminal = REPL.TerminalMenus.terminal;
+    term::REPL.Terminals.TTYTerminal = default_terminal();
     suppress_output::Bool = false)
     # Let GAP collect the information.
     info = Globals.HELP_Info(GapObj(topic), onlyexact)

--- a/src/help.jl
+++ b/src/help.jl
@@ -4,7 +4,8 @@ import Markdown
 import REPL
 
 if isdefined( REPL.TerminalMenus, :default_terminal)
-  default_terminal = REPL.TerminalMenus.default_terminal
+  import REPL.TerminalMenus: default_terminal
+# default_terminal = REPL.TerminalMenus.default_terminal
 else
   # before Julia 1.12
   function default_terminal()

--- a/test/help.jl
+++ b/test/help.jl
@@ -1,6 +1,6 @@
 @testset "help" begin
     using GAP.REPL
-    tt = REPL.TerminalMenus.terminal
+    tt = GAP.default_terminal()
 
     function test_gap_help(topic::String)
         inp = Base.IOBuffer("qq") # exit the menu if applicable


### PR DESCRIPTION
In Julia 1.12, one can use `default_terminal()`
instead of `REPL.TerminalMenus.terminal`.

resolves #978