### PR TITLE
provide a scratchspace for AtlasRep data if necessary

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -306,6 +306,9 @@ function __init__()
     end
 
     Packages.init_packagemanager()
+
+    # The AtlasRep package may get loaded automatically when GAP starts.
+    Packages.init_atlasrep()
 end
 
 """

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -69,6 +69,8 @@ import GAP: @wrap
 @wrap RNamObj(x::Any)::Int
 @wrap SetInfoLevel(x::GapObj, y::Int)::Nothing
 @wrap SetPackagePath(x::GapObj, y::GapObj)::Nothing
+@wrap SetUserPreference(x::GapObj, y::Any)::Nothing
+@wrap SetUserPreference(x::GapObj, y::GapObj, z::Any)::Nothing
 @wrap ShallowCopy(x::Any)::Any
 @wrap String(x::Any)::Any
 @wrap StringDisplayObj(x::Any)::GapObj
@@ -76,6 +78,8 @@ import GAP: @wrap
 @wrap StructuralCopy(x::Any)::Any
 @wrap SUM(x::Any, y::Any)::Any
 @wrap UNB_REC(x::GapObj, y::Int)::Nothing
+@wrap UserPreference(x::GapObj)::Any
+@wrap UserPreference(x::GapObj, y::GapObj)::Any
 @wrap ZeroSameMutability(x::Any)::Any
 
 end


### PR DESCRIPTION
If AtlasRep does not know a writable directory for downloaded data, i.e., if the value of its user preference AtlasRepDataDirectory is an empty string, provide a scratchspace and adjust the user preference.

For that, we check for the empty string when GAP has been started (which may trigger that AtlasRep gets loaded)
and in `GAP.Packages.load` calls.

Thus this mechanism will fail if one starts GAP without packages and then loads GAP packages only via the GAP function `LoadPackage`.