### PR TITLE
JuliaExperimental: stop using OtherPackagesLoadedInAdvance

### DIFF
--- a/pkg/JuliaExperimental/PackageInfo.g
+++ b/pkg/JuliaExperimental/PackageInfo.g
@@ -81,7 +81,6 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.11",
   NeededOtherPackages := [ ],
-  OtherPackagesLoadedInAdvance := [ [ "JuliaInterface", ">=0.11.1" ] ], 
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],
 ),


### PR DESCRIPTION
These days JuliaInterface is always loaded first
