### PR TITLE
Add `FORCE_JULIAINTERFACE_COMPILATION`

### DIFF
--- a/etc/run_with_override.jl
+++ b/etc/run_with_override.jl
@@ -44,7 +44,7 @@ add_jll_override(tmpdepot, "GAP", gapoverride)
 add_jll_override(tmpdepot, "GAP_lib", gapoverride)
 
 # prepend our temporary depot to the depot list...
-withenv("JULIA_DEPOT_PATH"=>tmpdepot*":") do
+withenv("JULIA_DEPOT_PATH"=>tmpdepot*":", "FORCE_JULIAINTERFACE_COMPILATION" => "true") do
 
     # ... and start Julia, by default with the same project environment
     run(`$(Base.julia_cmd()) --project=$(Base.active_project()) $(ARGS)`)

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -232,12 +232,12 @@ function locate_JuliaInterface_so(sysinfo::Dict{String, String})
     jll_hash = GitTools.tree_hash(joinpath(jll, "src"))
     bundled = joinpath(@__DIR__, "..", "pkg", "JuliaInterface")
     bundled_hash = GitTools.tree_hash(joinpath(bundled, "src"))
-    if jll_hash == bundled_hash
+    if jll_hash == bundled_hash && get(ENV, "FORCE_JULIAINTERFACE_COMPILATION", "false") != "true"
         # if the tree hashes match then we can use JuliaInterface.so from the JLL
         @debug "Use JuliaInterface.so from GAP_pkg_juliainterface_jll"
         path = joinpath(jll, "lib", "gap")
     else
-        # tree hashes differ: we must compile the bundled sources
+        # tree hashes differ: we must compile the bundled sources (or requested re-compilation via ENV)
         path = build_JuliaInterface(sysinfo)
         @debug "Use JuliaInterface.so from $(path)"
     end


### PR DESCRIPTION
Resolves https://github.com/oscar-system/GAP.jl/issues/997.

I verified by looking at debug output that just running the GAP.jl master uses the jll-version while running `julia --proj=override etc/run_with_override.jl /tmp/gap_jll_override --depwarn=error -e "ENV[\"JULIA_DEBUG\"] = all; using GAP"` prints `[Info: Compiling JuliaInterface...`