### PR TITLE
Add an error for enabled multithreaded gc

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -233,6 +233,10 @@ function __init__()
         windows_error()
     end
 
+    if isdefined(Threads, :ngcthreads) && Threads.ngcthreads() > 1
+        error("GAP.jl currently does not support multithreaded garbace collection. Please run julia with `--gcthreads=1` to for now.")
+    end
+
     # always regenerate our custom GAP root dir, to accommodate for changes
     # in the system configuration (artifact paths, available compilers, ...)
     global sysinfo


### PR DESCRIPTION
to inform users at startup about the problem and give them the workaround as proposed by @simonbrandhorst in https://github.com/oscar-system/GAP.jl/issues/960#issuecomment-2067696519.
Once https://github.com/oscar-system/GAP.jl/issues/960 is resolved, this change should get reverted.

To get the full effect of this in Oscar etc., this should get backported to a 0.10.x release branch and released from there.