### PR TITLE
Remove macOS `GAC_LDFLAGS` workaround

### DIFF
--- a/src/setup.jl
+++ b/src/setup.jl
@@ -118,7 +118,6 @@ function regenerate_gaproot()
     # add the necessary flags to link against libgap
     gap_lib = joinpath(gap_prefix, "lib")
     sysinfo["GAP_LDFLAGS"] = "-L$(gap_lib) -lgap"
-    Sys.isapple() && (sysinfo["GAC_LDFLAGS"] = " -bundle") # Remove this line once the GAP_jll build recipe is fixed
 
     GAP_VERSION = VersionNumber(sysinfo["GAP_VERSION"])
     gaproot_packages = joinpath(Base.DEPOT_PATH[1], "gaproot", "v$(GAP_VERSION.major).$(GAP_VERSION.minor)")


### PR DESCRIPTION
This has been fixed upstream in https://github.com/JuliaPackaging/Yggdrasil/pull/8885 and is available here due to https://github.com/oscar-system/GAP.jl/pull/1003.