### PR TITLE
tell JuliaInterface to load GAPDoc

### DIFF
--- a/pkg/JuliaInterface/PackageInfo.g
+++ b/pkg/JuliaInterface/PackageInfo.g
@@ -101,6 +101,7 @@ Dependencies := rec(
   GAP := ">= 4.11",    # need compatible code in GAP's src/julia_gc.c
   NeededOtherPackages := [ ],
   SuggestedOtherPackages := [ ],
+  OtherPackagesLoadedInAdvance := [ [ "GAPDoc", "1.6.6" ] ], # need StripEscapeSequences
   ExternalConditions := [ ],
 ),
 


### PR DESCRIPTION
When `ENV["GAP_BARE_DEPS"]` is bound before GAP.jl gets loaded, the JuliaInterface package will be loaded before GAPDoc, and this causes a warning because JuliaInterface needs a variable from GAPDoc.
In order to avoid this, add GAPDoc to the dependencies of JuliaInterface.