### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 Manifest.toml
 /tags
 *.log
-
-proj*
+/coverage/
+/override/


### PR DESCRIPTION
Changes the entry for the `setup_override_dir.jl` stuff from `proj*` to `override/`, and additionally adds an entry to ignore the JuliaInterface test coverage when running the script from the CI job locally.