### PR TITLE
fix a test

### DIFF
--- a/test/packages.jl
+++ b/test/packages.jl
@@ -6,6 +6,7 @@
     @test GAP.Packages.locate_package("no such package") == ""
 
     @test GAP.Packages.install("fga", interactive = false)
+    @test GAP.Packages.load("fga")
     @test ! isempty(GAP.Packages.locate_package("fga"))
     @test ! isempty(GAP.Packages.locate_package("FGA"))
     @test GAP.Packages.remove("fga", interactive = false)


### PR DESCRIPTION
The tests

```
@test GAP.Packages.install("fga", interactive = false)
@test ! isempty(GAP.Packages.locate_package("fga"))
```

pass only if the FGA package was already loaded before the tests, which is the case in usual installations.
If one starts GAP without packages (`-A` option) then the second test fails. One has to load the package in order to be sure that `locate_package` returns a nonempty result.