### PR TITLE
Provide a stale_age to mkpidlock

### DIFF
--- a/src/packages.jl
+++ b/src/packages.jl
@@ -243,7 +243,9 @@ function install(spec::String, version::String = "";
     # point PackageManager to the given pkg dir
     Globals.PKGMAN_CustomPackageDir = GapObj(pkgdir)
     mkpath(pkgdir)
-    Pidfile.mkpidlock("$pkgdir.lock") do
+    # pidlock timeout: 300 seconds = 5 minutes should suffice; about the
+    # slowest packages to install are Semigroups and NormalizInterface.
+    Pidfile.mkpidlock("$pkgdir.lock"; stale_age=300) do
       if quiet || debug
         oldlevel = Wrappers.InfoLevel(Globals.InfoPackageManager)
         Wrappers.SetInfoLevel(Globals.InfoPackageManager, quiet ? 0 : 3)

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -159,7 +159,7 @@ function regenerate_gaproot()
 
     # create the mutable gaproot
     mkpath(gaproot_mutable)
-    Pidfile.mkpidlock("$gaproot_mutable.lock") do
+    Pidfile.mkpidlock("$gaproot_mutable.lock"; stale_age=10) do
         # create fake sysinfo.gap
         unquoted = Set(["GAParch", "GAP_ABI", "GAP_HPCGAP", "GAP_KERNEL_MAJOR_VERSION", "GAP_KERNEL_MINOR_VERSION", "GAP_OBJEXT"])
         open("$gaproot_mutable/sysinfo.gap", "w") do file


### PR DESCRIPTION
Normally the pidlock should be held for just a few milliseconds; waiting for its age to exceed 10 seconds until we consider it stale should be very safe. In fact Julia waits 5 times longer if the process creating the pid lock file seems to be still running.

On the other hand, without a stale age, the lock file is *never* considered stale, even if the process creating it definitely is gone, and so the user can get stuck, which obviously is very bad. To get unstuck they need to manually delete the lock file.