### PR TITLE
support `gap_to_julia(::AbstractVector)`

### DIFF
--- a/pkg/JuliaInterface/tst/calls.tst
+++ b/pkg/JuliaInterface/tst/calls.tst
@@ -178,8 +178,8 @@ gap> g6 := JuliaEvalString("function g6(a,b,c,d,e,f) return f end");;
 gap> g7 := JuliaEvalString("function g7(a,b,c,d,e,f,g) return g end");;
 
 #
-gap> g0();
-<Julia: Ptr{Nothing} @0x0000000000000000>
+gap> Julia.typeof( g0() );
+<Julia: Ptr{Nothing}>
 gap> g1(true);
 true
 gap> g2(true,2);
@@ -237,4 +237,4 @@ gap> _JuliaFunctionByModule("parse", "Base");
 <Julia: parse>
 
 #
-gap> STOP_TEST( "calls.tst", 1 );
+gap> STOP_TEST( "calls.tst" );

--- a/pkg/JuliaInterface/tst/import.tst
+++ b/pkg/JuliaInterface/tst/import.tst
@@ -35,12 +35,12 @@ gap> Julia.Base.foo_bar_quux_not_defined;
 #
 gap> IsBound( Julia.Base.C_NULL );
 true
-gap> Julia.Base.C_NULL;
-<Julia: Ptr{Nothing} @0x0000000000000000>
+gap> Julia.typeof( Julia.Base.C_NULL );
+<Julia: Ptr{Nothing}>
 gap> IsBound( Julia.Base.C_NULL );
 true
 gap> Unbind( Julia.Base.C_NULL );
 Error, cannot unbind Julia variables
 
 ##
-gap> STOP_TEST( "import.tst", 1 );
+gap> STOP_TEST( "import.tst" );

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -172,10 +172,18 @@ function julia_to_gap(
 end
 
 ## Ranges
-function julia_to_gap(r::AbstractRange{<:Integer})
+function julia_to_gap(r::AbstractRange{<:Integer}, recursive::Bool = false)
     res = NewRange(length(r), first(r), step(r))
     Wrappers.IsRange(res) || throw(ConversionError(r, GapObj))
     return res
+end
+
+function julia_to_gap(
+    r::AbstractRange{<:Integer},
+    recursion_dict::IdDict{Any,Any};
+    recursive::Bool = false)
+
+    return julia_to_gap(r)
 end
 
 ## Dictionaries

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -116,7 +116,7 @@ julia_to_gap(obj::Any, recursion_dict::IdDict{Any,Any}; recursive::Bool = true) 
 
 ## Arrays (including BitVector)
 function julia_to_gap(
-    obj::Vector{T},
+    obj::AbstractVector{T},
     recursion_dict::IdDict{Any,Any} = IdDict();
     recursive::Bool = false,
 ) where {T}

--- a/src/types.jl
+++ b/src/types.jl
@@ -92,7 +92,7 @@ To also deal with GAP integers, finite field elements and booleans, use
 [`GAP.Obj`](@ref) instead.
 
 Recursive conversion of nested Julia objects (arrays, tuples, dictionaries)
-can be forced either by a second agument `true`
+can be forced either by a second argument `true`
 or by the keyword argument `recursive` with value `true`.
 
 # Examples
@@ -129,7 +129,7 @@ in order to convert Julia objects to GAP objects,
 whenever a suitable conversion has been defined.
 
 Recursive conversion of nested Julia objects (arrays, tuples, dictionaries)
-can be forced either by a second agument `true`
+can be forced either by a second argument `true`
 or by the keyword argument `recursive` with value `true`.
 
 # Examples

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -387,6 +387,11 @@ end
     y = GAP.julia_to_gap([true, false])
     @test y == x
     @test GAP.gap_to_julia(GAP.Globals.TNAM_OBJ(y)) == "list (boolean)"
+
+    v = BitVector([true, false])
+    gap_v = GAP.julia_to_gap(v)
+    @test gap_v == x
+    @test GAP.gap_to_julia(GAP.Globals.TNAM_OBJ(gap_v)) == "list (boolean)"
   end
 
   @testset "Tuples" begin

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -414,6 +414,11 @@ end
     r = GAP.evalstr("[ 1, 4 .. 10 ]")
     @test GAP.julia_to_gap(1:3:10) == r
     @test_throws GAP.ConversionError GAP.julia_to_gap(1:2^62)
+
+    r = GAP.julia_to_gap(1:2:11, IdDict(), recursive = false)
+    @test GAP.gap_to_julia(GAP.Globals.TNAM_OBJ(r)) == "list (range,ssort)"
+    r = GAP.Obj(1:10)
+    @test GAP.gap_to_julia(GAP.Globals.TNAM_OBJ(r)) == "list (range,ssort)"
   end
 
   @testset "Dictionaries" begin


### PR DESCRIPTION
It had been claimed already before the change that `gap_to_julia(::BitVector)` works, but this was not tested.

(The problem was uncovered because `gap_to_julia(::JSON3.Array)` did not work.)