### PR TITLE
Remove banner code and instead use `should_show_banner`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Thomas Breuer <sam@math.rwth-aachen.de>", "Sebastian Gutsche <gutsch
 version = "0.11.1"
 
 [deps]
+AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
@@ -22,6 +23,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 
 [compat]
+AbstractAlgebra = "0.41.11, 0.42.1"
 Artifacts = "1.6"
 Compat = "4.4.0"
 Downloads = "1.4.3"

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -20,6 +20,8 @@ if Sys.iswindows()
   windows_error()
 end
 
+import AbstractAlgebra # for should_show_banner()
+
 import GAP_jll: GAP_jll, libgap
 
 GAP_jll.is_available() ||
@@ -260,26 +262,7 @@ function __init__()
         end
     end
 
-    # Check if were loaded from another package
-    # if VERSION < 1.7.*, only the "other" package will have the
-    # _tryrequire_from_serialized in the backtrace.
-    # if VERSION >= 1.8, also doing 'using Package' will have
-    # _tryrequire_from_serialized the backtrace.
-    #
-    # To still distinguish both scenarios, notice that
-    # 'using OtherPackage' will either have _tryrequire_from_serialized at least twice,
-    # or one with four arguments (hence five as the function name is the first argument)
-    # 'using Package' serialized will have a version with less arguments
-    bt = Base.process_backtrace(Base.backtrace())
-    filter!(sf -> sf[1].func === :_tryrequire_from_serialized, bt)
-    isinteractive_manual =
-      length(bt) == 0 || (length(bt) == 1 && length(only(bt)[1].linfo.specTypes.parameters) < 4)
-
-    # Respect the -q flag
-    isquiet = Bool(Base.JLOptions().quiet)
-
-    show_banner = !isquiet && isinteractive_manual && isinteractive() &&
-                 !any(x->x.name in ["Oscar"], keys(Base.package_locks)) &&
+    show_banner = AbstractAlgebra.should_show_banner() &&
                  get(ENV, "GAP_PRINT_BANNER", "true") != "false"
 
     if !show_banner

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -3,6 +3,7 @@ using Aqua
 @testset "Aqua.jl" begin
     Aqua.test_all(
         GAP;
+        ambiguities=false, # some from AbstractAlgebra.jl show up here
         piracies=(GAP.use_jl_reinit_foreign_type() ? true : (treat_as_own=[GapObj],))
     )
 end


### PR DESCRIPTION
The current implementation does not work with julia 1.11 anymore. This has been fixed in the AA copy of this code in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1758.
All other of our packages have already switched from bundling their own version of this to calling the AA function. This PR does the same for GAP.jl.
I know that this introduces AA as a new dependency for GAP.jl (and Polymake.jl), please redirect comments concerning that to https://github.com/Nemocas/AbstractAlgebra.jl/issues/1698.

This PR, if merged, should be backported to the 0.10.x branch that is used with the current Oscar release 1.1.1, so that users of that won't see too many banners once julia 1.11 is released.