### PR TITLE
Fix testsuite for julia nightly

### DIFF
--- a/pkg/JuliaInterface/tst/calls.tst
+++ b/pkg/JuliaInterface/tst/calls.tst
@@ -178,8 +178,8 @@ gap> g6 := JuliaEvalString("function g6(a,b,c,d,e,f) return f end");;
 gap> g7 := JuliaEvalString("function g7(a,b,c,d,e,f,g) return g end");;
 
 #
-gap> g0();
-<Julia: Ptr{Nothing} @0x0000000000000000>
+gap> Julia.typeof( g0() );
+<Julia: Ptr{Nothing}>
 gap> g1(true);
 true
 gap> g2(true,2);
@@ -237,4 +237,4 @@ gap> _JuliaFunctionByModule("parse", "Base");
 <Julia: parse>
 
 #
-gap> STOP_TEST( "calls.tst", 1 );
+gap> STOP_TEST( "calls.tst" );

--- a/pkg/JuliaInterface/tst/import.tst
+++ b/pkg/JuliaInterface/tst/import.tst
@@ -35,12 +35,12 @@ gap> Julia.Base.foo_bar_quux_not_defined;
 #
 gap> IsBound( Julia.Base.C_NULL );
 true
-gap> Julia.Base.C_NULL;
-<Julia: Ptr{Nothing} @0x0000000000000000>
+gap> Julia.typeof( Julia.Base.C_NULL );
+<Julia: Ptr{Nothing}>
 gap> IsBound( Julia.Base.C_NULL );
 true
 gap> Unbind( Julia.Base.C_NULL );
 Error, cannot unbind Julia variables
 
 ##
-gap> STOP_TEST( "import.tst", 1 );
+gap> STOP_TEST( "import.tst" );

--- a/src/types.jl
+++ b/src/types.jl
@@ -92,7 +92,7 @@ To also deal with GAP integers, finite field elements and booleans, use
 [`GAP.Obj`](@ref) instead.
 
 Recursive conversion of nested Julia objects (arrays, tuples, dictionaries)
-can be forced either by a second agument `true`
+can be forced either by a second argument `true`
 or by the keyword argument `recursive` with value `true`.
 
 # Examples
@@ -129,7 +129,7 @@ in order to convert Julia objects to GAP objects,
 whenever a suitable conversion has been defined.
 
 Recursive conversion of nested Julia objects (arrays, tuples, dictionaries)
-can be forced either by a second agument `true`
+can be forced either by a second argument `true`
 or by the keyword argument `recursive` with value `true`.
 
 # Examples


### PR DESCRIPTION
- do not show `C_NULL` but just its type (since printing has changed in Julia)
- fix a typo

Extracted from https://github.com/oscar-system/GAP.jl/pull/989 to enable a faster merge and the possibility to backport to the `release-0.10` branch