### PR TITLE
Work around nightly breakage by re-allowing `Julia.name := val` from GAP

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -4,9 +4,10 @@ import REPL.REPLCompletions: completions
 
 # a helper function, not to be documented
 function _setglobal(M::Module, name::Symbol, val::Any)
-  @static if isdefined(Core,:setglobal!)
+  @static if isdefined(Core, :setglobal!)
     # `setglobal!` is available in Julia 1.9.
-    return Core.setglobal!(M, name, val)
+    Core.eval(M, Expr(:global, name)) # see https://github.com/JuliaLang/julia/pull/54678
+    return invokelatest(Core.setglobal!, M, name, val)
   else
     # `jl_set_global` is available up to Julia 1.8.
     ccall(:jl_set_global, Cvoid, (Any, Any, Any), M, name, val)


### PR DESCRIPTION
Resolves https://github.com/oscar-system/GAP.jl/issues/1004.

This code was last touched in https://github.com/oscar-system/GAP.jl/pull/803, where `Julia.MODULE.name := val` was allowed. In the recent julia nightly change https://github.com/JuliaLang/julia/pull/54678, the implicit creation of global bindings was disabled, one can now only change the value of a global variable but not create a new one.

I can think of multiple ways on how to resolve this in GAP.jl:
1. Use the workaround from https://github.com/JuliaLang/julia/pull/54678 to keep it working, i.e. add an explicit call to first create the global binding to `GAP._setglobal`. This is currently implemented in this PR.
2. Keep everything as is and just adjust the tests. GAP.jl users adding new global variables to julia via `Julia.MODULE.name := val` will then run into the new error introduced in https://github.com/JuliaLang/julia/pull/54678. One could consider this as a breaking change to GAP.jl, but note that the julia devs didn't consider https://github.com/JuliaLang/julia/pull/54678 breaking.
3. Only allow the implicit creation of global bindings via the method in 1. for the `Julia.Main` module, and either add our own error or direct to the julia error for all other modules. This was already discussed in https://github.com/oscar-system/GAP.jl/pull/803#pullrequestreview-946735258.

Please let me know what you think about the possible options, and I will be happy to adapt this PR.