### PR TITLE
rewrite `julia_to_gap`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
     simpler and safer and
   - restrict the necessity to create dictionaries to situations where
     recursive conversions make sense.
-  For that, the function `julia_to_gap_internal`, the macro `GAP.@install`,
+  For that, the function `GAP.GapObj_internal`, the macro `GAP.@install`,
   and the type `GapCacheDict` were introduced.
 
 ## Version 0.11.4 (released 2024-09-19)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes in GAP.jl
 
+- Rewrite `julia_to_gap`, in order to
+  - make the installation of new conversion methods from Julia to GAP
+    simpler and safer and
+  - restrict the necessity to create dictionaries to situations where
+    recursive conversions make sense.
+  For that, the function `julia_to_gap_internal`, the macro `GAP.@install`,
+  and the type `GapCacheDict` were introduced.
+
 ## Version 0.11.4 (released 2024-09-19)
 
 - Support AbstractAlgebra 0.43

--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -11,7 +11,8 @@ For a few types of objects, such conversions are unavoidable,
 see [Automatic GAP-to-Julia and Julia-to-GAP Conversions](@ref).
 In all other situations,
 the conversions between GAP objects and corresponding Julia objects
-can be performed using [`gap_to_julia`](@ref) and [`julia_to_gap`](@ref),
+can be performed using [`gap_to_julia`](@ref) and
+[`GapObj(x, cache::GapCacheDict = nothing; recursive::Bool = false)`](@ref),
 see [Explicit GAP-to-Julia and Julia-to-GAP Conversions](@ref), respectively.
 
 For convenience, also constructor methods are provided,
@@ -46,7 +47,7 @@ The exceptions are as follows.
 
 ```@docs
 gap_to_julia
-julia_to_gap
+GapObj(x, cache::GapCacheDict = nothing; recursive::Bool = false)
 ```
 
 ## Constructor Methods for GAP-to-Julia Conversions

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -99,7 +99,7 @@ julia> Vector{Vector{Int}}(cf)
 Next let us investigate the operation of the group on the 48 points.
 
 ```jldoctest rubik
-julia> orbs = GAP.Globals.Orbits(cube, GAP.GapObj(1:48))
+julia> orbs = GAP.Globals.Orbits(cube, GapObj(1:48))
 GAP: [ [ 1, 3, 17, 14, 8, 38, 9, 41, 19, 48, 22, 6, 30, 33, 43, 11, 46, 40, 24, 27, 25, 35, 16, 32 ], [ 2, 5, 12, 7, 36, 10, 47, 4, 28, 45, 34, 13, 29, 44, 20, 42, 26, 21, 37, 15, 31, 18, 23, 39 ] ]
 
 julia> length(orbs)
@@ -315,7 +315,7 @@ For this purpose we introduce a free group and a homomorphism of it
 onto the cube group.
 
 ```jldoctest rubik
-julia> f = GAP.Globals.FreeGroup(GAP.GapObj(["t", "l", "f", "r", "e", "b"], recursive =  true))
+julia> f = GAP.Globals.FreeGroup(GapObj(["t", "l", "f", "r", "e", "b"], recursive =  true))
 GAP: <free group on the generators [ t, l, f, r, e, b ]>
 
 julia> fhom = GAP.Globals.GroupHomomorphismByImages(f, cube)

--- a/docs/src/other.md
+++ b/docs/src/other.md
@@ -95,10 +95,10 @@ regarding the mutability of the result
 but here we have to choose one behaviour for the Julia function.
 
 ```jldoctest
-julia> l = GAP.julia_to_gap( [ 1, 3, 7, 15 ] )
+julia> l = GapObj( [ 1, 3, 7, 15 ] )
 GAP: [ 1, 3, 7, 15 ]
 
-julia> m = GAP.julia_to_gap( [ 1 2; 3 4 ] )
+julia> m = GapObj( [ 1 2; 3 4 ] )
 GAP: [ [ 1, 2 ], [ 3, 4 ] ]
 
 julia> length( l )

--- a/docs/src/other.md
+++ b/docs/src/other.md
@@ -13,6 +13,7 @@ DocTestSetup = :(using GAP)
 @gapwrap
 @gapattribute
 @wrap
+@install
 ```
 
 ## Convenience adapters

--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -178,8 +178,10 @@ DeclareAttribute( "JuliaPointer", IsJuliaWrapper );
 #! <Julia module GAP>
 #! gap> IsJuliaModule( Julia.GAP );
 #! true
-#! gap> Julia.GAP.julia_to_gap;
-#! <Julia: julia_to_gap>
+#! gap> Julia.GAP.gap_to_julia;
+#! <Julia: gap_to_julia>
+#! gap> JuliaFunction( "gap_to_julia", "GAP" );  # the same function
+#! <Julia: gap_to_julia>
 #! @EndExampleSession
 DeclareCategory( "IsJuliaModule", IsJuliaWrapper and IsRecord  );
 

--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -180,8 +180,6 @@ DeclareAttribute( "JuliaPointer", IsJuliaWrapper );
 #! true
 #! gap> Julia.GAP.gap_to_julia;
 #! <Julia: gap_to_julia>
-#! gap> JuliaFunction( "gap_to_julia", "GAP" );  # the same function
-#! <Julia: gap_to_julia>
 #! @EndExampleSession
 DeclareCategory( "IsJuliaModule", IsJuliaWrapper and IsRecord  );
 

--- a/pkg/JuliaInterface/gap/convert.gd
+++ b/pkg/JuliaInterface/gap/convert.gd
@@ -370,7 +370,7 @@
 #!
 #! <ManSection>
 #! <Func Name="Julia.GAP.Obj" Arg="juliaobj[, recursive]"/>
-#! <Func Name="Julia.GapObj" Arg="juliaobj[, recursive]"/>
+#! <Func Name="Julia.GAP.GapObj" Arg="juliaobj[, recursive]"/>
 #! <Returns>a &GAP; object</Returns>
 #! <Description>
 #! The &Julia; constructor <Ref Func="Julia.GAP.Obj"/> takes an object
@@ -403,7 +403,7 @@
 #! via suitable methods for <Ref Func="Julia.GAP.Obj"/>.
 #! <P/>
 #! If one is sure that the result of the conversion to &GAP; is not an
-#! immediate &GAP; object then one can call <Ref Func="Julia.GapObj"/>
+#! immediate &GAP; object then one can call <Ref Func="Julia.GAP.GapObj"/>
 #! instead of <Ref Func="Julia.GAP.Obj"/>.
 #! </Description>
 #! </ManSection>

--- a/pkg/JuliaInterface/gap/convert.gd
+++ b/pkg/JuliaInterface/gap/convert.gd
@@ -39,7 +39,7 @@
 #!   On the &Julia; side, there is usually no need for a wrapper,
 #!   as (thanks to the shared garbage collector)
 #!   most &GAP; objects are valid &Julia; objects of type
-#!   <C>GAP.GapObj</C>.
+#!   <C>GapObj</C>.
 #!   The exception to that rule are immediate &GAP; objects,
 #!   more on that in the next section.
 #! </Item>
@@ -84,7 +84,7 @@
 #!  <Ref Chap="Integers" BookName="ref"/> in the &GAP; Reference Manual.
 #!  Since these are not valid pointers, &Julia; cannot treat them like other
 #!  &GAP; objects, which are simply &Julia; objects of type
-#!  <C>GAP.GapObj</C>.
+#!  <C>GapObj</C>.
 #!  Instead, a conversion is unavoidable, at least when immediate objects
 #!  are passed as stand-alone arguments to a function.
 #!  <P/>
@@ -135,7 +135,7 @@
 #!    &Julia; function wrapper to &Julia; function,
 #!  </Item>
 #!  <Item>
-#!    other &GAP; objects to <C>GAP.GapObj</C>.
+#!    other &GAP; objects to <C>GapObj</C>.
 #!  </Item>
 #!  </List>
 #!
@@ -156,7 +156,7 @@
 #!    &Julia; <C>false</C> to &GAP; <K>false</K>,
 #!  </Item>
 #!  <Item>
-#!    <C>GAP.GapObj</C> to <C>Obj</C>,
+#!    <C>GapObj</C> to <C>Obj</C>,
 #!  </Item>
 #!  <Item>
 #!    other &Julia; objects to &Julia; object wrapper.
@@ -169,7 +169,7 @@
 #!  <Ref Func="GAPToJulia"/> and
 #!  <Ref Constr="JuliaToGAP" Label="for IsObject, IsObject"/>.
 #!  In &Julia;, conversion is done via <C>gap_to_julia</C> and
-#!  <C>julia_to_gap</C>.
+#!  <C>GapObj</C>.
 #!
 #!  <E>Conversion from &GAP; to &Julia;</E>
 #!
@@ -289,7 +289,7 @@
 #!  of nested objects.
 #!  Various methods for this constructor then take care of input validation
 #!  and the actual conversion, either by delegating to the &Julia; function
-#!  <C>julia_to_gap</C>
+#!  <C>GapObj</C>
 #!  (which takes just one or two arguments and chooses the &GAP; filters of
 #!  its result depending on the &Julia; type),
 #!  or by automatic conversion.
@@ -370,7 +370,7 @@
 #!
 #! <ManSection>
 #! <Func Name="Julia.GAP.Obj" Arg="juliaobj[, recursive]"/>
-#! <Func Name="Julia.GAP.GapObj" Arg="juliaobj[, recursive]"/>
+#! <Func Name="Julia.GapObj" Arg="juliaobj[, recursive]"/>
 #! <Returns>a &GAP; object</Returns>
 #! <Description>
 #! The &Julia; constructor <Ref Func="Julia.GAP.Obj"/> takes an object
@@ -403,7 +403,7 @@
 #! via suitable methods for <Ref Func="Julia.GAP.Obj"/>.
 #! <P/>
 #! If one is sure that the result of the conversion to &GAP; is not an
-#! immediate &GAP; object then one can call <Ref Func="Julia.GAP.GapObj"/>
+#! immediate &GAP; object then one can call <Ref Func="Julia.GapObj"/>
 #! instead of <Ref Func="Julia.GAP.Obj"/>.
 #! </Description>
 #! </ManSection>

--- a/pkg/JuliaInterface/gap/convert.gi
+++ b/pkg/JuliaInterface/gap/convert.gi
@@ -8,7 +8,7 @@
 InstallMethod(JuliaToGAP, ["IsInt", "IsJuliaObject"],
 function(filter, obj)
     if Julia.isa(obj, Julia.Base.Integer) then
-        return Julia.GapObj(obj);
+        return Julia.GAP.GapObj(obj);
     fi;
     Error("<obj> must be a Julia integer");
 end);
@@ -22,7 +22,7 @@ end);
 InstallMethod(JuliaToGAP, ["IsRat", "IsJuliaObject"],
 function(filter, obj)
     if Julia.isa(obj, Julia.Base.Integer) or Julia.isa(obj, Julia.Base.Rational) then
-        return Julia.GapObj(obj);
+        return Julia.GAP.GapObj(obj);
     fi;
     Error("<obj> must be a Julia integer or rational");
 end);
@@ -38,7 +38,7 @@ end);
 InstallMethod(JuliaToGAP, ["IsFloat", "IsJuliaObject"],
 function(filter, obj)
     if Julia.isa(obj, Julia.Base.AbstractFloat) then
-        return Julia.GapObj(obj);
+        return Julia.GAP.GapObj(obj);
     fi;
     Error("<obj> must be a Julia float");
 end);
@@ -54,10 +54,10 @@ end);
 InstallMethod(JuliaToGAP, ["IsChar", "IsJuliaObject"],
 function(filter, obj)
     if Julia.isa(obj, Julia.Base.Char) then
-        return Julia.GapObj(obj);
+        return Julia.GAP.GapObj(obj);
     elif Julia.isa(obj, Julia.Base.Int8) or
          Julia.isa(obj, Julia.Base.UInt8) then
-        return CharInt( Julia.GapObj(obj) );
+        return CharInt( Julia.GAP.GapObj(obj) );
     fi;
 
     Error("<obj> must be a Julia Char or Int8 or UInt8");
@@ -119,7 +119,7 @@ InstallMethod(JuliaToGAP, ["IsString", "IsJuliaObject"],
 function(filter, obj)
     if Julia.isa(obj, Julia.Base.AbstractString) or
        Julia.isa(obj, Julia.Base.Symbol) then
-        return Julia.GapObj(obj);
+        return Julia.GAP.GapObj(obj);
     fi;
     Error("<obj> must be a Julia string or symbol");
 end);

--- a/pkg/JuliaInterface/gap/convert.gi
+++ b/pkg/JuliaInterface/gap/convert.gi
@@ -8,7 +8,7 @@
 InstallMethod(JuliaToGAP, ["IsInt", "IsJuliaObject"],
 function(filter, obj)
     if Julia.isa(obj, Julia.Base.Integer) then
-        return Julia.GAP.julia_to_gap(obj);
+        return Julia.GapObj(obj);
     fi;
     Error("<obj> must be a Julia integer");
 end);
@@ -22,7 +22,7 @@ end);
 InstallMethod(JuliaToGAP, ["IsRat", "IsJuliaObject"],
 function(filter, obj)
     if Julia.isa(obj, Julia.Base.Integer) or Julia.isa(obj, Julia.Base.Rational) then
-        return Julia.GAP.julia_to_gap(obj);
+        return Julia.GapObj(obj);
     fi;
     Error("<obj> must be a Julia integer or rational");
 end);
@@ -38,7 +38,7 @@ end);
 InstallMethod(JuliaToGAP, ["IsFloat", "IsJuliaObject"],
 function(filter, obj)
     if Julia.isa(obj, Julia.Base.AbstractFloat) then
-        return Julia.GAP.julia_to_gap(obj);
+        return Julia.GapObj(obj);
     fi;
     Error("<obj> must be a Julia float");
 end);
@@ -54,10 +54,10 @@ end);
 InstallMethod(JuliaToGAP, ["IsChar", "IsJuliaObject"],
 function(filter, obj)
     if Julia.isa(obj, Julia.Base.Char) then
-        return Julia.GAP.julia_to_gap(obj);
+        return Julia.GapObj(obj);
     elif Julia.isa(obj, Julia.Base.Int8) or
          Julia.isa(obj, Julia.Base.UInt8) then
-        return CharInt( Julia.GAP.julia_to_gap(obj) );
+        return CharInt( Julia.GapObj(obj) );
     fi;
 
     Error("<obj> must be a Julia Char or Int8 or UInt8");
@@ -119,7 +119,7 @@ InstallMethod(JuliaToGAP, ["IsString", "IsJuliaObject"],
 function(filter, obj)
     if Julia.isa(obj, Julia.Base.AbstractString) or
        Julia.isa(obj, Julia.Base.Symbol) then
-        return Julia.GAP.julia_to_gap(obj);
+        return Julia.GapObj(obj);
     fi;
     Error("<obj> must be a Julia string or symbol");
 end);

--- a/pkg/JuliaInterface/gap/juliahelp.g
+++ b/pkg/JuliaInterface/gap/juliahelp.g
@@ -52,10 +52,10 @@
 #!   &Julia; functions belong to &Julia; modules.
 #!   Many &Julia; functions can be accessed only relative to their modules,
 #!   and then also the help requests work only for the qualified names.
-#!   For example, <C>?Julia:GAP.julia_to_gap</C> yields the description
-#!   of the &Julia; function <C>julia_to_gap</C> that is defined in the
+#!   For example, <C>?Julia:GAP.wrap_rng</C> yields the description
+#!   of the &Julia; function <C>wrap_rng</C> that is defined in the
 #!   &Julia; module <C>GAP</C>,
-#!   whereas no match is found for the input <C>?Julia:julia_to_gap</C>.
+#!   whereas no match is found for the input <C>?Julia:wrap_rng</C>.
 #!  </Item>
 #!  </List>
 #! @EndChunk

--- a/pkg/JuliaInterface/tst/convert.tst
+++ b/pkg/JuliaInterface/tst/convert.tst
@@ -189,11 +189,11 @@ gap> Julia.GAP.Obj( list );
 [ 1, 2, 3 ]
 
 ##  ranges
-gap> Julia.GAP.julia_to_gap( JuliaEvalString( "1:3" ) );
+gap> Julia.GapObj( JuliaEvalString( "1:3" ) );
 [ 1 .. 3 ]
-gap> Julia.GAP.julia_to_gap( JuliaEvalString( "1:2:5" ) );
+gap> Julia.GapObj( JuliaEvalString( "1:2:5" ) );
 [ 1, 3 .. 5 ]
-gap> Julia.GAP.julia_to_gap( JuliaEvalString( "3:2" ) );
+gap> Julia.GapObj( JuliaEvalString( "3:2" ) );
 [  ]
 gap> Julia.GAP.Obj( JuliaEvalString( "1:3" ) );
 [ 1 .. 3 ]

--- a/pkg/JuliaInterface/tst/convert.tst
+++ b/pkg/JuliaInterface/tst/convert.tst
@@ -189,11 +189,11 @@ gap> Julia.GAP.Obj( list );
 [ 1, 2, 3 ]
 
 ##  ranges
-gap> Julia.GapObj( JuliaEvalString( "1:3" ) );
+gap> Julia.GAP.GapObj( JuliaEvalString( "1:3" ) );
 [ 1 .. 3 ]
-gap> Julia.GapObj( JuliaEvalString( "1:2:5" ) );
+gap> Julia.GAP.GapObj( JuliaEvalString( "1:2:5" ) );
 [ 1, 3 .. 5 ]
-gap> Julia.GapObj( JuliaEvalString( "3:2" ) );
+gap> Julia.GAP.GapObj( JuliaEvalString( "3:2" ) );
 [  ]
 gap> Julia.GAP.Obj( JuliaEvalString( "1:3" ) );
 [ 1 .. 3 ]

--- a/pkg/JuliaInterface/tst/help.tst
+++ b/pkg/JuliaInterface/tst/help.tst
@@ -57,7 +57,7 @@ true
 gap> str:= HelpString( "Julia:GAP.wrap_rng" );; # is not exported from GAP
 gap> PositionSublist( str, "wrap_rng" ) <> fail;
 true
-gap> str:= HelpString( "Julia:GapObj" );; # is exported from GAP
+gap> str:= HelpString( "Julia:GAP.GapObj" );;
 gap> PositionSublist( str, "GapObj" ) <> fail;
 true
 gap> str:= HelpString( "Julia:sqrt" );; # is from Julia.Base

--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -449,7 +449,7 @@ Base.copy(rng::MersenneTwister) = MersenneTwister(state=MersenneTwisterState(Glo
 Random.rand(rng::AbstractGAPRNG, x::Random.SamplerTrivial{<:Obj}) = Globals.Random(rng.ptr, x[])
 
 Random.rand(rng::AbstractGAPRNG, x::Random.SamplerTrivial{<:AbstractUnitRange}) =
-    Globals.Random(rng.ptr, julia_to_gap(first(x[])), julia_to_gap(last(x[])))
+    Globals.Random(rng.ptr, GapObj(first(x[])), GapObj(last(x[])))
 
 Random.Sampler(::Type{<:AbstractGAPRNG}, x::AbstractUnitRange, ::Random.Repetition) =
     Random.SamplerTrivial(x)
@@ -464,7 +464,7 @@ for U in (Base.BitInteger64, Union{Int128,UInt128})
 end
 
 Random.Sampler(::Type{<:AbstractGAPRNG}, x::AbstractVector, ::Random.Repetition) =
-    Random.SamplerTrivial(julia_to_gap(x, recursive=false))
+    Random.SamplerTrivial(GapObj(x, recursive=false))
 
 
 # The following bypasses GAP's redirection of `x^-1` to `InverseSameMutability(x)`.

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -127,11 +127,11 @@ be a useful escape hatch to access GAP functionality that is otherwise
 impossible to difficult to reach. But in most typical scenarios it
 should not be necessary to use it at all.
 
-Instead, use `GAP.GapObj` or `GAP.Obj` for constructing GAP objects
+Instead, use `GapObj` or `GAP.Obj` for constructing GAP objects
 that correspond to given Julia objects,
 and call GAP functions directly in the Julia session.
 For example, executing `GAP.evalstr( "x:= []; Add( x, 2 )" )`
-can be replaced by the Julia code `x = GAP.GapObj([]); GAP.Globals.Add(x, 2)`.
+can be replaced by the Julia code `x = GapObj([]); GAP.Globals.Add(x, 2)`.
 Note that the variable `x` in the former example lives in the GAP session,
 i.e., it can be accessed as `GAP.Globals.x` after the call of `GAP.evalstr`,
 whereas `x` in the latter example lives in the Julia session.

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -3,11 +3,11 @@ Obj(x::Obj) = x
 GapObj(x::GapObj) = x
 
 ## Handle conversion of Julia objects to GAP objects
-Obj(obj; recursive::Bool = false) = julia_to_gap(obj, IdDict(); recursive)::Obj
-GapObj(obj; recursive::Bool = false) = julia_to_gap(obj, IdDict(); recursive)::GapObj
+Obj(obj; recursive::Bool = false) = julia_to_gap_internal(obj, nothing, recursive)::Obj
+GapObj(obj; recursive::Bool = false) = julia_to_gap_internal(obj, nothing, recursive)::GapObj
 
-Obj(obj, recursive::Bool) = julia_to_gap(obj, IdDict(); recursive)::Obj
-GapObj(obj, recursive::Bool) = julia_to_gap(obj, IdDict(); recursive)::GapObj
+Obj(obj, recursive::Bool) = julia_to_gap_internal(obj, nothing, recursive)::Obj
+GapObj(obj, recursive::Bool) = julia_to_gap_internal(obj, nothing, recursive)::GapObj
 
 ## Conversion to gap integers
 GapInt(x::Integer) = julia_to_gap(x)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -3,11 +3,11 @@ Obj(x::Obj) = x
 GapObj(x::GapObj) = x
 
 ## Handle conversion of Julia objects to GAP objects
-Obj(obj; recursive::Bool = false) = julia_to_gap_internal(obj, nothing, recursive)::Obj
-GapObj(obj; recursive::Bool = false) = julia_to_gap_internal(obj, nothing, recursive)::GapObj
+Obj(obj; recursive::Bool = false) = GapObj_internal(obj, nothing, recursive)::Obj
+GapObj(obj; recursive::Bool = false) = GapObj_internal(obj, nothing, recursive)::GapObj
 
-Obj(obj, recursive::Bool) = julia_to_gap_internal(obj, nothing, recursive)::Obj
-GapObj(obj, recursive::Bool) = julia_to_gap_internal(obj, nothing, recursive)::GapObj
+Obj(obj, recursive::Bool) = GapObj_internal(obj, nothing, recursive)::Obj
+GapObj(obj, recursive::Bool) = GapObj_internal(obj, nothing, recursive)::GapObj
 
 ## Conversion to gap integers
 GapInt(x::Integer) = julia_to_gap(x)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -3,10 +3,10 @@ Obj(x::Obj) = x
 GapObj(x::GapObj) = x
 
 ## Handle conversion of Julia objects to GAP objects
-Obj(obj; recursive::Bool = false) = GapObj_internal(obj, nothing, recursive)::Obj
+Obj(obj; recursive::Bool = false) = GapObj_internal(obj, nothing, Val(recursive))::Obj
 
-Obj(obj, recursive::Bool) = GapObj_internal(obj, nothing, recursive)::Obj
-GapObj(obj, recursive::Bool) = GapObj_internal(obj, nothing, recursive)::Obj
+Obj(obj, recursive::Bool) = GapObj_internal(obj, nothing, Val(recursive))::Obj
+GapObj(obj, recursive::Bool) = GapObj_internal(obj, nothing, Val(recursive))::Obj
 
 ## Conversion to gap integers
 GapInt(x::Integer) = GapObj(x)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -1,16 +1,15 @@
-## Handle "conversion" to GAP.Obj and GAP.GapObj (may occur in recursions).
+## Handle "conversion" to GAP.Obj and GapObj (may occur in recursions).
 Obj(x::Obj) = x
 GapObj(x::GapObj) = x
 
 ## Handle conversion of Julia objects to GAP objects
 Obj(obj; recursive::Bool = false) = GapObj_internal(obj, nothing, recursive)::Obj
-GapObj(obj; recursive::Bool = false) = GapObj_internal(obj, nothing, recursive)::GapObj
 
 Obj(obj, recursive::Bool) = GapObj_internal(obj, nothing, recursive)::Obj
-GapObj(obj, recursive::Bool) = GapObj_internal(obj, nothing, recursive)::GapObj
+GapObj(obj, recursive::Bool) = GapObj_internal(obj, nothing, recursive)::Obj
 
 ## Conversion to gap integers
-GapInt(x::Integer) = julia_to_gap(x)
+GapInt(x::Integer) = GapObj(x)
 
 
 """

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -15,6 +15,8 @@ An internal type of GAP.jl used for tracking conversion results in `gap_to_julia
 """
 const RecDict = IdDict{Any,Any}
 
+const GapCacheDict = Union{Nothing,RecDict}
+
 ## Conversion from GAP to Julia
 """
     gap_to_julia(type, x, recursion_dict::Union{Nothing,RecDict}=nothing; recursive::Bool=true)

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -1,31 +1,53 @@
 ## Converters
 """
-    julia_to_gap(input, recursion_dict::GapCacheDict = nothing; recursive::Bool = false)
+    GapObj(input, recursion_dict::GapCacheDict = nothing; recursive::Bool = false)
+    GapObj(input, recursive::Bool = false)
 
-Convert a julia object `input` to an appropriate GAP object.
-If `recursive` is set to `true`, recursive conversion on
-arrays, tuples, and dictionaries is performed.
+One can use the type [`GapObj`](@ref) as a constructor,
+in order to convert the julia object `input` to an appropriate GAP object.
+
+If `recursive` is set to `true`, recursive conversion of nested Julia objects
+(arrays, tuples, and dictionaries) is performed.
+
 
 The input `recursion_dict` should never be set by the user, it is meant to keep egality
 of input data, by converting equal data to identical objects in GAP.
 
 # Examples
 ```jldoctest
-julia> GAP.julia_to_gap(1//3)
+julia> GapObj(1//3)
 GAP: 1/3
 
-julia> GAP.julia_to_gap("abc")
+julia> GapObj("abc")
 GAP: "abc"
 
-julia> GAP.julia_to_gap([ [1, 2], [3, 4]])
-GAP: [ <Julia: [1, 2]>, <Julia: [3, 4]> ]
-
-julia> GAP.julia_to_gap([ [1, 2], [3, 4]], recursive = true)
+julia> GapObj([1 2; 3 4])
 GAP: [ [ 1, 2 ], [ 3, 4 ] ]
 
+julia> GapObj([[1, 2], [3, 4]])
+GAP: [ <Julia: [1, 2]>, <Julia: [3, 4]> ]
+
+julia> GapObj([[1, 2], [3, 4]], true)
+GAP: [ [ 1, 2 ], [ 3, 4 ] ]
+
+julia> GapObj([[1, 2], [3, 4]], recursive = true)
+GAP: [ [ 1, 2 ], [ 3, 4 ] ]
 ```
 
-The following `julia_to_gap` conversions are supported by GAP.jl.
+Note that this conversion is *not* restricted to outputs that actually are
+of type `GapObj`,
+also GAP integers, finite field elements, and booleans can be created
+by the constructor `GapObj`.
+
+```jldoctest
+julia> res = GapObj(42);  res isa GapObj
+false
+
+julia> res isa GAP.Obj
+true
+```
+
+The following `GapObj` conversions are supported by GAP.jl.
 (Other Julia packages may provide conversions for more Julia objects.)
 
 | Julia type                           | GAP filter   |
@@ -46,9 +68,9 @@ The following `julia_to_gap` conversions are supported by GAP.jl.
 | `UnitRange{T}`, `StepRange{T, S}`    | `IsRange`    |
 | `Function`                           | `IsFunction` |
 """
-julia_to_gap(x, cache::GapCacheDict = nothing; recursive::Bool = false) = GapObj_internal(x, cache, recursive)
+GapObj(x, cache::GapCacheDict = nothing; recursive::Bool = false) = GapObj_internal(x, cache, recursive)
 
-# The calls to `GAP.@install` install methods for `GapObj_internal`
+# The calls to `GAP.@install` install methods for `GAP.GapObj_internal`
 # so we must make sure it is declared before
 function GapObj_internal end
 
@@ -226,7 +248,7 @@ end
 ## We have to do something only if recursive conversion is required,
 ## and if `obj` contains Julia subobjects;
 ## in this case, `obj` is a GAP list or record.
-## An example of such an `obj` is `GAP.julia_to_gap([[1]])`.
+## An example of such an `obj` is `GapObj([[1]])`.
 function GapObj_internal(
     obj::GapObj,
     recursion_dict::GapCacheDict,

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -46,44 +46,49 @@ The following `julia_to_gap` conversions are supported by GAP.jl.
 | `UnitRange{T}`, `StepRange{T, S}`    | `IsRange`    |
 | `Function`                           | `IsFunction` |
 """
-julia_to_gap(x::FFE) = x    # Default for actual GAP objects is to do nothing
-julia_to_gap(x::Bool) = x   # Default for actual GAP objects is to do nothing
+function julia_to_gap end
+
+# default
+julia_to_gap(x, cache::GapCacheDict = nothing; recursive::Bool = false) = julia_to_gap_internal(x, cache, recursive)
+
+julia_to_gap_internal(x::FFE, cache::GapCacheDict, recursive::Bool) = x    # Default for actual GAP objects is to do nothing
+julia_to_gap_internal(x::Bool, cache::GapCacheDict, recursive::Bool) = x   # Default for actual GAP objects is to do nothing
 
 ## Integers: general case first deal with things that fit into immediate
 ## integers, then falls back to converting to BigInt and calling into the GAP
 ## kernel API.
 ## TODO: we could provide more efficient conversion for UInt64, Int128, UInt128
 ## which avoids the conversion to BigInt, if we wanted to.
-function julia_to_gap(x::Integer)
+function julia_to_gap_internal(x::Integer, cache::GapCacheDict, recursive::Bool)
     # if it fits into a GAP immediate integer, convert x to Int64
     x in -1<<60:(1<<60-1) && return Int64(x)
     # for the general case, fall back to BigInt
-    return julia_to_gap(BigInt(x))
+    return julia_to_gap_internal(BigInt(x), cache, recursive)
 end
 
 ## Small integers types always fit into GAP immediate integers, and thus are
 ## represented by Int64 on the Julia side.
-julia_to_gap(x::Int64) = x
-julia_to_gap(x::Int32) = Int64(x)
-julia_to_gap(x::Int16) = Int64(x)
-julia_to_gap(x::Int8) = Int64(x)
-julia_to_gap(x::UInt32) = Int64(x)
-julia_to_gap(x::UInt16) = Int64(x)
-julia_to_gap(x::UInt8) = Int64(x)
+julia_to_gap_internal(x::Int64, cache::GapCacheDict, recursive::Bool) = x
+julia_to_gap_internal(x::Int32, cache::GapCacheDict, recursive::Bool) = Int64(x)
+julia_to_gap_internal(x::Int16, cache::GapCacheDict, recursive::Bool) = Int64(x)
+julia_to_gap_internal(x::Int8, cache::GapCacheDict, recursive::Bool) = Int64(x)
+julia_to_gap_internal(x::UInt32, cache::GapCacheDict, recursive::Bool) = Int64(x)
+julia_to_gap_internal(x::UInt16, cache::GapCacheDict, recursive::Bool) = Int64(x)
+julia_to_gap_internal(x::UInt8, cache::GapCacheDict, recursive::Bool) = Int64(x)
 
-function julia_to_gap(x::UInt)
+function julia_to_gap_internal(x::UInt, cache::GapCacheDict, recursive::Bool)
     x < (1<<60) && return Int64(x)
     return ccall((:ObjInt_UInt, libgap), GapObj, (UInt64, ), x)
 end
 
 ## BigInts are converted via a ccall
-function julia_to_gap(x::BigInt)
+function julia_to_gap_internal(x::BigInt, cache::GapCacheDict, recursive::Bool)
     x in -1<<60:(1<<60-1) && return Int64(x)
     return GC.@preserve x ccall((:MakeObjInt, libgap), GapObj, (Ptr{UInt64}, Cint), x.d, x.size)
 end
 
 ## Rationals
-function julia_to_gap(x::Rational{T}) where {T<:Integer}
+function julia_to_gap_internal(x::Rational{T}, cache::GapCacheDict, recursive::Bool) where {T<:Integer}
     denom_julia = denominator(x)
     numer_julia = numerator(x)
     if denom_julia == 0
@@ -93,37 +98,43 @@ function julia_to_gap(x::Rational{T}) where {T<:Integer}
             return -Globals.infinity
         end
     end
-    numer = julia_to_gap(numer_julia)
-    denom = julia_to_gap(denom_julia)
+    numer = julia_to_gap_internal(numer_julia, cache, recursive)
+    denom = julia_to_gap_internal(denom_julia, cache, recursive)
     return Wrappers.QUO(numer, denom)
 end
 
 ## Floats
-julia_to_gap(x::Float64) = NEW_MACFLOAT(x)
-julia_to_gap(x::Float32) = NEW_MACFLOAT(Float64(x))
-julia_to_gap(x::Float16) = NEW_MACFLOAT(Float64(x))
+julia_to_gap_internal(x::Float64, cache::GapCacheDict, recursive::Bool) = NEW_MACFLOAT(x)
+julia_to_gap_internal(x::Float32, cache::GapCacheDict, recursive::Bool) = NEW_MACFLOAT(Float64(x))
+julia_to_gap_internal(x::Float16, cache::GapCacheDict, recursive::Bool) = NEW_MACFLOAT(Float64(x))
 
 ## Chars
-julia_to_gap(x::Char) = CharWithValue(Cuchar(x))
+julia_to_gap_internal(x::Char, cache::GapCacheDict, recursive::Bool) = CharWithValue(Cuchar(x))
 
 ## Strings and symbols
-julia_to_gap(x::AbstractString) = MakeString(string(x))
-julia_to_gap(x::Symbol) = MakeString(string(x))
+julia_to_gap_internal(x::AbstractString, cache::GapCacheDict, recursive::Bool) = MakeString(string(x))
+julia_to_gap_internal(x::Symbol, cache::GapCacheDict, recursive::Bool) = MakeString(string(x))
 
-## Generic caller for optional arguments
-julia_to_gap(obj::Any; recursive::Bool) = julia_to_gap(obj)
-julia_to_gap(obj::Any, recursion_dict::IdDict{Any,Any}; recursive::Bool = true) = julia_to_gap(obj)
+# ## Generic caller for optional arguments
+# julia_to_gap(obj::Any; recursive::Bool) = julia_to_gap(obj)
+# julia_to_gap(obj::Any, recursion_dict::IdDict{Any,Any}; recursive::Bool = true) = julia_to_gap(obj)
 
 ## Arrays (including BitVector)
-function julia_to_gap(
+function julia_to_gap_internal(
     obj::AbstractVector{T},
-    recursion_dict::IdDict{Any,Any} = IdDict();
-    recursive::Bool = false,
+    recursion_dict::GapCacheDict,
+    recursive::Bool,
 ) where {T}
 
+    if recursion_dict !== nothing && haskey(recursion_dict, obj)
+      return recursion_dict[obj]
+    end
     len = length(obj)
     ret_val = NewPlist(len)
     if recursive
+        if recursion_dict === nothing
+          recursion_dict = RecDict()
+        end
         recursion_dict[obj] = ret_val
     end
     for i = 1:len
@@ -133,7 +144,7 @@ function julia_to_gap(
         end
         if recursive
             x = get!(recursion_dict, x) do
-                julia_to_gap(x, recursion_dict; recursive)
+                julia_to_gap_internal(x, recursion_dict, recursive)
             end
         end
         ret_val[i] = x
@@ -142,66 +153,64 @@ function julia_to_gap(
 end
 
 ## Convert two dimensional arrays
-function julia_to_gap(
+function julia_to_gap_internal(
     obj::Matrix{T},
-    recursion_dict::IdDict{Any,Any} = IdDict();
-    recursive::Bool = false,
+    recursion_dict::GapCacheDict,
+    recursive::Bool,
 ) where {T}
-    (rows, cols) = size(obj)
-    if haskey(recursion_dict, obj)
-        return recursion_dict[obj]
+    if recursion_dict !== nothing && haskey(recursion_dict, obj)
+      return recursion_dict[obj]
     end
+    (rows, cols) = size(obj)
     ret_val = NewPlist(rows)
     if recursive
+        if recursion_dict === nothing
+          recursion_dict = RecDict()
+        end
         recursion_dict[obj] = ret_val
     end
     for i = 1:rows
-        ret_val[i] = julia_to_gap(obj[i, :], recursion_dict; recursive)
+        ret_val[i] = julia_to_gap_internal(obj[i, :], recursion_dict, recursive)
     end
     return ret_val
 end
 
 ## Tuples
-function julia_to_gap(
+function julia_to_gap_internal(
     obj::Tuple,
-    recursion_dict::IdDict{Any,Any} = IdDict();
-    recursive::Bool = false,
+    recursion_dict::GapCacheDict,
+    recursive::Bool,
 )
     array = collect(Any, obj)
-    return julia_to_gap(array, recursion_dict; recursive)
+    return julia_to_gap_internal(array, recursion_dict, recursive)
 end
 
 ## Ranges
-function julia_to_gap(r::AbstractRange{<:Integer}, recursive::Bool = false)
+function julia_to_gap_internal(r::AbstractRange{<:Integer}, recursion_dict::GapCacheDict, recursive::Bool)
     res = NewRange(length(r), first(r), step(r))
     Wrappers.IsRange(res) || throw(ConversionError(r, GapObj))
     return res
 end
 
-function julia_to_gap(
-    r::AbstractRange{<:Integer},
-    recursion_dict::IdDict{Any,Any};
-    recursive::Bool = false)
-
-    return julia_to_gap(r)
-end
-
 ## Dictionaries
-function julia_to_gap(
+function julia_to_gap_internal(
     obj::Dict{T,S},
-    recursion_dict::IdDict{Any,Any} = IdDict();
-    recursive::Bool = false,
+    recursion_dict::GapCacheDict,
+    recursive::Bool,
 ) where {S} where {T<:Union{Symbol,AbstractString}}
 
     record = NewPrecord(0)
     if recursive
+        if recursion_dict === nothing
+          recursion_dict = RecDict()
+        end
         recursion_dict[obj] = record
     end
     for (x, y) in obj
         x = Wrappers.RNamObj(MakeString(string(x)))
         if recursive
             y = get!(recursion_dict, y) do
-                julia_to_gap(y, recursion_dict; recursive)
+                julia_to_gap_internal(y, recursion_dict, recursive)
             end
         end
         Wrappers.ASS_REC(record, x, y)
@@ -215,26 +224,32 @@ end
 ## and if `obj` contains Julia subobjects;
 ## in this case, `obj` is a GAP list or record.
 ## An example of such an `obj` is `GAP.julia_to_gap([[1]])`.
-function julia_to_gap(
+function julia_to_gap_internal(
     obj::GapObj,
-    recursion_dict::IdDict{Any,Any} = IdDict();
-    recursive::Bool = false,
+    recursion_dict::GapCacheDict,
+    recursive::Bool,
 )
     if ! recursive
         ret_val = obj
     elseif Wrappers.IsList(obj)
         len = length(obj)
         ret_val = NewPlist(len)
+        if recursion_dict === nothing
+          recursion_dict = RecDict()
+        end
         recursion_dict[obj] = ret_val
         for i = 1:len
-             ret_val[i] = julia_to_gap(obj[i], recursion_dict; recursive)
+             ret_val[i] = julia_to_gap_internal(obj[i], recursion_dict, recursive)
         end
     elseif Wrappers.IsRecord(obj)
         ret_val = NewPrecord(0)
+        if recursion_dict === nothing
+          recursion_dict = RecDict()
+        end
         recursion_dict[obj] = ret_val
         for xx in Wrappers.RecNames(obj)::GapObj
             x = Wrappers.RNamObj(xx)
-            Wrappers.ASS_REC(ret_val, x, julia_to_gap(Wrappers.ELM_REC(obj, x), recursion_dict; recursive = true))
+            Wrappers.ASS_REC(ret_val, x, julia_to_gap_internal(Wrappers.ELM_REC(obj, x), recursion_dict, recursive))
         end
     else
         ret_val = obj
@@ -243,4 +258,4 @@ function julia_to_gap(
     return ret_val
 end
 
-julia_to_gap(func::Function) = WrapJuliaFunc(func)
+julia_to_gap_internal(func::Function, recursion_dict::GapCacheDict, recursive::Bool) = WrapJuliaFunc(func)

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -334,6 +334,9 @@ function GapObj_internal(
     recursion_dict::GapCacheDict,
     ::Val{recursive},
 ) where {recursive}
+
+    recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && return recursion_dict[obj]
+
     if ! recursive
         ret_val = obj
     elseif Wrappers.IsList(obj)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -478,7 +478,7 @@ macro install(ex)
       typeannot = x.args[2]
     end
     Base.eval(__module__, quote
-        GAP._needs_tracking_julia_to_gap(::Type{$typeannot}) = false
+        GAP._needs_tracking_julia_to_gap(::Type{Sub}) where Sub <: $typeannot = false
       end)
 
     return esc(Expr(

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -420,7 +420,24 @@ macro wrap(ex)
     end)
 end
 
-function install_macro_helper(ex::Expr)
+
+"""
+    @install
+
+When applied to a unary method definition for the function `GapObj`,
+with argument of type `T`,
+this macro installs instead a three argument method for
+`GAP.julia_to_gap_internal`, with second argument of type
+`GAP.GapCacheDict` and third argument of type `Bool`.
+
+This way, the intended `GapObj(x::T)` method becomes available,
+and additionally its code is applicable in recursive calls,
+for example when `GapObj` is called with a vector of objects of type `T`.
+
+The calls of the macro have the form `GAP.@install GapObj(x::T) = f(x)`
+or `GAP.@install function GapObj(x::T) ... end`.
+"""
+macro install(ex)
     errmsg = "GAP.@install must be applied to a unary method definition for GapObj"
 
     # split the method definition
@@ -446,24 +463,4 @@ function install_macro_helper(ex::Expr)
         :block,
         :(Base.@__doc__ $ex),
         ))
-end
-
-"""
-    @install
-
-When applied to a unary method definition for the function `GapObj`,
-with argument of type `T`,
-this macro installs instead a three argument method for
-`GAP.julia_to_gap_internal`, with second argument of type
-`GAP.GapCacheDict` and third argument of type `Bool`.
-
-This way, the intended `GapObj(x::T)` method becomes available,
-and additionally its code is applicable in recursive calls,
-for example when `GapObj` is called with a vector of objects of type `T`.
-
-The calls of the macro have the form `GAP.@install GapObj(x::T) = f(x)`
-or `GAP.@install function GapObj(x::T) ... end`.
-"""
-macro install(ex)
-    return install_macro_helper(ex)
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -383,9 +383,9 @@ macro wrap(ex)
                 # type annotations -> split and decide what to do
                 var = x.args[1]
                 typeannot = x.args[2]
-                if typeannot in [:GapObj, :(GAP.GapObj)]
-                    # the lhs has no type annotation, rhs gets wrapped in `GAP.GapObj(...)::GAP.GapObj` 
-                    (var, :(GAP.GapObj($var)::GAP.GapObj))
+                if typeannot in [:GapObj, :(GapObj)]
+                    # the lhs has no type annotation, rhs gets wrapped in `GapObj(...)::GapObj`
+                    (var, :(GapObj($var)::GapObj))
                 elseif typeannot == :(GAP.Obj)
                     # the lhs has no type annotation, rhs gets wrapped in `GAP.Obj(...)::GAP.Obj`
                     (var, :(GAP.Obj($var)::GAP.Obj))
@@ -403,7 +403,7 @@ macro wrap(ex)
     ]
     lhsargs = map(first, tempargs)
     rhsargs = map(last, tempargs)
-    
+
     # the "outer" part of the body
     body = MacroTools.@qq begin
                global $newsym

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -457,7 +457,12 @@ macro install(ex)
 
     # extend the arguments list of the function
     push!(def_dict[:args], :(cache::GAP.GapCacheDict))
-    push!(def_dict[:args], :(recursive::Bool))
+    push!(def_dict[:args], :(::Val{recursive}))
+    if length(def_dict[:whereparams]) == 0
+      def_dict[:whereparams] = (:recursive,)
+    else
+      def_dict[:whereparams] = Tuple(push!(collect(def_dict[:whereparams]), :recursive))
+    end
 
     # replace the function name
     def_dict[:name] = :(GAP.GapObj_internal)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -427,7 +427,7 @@ end
 When applied to a unary method definition for the function `GapObj`,
 with argument of type `T`,
 this macro installs instead a three argument method for
-`GAP.julia_to_gap_internal`, with second argument of type
+`GAP.GapObj_internal`, with second argument of type
 `GAP.GapCacheDict` and third argument of type `Bool`.
 
 This way, the intended `GapObj(x::T)` method becomes available,
@@ -454,7 +454,7 @@ macro install(ex)
     push!(def_dict[:args], :(recursive::Bool))
 
     # replace the function name
-    def_dict[:name] = :(GAP.julia_to_gap_internal)
+    def_dict[:name] = :(GAP.GapObj_internal)
 
     # assemble the method definition again
     ex = MacroTools.combinedef(def_dict)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -420,6 +420,34 @@ macro wrap(ex)
     end)
 end
 
+function install_macro_helper(ex::Expr)
+    errmsg = "GAP.@install must be applied to a unary method definition for GapObj"
+
+    # split the method definition
+    def_dict = try
+        MacroTools.splitdef(ex)
+    catch
+        error(errmsg)
+    end
+    def_dict[:name] === :GapObj || def_dict[:name] == :(GAP.GapObj) || error(errmsg)
+    length(def_dict[:args]) == 1 || error(errmsg)
+
+    # extend the arguments list of the function
+    push!(def_dict[:args], :(cache::GAP.GapCacheDict))
+    push!(def_dict[:args], :(recursive::Bool))
+
+    # replace the function name
+    def_dict[:name] = :(GAP.julia_to_gap_internal)
+
+    # assemble the method definition again
+    ex = MacroTools.combinedef(def_dict)
+
+    return esc(Expr(
+        :block,
+        :(Base.@__doc__ $ex),
+        ))
+end
+
 """
     @install
 
@@ -437,29 +465,5 @@ The calls of the macro have the form `GAP.@install GapObj(x::T) = f(x)`
 or `GAP.@install function GapObj(x::T) ... end`.
 """
 macro install(ex)
-    errmsg = "GAP.@install must be applied to a unary method definition for GapObj"
-
-    # split the method definition
-    def_dict = try
-        MacroTools.splitdef(ex)
-    catch
-        error(errmsg)
-    end
-    def_dict[:name] === :GapObj || throw(ArgumentError(errmsg))
-    length(def_dict[:args]) == 1 || throw(ArgumentError(errmsg))
-
-    # extend the arguments list of the function
-    push!(def_dict[:args], :(cache::GAP.GapCacheDict))
-    push!(def_dict[:args], :(recursive::Bool))
-
-    # replace the function name
-    def_dict[:name] = :(GAP.julia_to_gap_internal)
-
-    # assemble the method definition again
-    ex = MacroTools.combinedef(def_dict)
-
-    return esc(Expr(
-        :block,
-        :(Base.@__doc__ $ex),
-        ))
+    return install_macro_helper(ex)
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -84,38 +84,11 @@ Module
 ```
 
 One can use `GapObj` as a constructor,
-in order to convert Julia objects to GAP objects.
-Such calls are delegated to [`julia_to_gap`](@ref).
-
-However, this is restricted to outputs that actually are of type `GapObj`.
-To also deal with GAP integers, finite field elements and booleans, use
-[`GAP.Obj`](@ref) instead.
-
-Recursive conversion of nested Julia objects (arrays, tuples, dictionaries)
-can be forced either by a second argument `true`
-or by the keyword argument `recursive` with value `true`.
-
-# Examples
-```jldoctest
-julia> GapObj(1//3)
-GAP: 1/3
-
-julia> GapObj([1 2; 3 4])
-GAP: [ [ 1, 2 ], [ 3, 4 ] ]
-
-julia> GapObj([[1, 2], [3, 4]])
-GAP: [ <Julia: [1, 2]>, <Julia: [3, 4]> ]
-
-julia> GapObj([[1, 2], [3, 4]], true)
-GAP: [ [ 1, 2 ], [ 3, 4 ] ]
-
-julia> GapObj([[1, 2], [3, 4]], recursive=true)
-GAP: [ [ 1, 2 ], [ 3, 4 ] ]
-
-julia> GapObj(42)
-ERROR: TypeError: in typeassert, expected GapObj, got a value of type Int64
-```
+in order to convert Julia objects to GAP objects,
+see [`GapObj(x, cache::GapCacheDict = nothing; recursive::Bool = false)`](@ref)
+for that.
 """ GapObj
+
 
 """
     GAP.Obj

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -3,7 +3,8 @@ module Wrappers
 using GAP
 import GAP: @wrap
 
-@wrap Add(x::GapObj, y::GapObj, z::Int)::Nothing
+@wrap Add(x::GapObj, y::Any)::Nothing
+@wrap Add(x::GapObj, y::Any, z::Int)::Nothing
 @wrap AdditiveInverseSameMutability(x::Any)::Any
 @wrap Append(x::GapObj, y::GapObj)::Nothing
 @wrap ASS_LIST(x::Any, i::Int, v::Any)::Nothing
@@ -40,6 +41,7 @@ import GAP: @wrap
 @wrap IsRange(x::Any)::Bool
 @wrap IsRangeRep(x::Any)::Bool
 @wrap IsRecord(x::Any)::Bool
+@wrap IsSet(x::Any)::Bool
 @wrap IsSSortedList(x::Any)::Bool
 @wrap IsString(x::Any)::Bool
 @wrap IsStringRep(x::Any)::Bool
@@ -70,6 +72,7 @@ import GAP: @wrap
 @wrap SetInfoLevel(x::GapObj, y::Int)::Nothing
 @wrap SetPackagePath(x::GapObj, y::GapObj)::Nothing
 @wrap ShallowCopy(x::Any)::Any
+@wrap Sort(x::GapObj)::Nothing
 @wrap String(x::Any)::Any
 @wrap StringDisplayObj(x::Any)::GapObj
 @wrap StringViewObj(x::Any)::GapObj

--- a/test/adapter.jl
+++ b/test/adapter.jl
@@ -44,7 +44,7 @@ end
 
 @testset "GapObj" begin
     io = IOBuffer();
-    print(io, GAP.GapObj)
+    print(io, GapObj)
     @test String(take!(io)) == "GapObj"
 
     L = [ GAP.evalstr( "()" ) ]
@@ -52,9 +52,9 @@ end
     @test String(take!(io)) == "GapObj[GAP: ()]"
 
     ioc = IOContext(io, :module => nothing);
-    print(ioc, GAP.GapObj)
+    print(ioc, GapObj)
     if GAP.use_jl_reinit_foreign_type()
-        @test String(take!(io)) == "GAP.GapObj"
+        @test String(take!(io)) == "GapObj"
     else
         @test String(take!(io)) == "GAP_jll.GapObj"
     end

--- a/test/adapter.jl
+++ b/test/adapter.jl
@@ -54,7 +54,7 @@ end
     ioc = IOContext(io, :module => nothing);
     print(ioc, GapObj)
     if GAP.use_jl_reinit_foreign_type()
-        @test String(take!(io)) == "GapObj"
+        @test String(take!(io)) == "GAP.GapObj"
     else
         @test String(take!(io)) == "GAP_jll.GapObj"
     end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -2,7 +2,7 @@
     @test GAP.CSTR_STRING(GAP.Globals.String(GAP.Globals.PROD(2^59, 2^59))) ==
           "332306998946228968225951765070086144"
 
-    l = GAP.julia_to_gap([1, 2, 3])
+    l = GapObj([1, 2, 3])
 
     @test l[1] == 1
     @test l[end] == 3
@@ -18,10 +18,10 @@
     x.a = 1
     @test x.a == 1
 
-    xx = GAP.julia_to_gap([1, 2, 3])
+    xx = GapObj([1, 2, 3])
     @test_throws ErrorException xx[4]
 
-    @test string(GAP.julia_to_gap("x")) == "x"
+    @test string(GapObj("x")) == "x"
 
     # equality and hashing
     x = GAP.evalstr("[]")
@@ -74,14 +74,14 @@ end
 @testset "gapcalls" begin
     f = GAP.evalstr("{x...} -> x")
 
-    @test GAP.julia_to_gap([]) == f()
-    @test GAP.julia_to_gap([1]) == f(1)
-    @test GAP.julia_to_gap([1, 2]) == f(1, 2)
-    @test GAP.julia_to_gap([1, 2, 3]) == f(1, 2, 3)
-    @test GAP.julia_to_gap([1, 2, 3, 4]) == f(1, 2, 3, 4)
-    @test GAP.julia_to_gap([1, 2, 3, 4, 5]) == f(1, 2, 3, 4, 5)
-    @test GAP.julia_to_gap([1, 2, 3, 4, 5, 6]) == f(1, 2, 3, 4, 5, 6)
-    @test GAP.julia_to_gap([1, 2, 3, 4, 5, 6, 7]) == f(1, 2, 3, 4, 5, 6, 7)
+    @test GapObj([]) == f()
+    @test GapObj([1]) == f(1)
+    @test GapObj([1, 2]) == f(1, 2)
+    @test GapObj([1, 2, 3]) == f(1, 2, 3)
+    @test GapObj([1, 2, 3, 4]) == f(1, 2, 3, 4)
+    @test GapObj([1, 2, 3, 4, 5]) == f(1, 2, 3, 4, 5)
+    @test GapObj([1, 2, 3, 4, 5, 6]) == f(1, 2, 3, 4, 5, 6)
+    @test GapObj([1, 2, 3, 4, 5, 6, 7]) == f(1, 2, 3, 4, 5, 6, 7)
 
     @test [] == Vector{String}(f())
     @test ["1"] == Vector{String}(f("1"))
@@ -94,14 +94,14 @@ end
 
     g = GAP.evalstr("""{x...} -> [x,ValueOption("option")]""")
 
-    @test GAP.julia_to_gap([[], 42], recursive=true) == g(; option=42)
-    @test GAP.julia_to_gap([[1], 42], recursive=true) == g(1; option=42)
-    @test GAP.julia_to_gap([[1, 2], 42], recursive=true) == g(1, 2; option=42)
-    @test GAP.julia_to_gap([[1, 2, 3], 42], recursive=true) == g(1, 2, 3; option=42)
-    @test GAP.julia_to_gap([[1, 2, 3, 4], 42], recursive=true) == g(1, 2, 3, 4; option=42)
-    @test GAP.julia_to_gap([[1, 2, 3, 4, 5], 42], recursive=true) == g(1, 2, 3, 4, 5; option=42)
-    @test GAP.julia_to_gap([[1, 2, 3, 4, 5, 6], 42], recursive=true) == g(1, 2, 3, 4, 5, 6; option=42)
-    @test GAP.julia_to_gap([[1, 2, 3, 4, 5, 6, 7], 42], recursive=true) == g(1, 2, 3, 4, 5, 6, 7; option=42)
+    @test GapObj([[], 42], recursive=true) == g(; option=42)
+    @test GapObj([[1], 42], recursive=true) == g(1; option=42)
+    @test GapObj([[1, 2], 42], recursive=true) == g(1, 2; option=42)
+    @test GapObj([[1, 2, 3], 42], recursive=true) == g(1, 2, 3; option=42)
+    @test GapObj([[1, 2, 3, 4], 42], recursive=true) == g(1, 2, 3, 4; option=42)
+    @test GapObj([[1, 2, 3, 4, 5], 42], recursive=true) == g(1, 2, 3, 4, 5; option=42)
+    @test GapObj([[1, 2, 3, 4, 5, 6], 42], recursive=true) == g(1, 2, 3, 4, 5, 6; option=42)
+    @test GapObj([[1, 2, 3, 4, 5, 6, 7], 42], recursive=true) == g(1, 2, 3, 4, 5, 6, 7; option=42)
 
     # check to see if a non-basic object (here: a tuple) can be
     # passed and then extracted again

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -4,7 +4,7 @@
 
   @testset "Conversion to GAP.Obj and GAP.GapObj" begin
     x = GAP.evalstr("2^100")
-    @test (@inferred GAP.GapObj(x)) == x
+    @test (@inferred GapObj(x)) == x
     @test GAP.Obj(true) == true
     x = GAP.evalstr("Z(3)")
     @test GAP.Obj(x) == x
@@ -17,11 +17,11 @@
     @test c == GAP.Obj(m, false)
     c = GAP.Obj(m, true)
     @test c[1] isa GAP.Obj
-    c = GAP.GapObj(m)
+    c = GapObj(m)
     @test c[1] isa Vector
-    @test c == GAP.GapObj(m, false)
-    c = GAP.GapObj(m, true)
-    @test c[1] isa GAP.GapObj
+    @test c == GapObj(m, false)
+    c = GapObj(m, true)
+    @test c[1] isa GapObj
   end
 
   @testset "Border cases" begin
@@ -100,23 +100,23 @@
   end
 
   @testset "Vectors" begin
-    x = GAP.julia_to_gap([1, 2, 3])
+    x = GapObj([1, 2, 3])
     @test (@inferred Vector{Any}(x)) == [1, 2, 3]
     @test (@inferred Vector{Int64}(x)) == [1, 2, 3]
     @test (@inferred Vector{BigInt}(x)) == [1, 2, 3]
-    n = GAP.julia_to_gap(big(2)^100)
+    n = GapObj(big(2)^100)
     @test_throws GAP.ConversionError Vector{Int64}(n)
     @test_throws GAP.ConversionError Vector{BigInt}(n)
     x = GAP.evalstr("[ [ 1, 2 ], [ 3, 4 ] ]")
-    nonrec1 = @inferred Vector{GAP.GapObj}(x)
+    nonrec1 = @inferred Vector{GapObj}(x)
     nonrec2 = @inferred Vector{Any}(x; recursive = false)
     rec = @inferred Vector{Any}(x; recursive = true)
-    @test all(x -> isa(x, GAP.GapObj), nonrec1)
+    @test all(x -> isa(x, GapObj), nonrec1)
     @test nonrec1 == nonrec2
     @test nonrec1 != rec
     @test all(x -> isa(x, Array), rec)
     x = [1, 2]
-    y = GAP.julia_to_gap([x, x]; recursive = true)
+    y = GapObj([x, x]; recursive = true)
     z = Vector{Any}(y)
     @test z[1] === z[2]
   end
@@ -125,9 +125,9 @@
     n = GAP.evalstr("[[1,2],[3,4]]")
     @test (@inferred Matrix{Int64}(n)) == [1 2; 3 4]
     xt = [(1,) (2,); (3,) (4,)]
-    n = GAP.julia_to_gap(xt; recursive = false)
+    n = GapObj(xt; recursive = false)
     @test (@inferred Matrix{Tuple{Int64}}(n)) == xt
-    n = GAP.julia_to_gap(big(2)^100)
+    n = GapObj(big(2)^100)
     @test_throws GAP.ConversionError Matrix{Int64}(n)
     n = GAP.evalstr("[[1,2],[,4]]")
     #@test Matrix{Union{Int64,Nothing}}(n) == [1 2; nothing 4]
@@ -135,12 +135,12 @@
     m = Any[1 2; 3 4]
     m[1, 1] = x
     m[2, 2] = x
-    x = GAP.julia_to_gap(m; recursive = true)
+    x = GapObj(m; recursive = true)
     y = @inferred Matrix{Any}(x)
-    @test !isa(y[1, 1], GAP.GapObj)
+    @test !isa(y[1, 1], GapObj)
     @test y[1, 1] === y[2, 2]
     z = @inferred Matrix{Any}(x; recursive = false)
-    @test isa(z[1, 1], GAP.GapObj)
+    @test isa(z[1, 1], GapObj)
     @test z[1, 1] === z[2, 2]
   end
 
@@ -149,16 +149,16 @@
     @test (@inferred Set{Vector{Int}}(GAP.evalstr("[[1,2],[2,3,4]]"))) == Set([[1, 2], [2, 3, 4]])
     @test (@inferred Set{String}(GAP.evalstr("[\"b\", \"a\", \"b\"]"))) == Set(["b", "a", "b"])
     x = GAP.evalstr("SymmetricGroup(3)")
-    #@test (@inferred Set{GAP.GapObj}(x)) == Set{GAP.GapObj}(GAP.Globals.AsSet(x))
+    #@test (@inferred Set{GapObj}(x)) == Set{GapObj}(GAP.Globals.AsSet(x))
   end
 
   @testset "Tuples" begin
-    x = GAP.julia_to_gap([1, 2, 3])
+    x = GapObj([1, 2, 3])
     @test (@inferred Tuple{Int64,Int16,Int32}(x)) == (1, 2, 3)
     @test Tuple{Int64,Any,Int32}(x) == (1, 2, 3)
     @test_throws ArgumentError Tuple{Any,Any}(x)
     @test_throws ArgumentError Tuple{Any,Any,Any,Any}(x)
-    n = GAP.julia_to_gap(big(2)^100)
+    n = GapObj(big(2)^100)
     @test_throws GAP.ConversionError Tuple{Int64,Any,Int32}(n)
     x = GAP.evalstr("[ [ 1, 2 ], [ 3, [ 4, 5 ] ] ]")
     y = Tuple{GAP.Obj,Any}(x)
@@ -198,7 +198,7 @@
     x = GAP.evalstr("rec( foo := 1, bar := \"foo\" )")
     y = Dict{Symbol,Any}(:foo => 1, :bar => "foo")
     @test (@inferred Dict{Symbol,Any}(x)) == y
-    n = GAP.julia_to_gap(big(2)^100)
+    n = GapObj(big(2)^100)
     @test_throws GAP.ConversionError Dict{Symbol,Any}(n)
     x = GAP.evalstr("rec( a:= [ 1, 2 ], b:= [ 3, [ 4, 5 ] ] )")
     y = @inferred Dict{Symbol,Any}(x)
@@ -226,7 +226,7 @@
   end
 
   @testset "GAP lists with Julia objects" begin
-    xx = GAP.julia_to_gap([(1,)])
+    xx = GapObj([(1,)])
     yy = @inferred Vector{Tuple{Int64}}(xx)
     @test [(1,)] == yy
     @test typeof(yy) == Vector{Tuple{Int64}}

--- a/test/convenience.jl
+++ b/test/convenience.jl
@@ -68,7 +68,7 @@ end
 
     # Julia object in GAP list
     l = [ [ 1 2 ], [ 3 4 ] ]
-    gaplist = GAP.julia_to_gap( l )  # list of Julia arrays
+    gaplist = GapObj( l )  # list of Julia arrays
     @test l[1] in gaplist
     @test !([ 5 6 ] in gaplist)
 end

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -382,6 +382,13 @@ end
     @test GapObj([1 2; 3 4]) == x
   end
 
+  @testset "Sets" begin
+    x = GAP.evalstr("[1, 3, 4]")
+    @test GapObj(Set([4, 3, 1])) == x
+    x = GAP.evalstr("[\"a\", \"b\", \"c\"]")
+    @test GapObj(Set(["c", "b", "a"]); recursive = true) == x
+  end
+
   @testset "BitVectors" begin
     x = GAP.evalstr("BlistList([1,2],[1])")
     y = GapObj([true, false])
@@ -452,23 +459,32 @@ end
     # a GAP list with identical Julia subobjects
     l = GapObj([])
     x = BigInt(2)^100
+    y = [1]
     l[1] = x
     l[2] = x
-    @test l[1] === l[2]
+    l[3] = y
+    l[4] = y
     res = GapObj(l)
     @test res[1] === res[2]
+    @test res[3] === res[4]
     res = GapObj(l, recursive=true)
-    @test res[1] === res[2]
+    @test res[1] == res[2]
+    @test res[1] !== res[2]  # `BigInt` wants no identity tracking
+    @test res[3] === res[4]  # `Array` wants identity tracking
 
     # a GAP record with identical Julia subobjects
     r = GapObj(Dict{String, String}())
     setproperty!(r, :a, x)
     setproperty!(r, :b, x)
-    @test r.a === r.b
+    setproperty!(r, :c, y)
+    setproperty!(r, :d, y)
     res = GapObj(r)
     @test res.a === res.b
+    @test res.c === res.d
     res = GapObj(r, recursive=true)
-    @test res.a === res.b
+    @test res.a == res.b
+    @test res.a !== res.b  # `BigInt` wants no identity tracking
+    @test res.c === res.d
   end
 
   @testset "converting a list with circular refs" begin

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -472,6 +472,28 @@ end
     @test res[1] !== res[2]  # `BigInt` wants no identity tracking
     @test res[3] === res[4]  # `Array` wants identity tracking
 
+    # a Julia array containing GAP lists containing Julia subobjects
+    v = GapObj([1, 2, 3])
+    l = [v, v]
+    ll = GapObj(l)
+    @test ll[1] === ll[2]
+    @test ll[1] === l[1]
+
+    v[1] = [1,2]
+    ll = GapObj(l)
+    @test ll[1][1] === ll[2][1]
+    ll = GapObj(l; recursive = true)
+    @test ll[1][1] === ll[2][1]
+    @test ll[1] === ll[2]
+
+    l[2] = GapObj([1, 2, 3])
+    l[2][1] = l[1][1]
+    ll = GapObj(l)
+    @test ll[1][1] === ll[2][1]  # two Julia vectors
+    ll = GapObj(l; recursive = true)
+    @test ll[1][1] === ll[2][1]  # two GAP lists
+    @test ll[1] !== ll[2]
+
     # a GAP record with identical Julia subobjects
     r = GapObj(Dict{String, String}())
     setproperty!(r, :a, x)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -6,9 +6,9 @@
     @test GAP.gap_to_julia(Any, "foo") == "foo"
   end
 
-  @testset "Conversion to GAP.Obj and GAP.GapObj" begin
+  @testset "Conversion to GAP.Obj and GapObj" begin
     x = GAP.evalstr("2^100")
-    @test GAP.gap_to_julia(GAP.GapObj, x) == x
+    @test GAP.gap_to_julia(GapObj, x) == x
     @test GAP.gap_to_julia(GAP.Obj, true) == true
     x = GAP.evalstr("Z(3)")
     @test GAP.gap_to_julia(GAP.Obj, x) == x
@@ -93,9 +93,9 @@
     @test (@inferred GAP.gap_to_julia(String, x)) == "foo"
     @test GAP.gap_to_julia(x) == "foo"
     x = "abc\000def"
-    @test GAP.gap_to_julia(GAP.julia_to_gap(x)) == x
+    @test GAP.gap_to_julia(GapObj(x)) == x
     x = "jμΛIα"
-    @test GAP.gap_to_julia(GAP.julia_to_gap(x)) == x
+    @test GAP.gap_to_julia(GapObj(x)) == x
   end
 
   @testset "Symbols" begin
@@ -121,24 +121,24 @@
   end
 
   @testset "Vectors" begin
-    x = GAP.julia_to_gap([1, 2, 3])
+    x = GapObj([1, 2, 3])
     @test (@inferred GAP.gap_to_julia(Vector{Any}, x)) == Vector{Any}([1, 2, 3])
     @test GAP.gap_to_julia(x) == Vector{Any}([1, 2, 3])
     @test (@inferred GAP.gap_to_julia(Vector{Int64}, x)) == [1, 2, 3]
     @test (@inferred GAP.gap_to_julia(Vector{BigInt}, x)) == [1, 2, 3]
-    n = GAP.julia_to_gap(big(2)^100)
+    n = GapObj(big(2)^100)
     @test_throws GAP.ConversionError GAP.gap_to_julia(Vector{Int64}, n)
     @test_throws GAP.ConversionError GAP.gap_to_julia(Vector{BigInt}, n)
     x = GAP.evalstr("[ [ 1, 2 ], [ 3, 4 ] ]")
-    nonrec1 = @inferred GAP.gap_to_julia(Vector{GAP.GapObj}, x)
+    nonrec1 = @inferred GAP.gap_to_julia(Vector{GapObj}, x)
     nonrec2 = @inferred GAP.gap_to_julia(Vector{Any}, x; recursive = false)
     rec = GAP.gap_to_julia(Vector{Any}, x; recursive = true)
-    @test all(x -> isa(x, GAP.GapObj), nonrec1)
+    @test all(x -> isa(x, GapObj), nonrec1)
     @test nonrec1 == nonrec2
     @test nonrec1 != rec
     @test all(x -> isa(x, Array), rec)
     x = [1, 2]
-    y = GAP.julia_to_gap([x, x]; recursive = true)
+    y = GapObj([x, x]; recursive = true)
     z = GAP.gap_to_julia(Vector{Any}, y)
     @test z[1] === z[2]
     x = GAP.evalstr( "NewVector( IsPlistVectorRep, Integers, [ 0, 2, 5 ] )" )
@@ -150,9 +150,9 @@
     n = GAP.evalstr("[[1,2],[3,4]]")
     @test (@inferred GAP.gap_to_julia(Matrix{Int64}, n)) == [1 2; 3 4]
     xt = [(1,) (2,); (3,) (4,)]
-    n = GAP.julia_to_gap(xt; recursive = false)
+    n = GapObj(xt; recursive = false)
     @test (@inferred GAP.gap_to_julia(Matrix{Tuple{Int64}}, n)) == xt
-    n = GAP.julia_to_gap(big(2)^100)
+    n = GapObj(big(2)^100)
     @test_throws GAP.ConversionError GAP.gap_to_julia(Matrix{Int64}, n)
     #n = GAP.evalstr("[[1,2],[,4]]")
     #@test GAP.gap_to_julia(Matrix{Union{Int64,Nothing}}, n) == [1 2; nothing 4]
@@ -160,12 +160,12 @@
     m = Any[1 2; 3 4]
     m[1, 1] = x
     m[2, 2] = x
-    x = GAP.julia_to_gap(m; recursive = true)
+    x = GapObj(m; recursive = true)
     y = GAP.gap_to_julia(Matrix{Any}, x)
-    @test !isa(y[1, 1], GAP.GapObj)
+    @test !isa(y[1, 1], GapObj)
     @test y[1, 1] === y[2, 2]
     z = GAP.gap_to_julia(Matrix{Any}, x; recursive = false)
-    @test isa(z[1, 1], GAP.GapObj)
+    @test isa(z[1, 1], GapObj)
     @test z[1, 1] === z[2, 2]
     m = GAP.evalstr( "NewMatrix( IsPlistMatrixRep, Integers, 2, [ 0, 1, 2, 3 ] )" )
     @test GAP.gap_to_julia(m) == Matrix{Any}([0 1; 2 3])
@@ -176,7 +176,7 @@
     x = GAP.evalstr("[ [ 1 ], [ 2 ], [ 1 ] ]")
     y = [GAP.evalstr("[ 1 ]"), GAP.evalstr("[ 2 ]")]
     @test (@inferred GAP.gap_to_julia(Set{Vector{Int}}, x)) == Set([[1], [2], [1]])
-    #@test @inferred GAP.gap_to_julia(Set{GAP.GapObj}, x, recursive = false) == Set(y)
+    #@test @inferred GAP.gap_to_julia(Set{GapObj}, x, recursive = false) == Set(y)
     #@test @inferred GAP.gap_to_julia(Set{Any}, x, recursive = false) == Set(y)
     @test (@inferred GAP.gap_to_julia(Set{Any}, x)) == Set([[1], [2], [1]])
     x = GAP.evalstr("[ Z(2), Z(3) ]")  # a non-collection
@@ -185,11 +185,11 @@
   end
 
   @testset "Tuples" begin
-    x = GAP.julia_to_gap([1, 2, 3])
+    x = GapObj([1, 2, 3])
     @test (@inferred GAP.gap_to_julia(Tuple{Int64,Int16,Int32}, x)) == (1, 2, 3)
     @test_throws ArgumentError GAP.gap_to_julia(Tuple{Any,Any}, x)
     @test_throws ArgumentError GAP.gap_to_julia(Tuple{Any,Any,Any,Any}, x)
-    n = GAP.julia_to_gap(big(2)^100)
+    n = GapObj(big(2)^100)
     @test_throws GAP.ConversionError GAP.gap_to_julia(Tuple{Int64,Any,Int32}, n)
     x = GAP.evalstr("[ [ 1, 2 ], [ 3, [ 4, 5 ] ] ]")
     y = GAP.gap_to_julia(Tuple{GAP.Obj,Any}, x)
@@ -230,7 +230,7 @@
     y = Dict{Symbol,Any}(:foo => 1, :bar => "foo")
     @test (@inferred GAP.gap_to_julia(Dict{Symbol,Any}, x)) == y
     @test GAP.gap_to_julia(x) == y
-    n = GAP.julia_to_gap(big(2)^100)
+    n = GapObj(big(2)^100)
     @test_throws GAP.ConversionError GAP.gap_to_julia(Dict{Symbol,Any}, n)
     x = GAP.evalstr("rec( a:= [ 1, 2 ], b:= [ 3, [ 4, 5 ] ] )")
     y = GAP.gap_to_julia(Dict{Symbol,Any}, x)
@@ -265,7 +265,7 @@
   end
 
   @testset "Catch conversions to types that are not supported" begin
-    xx = GAP.julia_to_gap("a")
+    xx = GapObj("a")
     @test_throws ErrorException GAP.gap_to_julia(Dict{Int64,Int64}, xx)
   end
 
@@ -281,7 +281,7 @@
   end
 
   @testset "GAP lists with Julia objects" begin
-    xx = GAP.julia_to_gap([(1,)])
+    xx = GapObj([(1,)])
     yy = GAP.gap_to_julia(Vector{Tuple{Int64}}, xx)
     @test [(1,)] == yy
     @test typeof(yy) == Vector{Tuple{Int64}}
@@ -292,131 +292,131 @@ end
   end
 
   @testset "Defaults" begin
-    @test GAP.julia_to_gap(true)
+    @test GapObj(true)
   end
 
   @testset "Integers" begin
     for i in -2:2
-        @test GAP.julia_to_gap(Int128(i)) == i
-        @test GAP.julia_to_gap(Int64(i)) == i
-        @test GAP.julia_to_gap(Int32(i)) == i
-        @test GAP.julia_to_gap(Int16(i)) == i
-        @test GAP.julia_to_gap(Int8(i)) == i
+        @test GapObj(Int128(i)) == i
+        @test GapObj(Int64(i)) == i
+        @test GapObj(Int32(i)) == i
+        @test GapObj(Int16(i)) == i
+        @test GapObj(Int8(i)) == i
     end
   end
 
   @testset "Int64 corner cases" begin
-    @test GAP.julia_to_gap(-2^60) === -2^60
-    @test GAP.julia_to_gap(2^60 - 1) === 2^60 - 1
+    @test GapObj(-2^60) === -2^60
+    @test GapObj(2^60 - 1) === 2^60 - 1
 
-    @test GAP.Globals.IsInt(GAP.julia_to_gap(-2^60 - 1))
-    @test GAP.Globals.IsInt(GAP.julia_to_gap(2^60))
+    @test GAP.Globals.IsInt(GapObj(-2^60 - 1))
+    @test GAP.Globals.IsInt(GapObj(2^60))
 
-    @test GAP.Globals.IsInt(GAP.julia_to_gap(-2^63 - 1))
-    @test GAP.Globals.IsInt(GAP.julia_to_gap(-2^63))
-    @test GAP.Globals.IsInt(GAP.julia_to_gap(2^63 - 1))
-    @test GAP.Globals.IsInt(GAP.julia_to_gap(2^63))
+    @test GAP.Globals.IsInt(GapObj(-2^63 - 1))
+    @test GAP.Globals.IsInt(GapObj(-2^63))
+    @test GAP.Globals.IsInt(GapObj(2^63 - 1))
+    @test GAP.Globals.IsInt(GapObj(2^63))
 
     # see issue https://github.com/oscar-system/GAP.jl/issues/332
     @test 2^60 * GAP.Globals.Factorial(20) == GAP.evalstr("2^60 * Factorial(20)")
   end
 
   @testset "Unsigned integers" begin
-    @test GAP.julia_to_gap(UInt128(1)) == 1
-    @test GAP.julia_to_gap(UInt64(1)) == 1
-    @test GAP.julia_to_gap(UInt32(1)) == 1
-    @test GAP.julia_to_gap(UInt16(1)) == 1
-    @test GAP.julia_to_gap(UInt8(1)) == 1
+    @test GapObj(UInt128(1)) == 1
+    @test GapObj(UInt64(1)) == 1
+    @test GapObj(UInt32(1)) == 1
+    @test GapObj(UInt16(1)) == 1
+    @test GapObj(UInt8(1)) == 1
   end
 
   @testset "BigInts" begin
     for i = -2:2
-        @test GAP.julia_to_gap(BigInt(i)) == i
+        @test GapObj(BigInt(i)) == i
     end
     x = GAP.evalstr("2^100")
-    @test GAP.julia_to_gap(BigInt(2)^100) == x
-    @test GAP.julia_to_gap(-BigInt(2)^100) == -x
+    @test GapObj(BigInt(2)^100) == x
+    @test GapObj(-BigInt(2)^100) == -x
   end
 
   @testset "Rationals" begin
     x = GAP.evalstr("2^100")
-    @test GAP.julia_to_gap(Rational{BigInt}(2)^100 // 1) == x
+    @test GapObj(Rational{BigInt}(2)^100 // 1) == x
     x = GAP.evalstr("2^100/3")
-    @test GAP.julia_to_gap(Rational{BigInt}(2)^100 // 3) == x
-    @test GAP.julia_to_gap(1 // 0) == GAP.Globals.infinity
-    @test GAP.julia_to_gap(-1 // 0) == -GAP.Globals.infinity
+    @test GapObj(Rational{BigInt}(2)^100 // 3) == x
+    @test GapObj(1 // 0) == GAP.Globals.infinity
+    @test GapObj(-1 // 0) == -GAP.Globals.infinity
   end
 
   @testset "Floats" begin
     x = GAP.evalstr("2.")
-    @test GAP.julia_to_gap(2.0) == x
-    @test GAP.julia_to_gap(Float32(2.0)) == x
-    @test GAP.julia_to_gap(Float16(2.0)) == x
+    @test GapObj(2.0) == x
+    @test GapObj(Float32(2.0)) == x
+    @test GapObj(Float16(2.0)) == x
   end
 
   @testset "Chars" begin
     x = GAP.evalstr("'x'")
-    @test GAP.julia_to_gap('x') == x
+    @test GapObj('x') == x
   end
 
   @testset "Strings & Symbols" begin
     x = GAP.evalstr("\"foo\"")
-    @test GAP.julia_to_gap("foo") == x
-    @test GAP.julia_to_gap(:foo) == x
+    @test GapObj("foo") == x
+    @test GapObj(:foo) == x
     substr = match(r"a(.*)c", "abc").match  # type is `SubString{String}`
-    @test GAP.julia_to_gap(substr) == GAP.julia_to_gap("abc")
-    @test length(GAP.julia_to_gap("abc\000def")) == 7  # contains a null character
+    @test GapObj(substr) == GapObj("abc")
+    @test length(GapObj("abc\000def")) == 7  # contains a null character
     x = GAP.evalstr("\"jμΛIα\"")
     @test length(x) == 8  # in GAP, the number of bytes
-    @test GAP.julia_to_gap("jμΛIα") == x
+    @test GapObj("jμΛIα") == x
     @test length("jμΛIα") == 5
     @test sizeof("jμΛIα") == 8
   end
 
   @testset "Arrays" begin
     x = GAP.evalstr("[1,\"foo\",2]")
-    @test GAP.julia_to_gap([1, "foo", BigInt(2)]; recursive = true) == x
+    @test GapObj([1, "foo", BigInt(2)]; recursive = true) == x
     x = GAP.evalstr("[1,JuliaEvalString(\"\\\"foo\\\"\"),2]")
-    @test GAP.julia_to_gap([1, "foo", BigInt(2)]) == x
+    @test GapObj([1, "foo", BigInt(2)]) == x
     x = GAP.evalstr("[[1,2],[3,4]]")
-    @test GAP.julia_to_gap([1 2; 3 4]) == x
+    @test GapObj([1 2; 3 4]) == x
   end
 
   @testset "BitVectors" begin
     x = GAP.evalstr("BlistList([1,2],[1])")
-    y = GAP.julia_to_gap([true, false])
+    y = GapObj([true, false])
     @test y == x
     @test GAP.gap_to_julia(GAP.Globals.TNAM_OBJ(y)) == "list (boolean)"
 
     v = BitVector([true, false])
-    gap_v = GAP.julia_to_gap(v)
+    gap_v = GapObj(v)
     @test gap_v == x
     @test GAP.gap_to_julia(GAP.Globals.TNAM_OBJ(gap_v)) == "list (boolean)"
   end
 
   @testset "Tuples" begin
     x = GAP.evalstr("[1,\"foo\",2]")
-    @test GAP.julia_to_gap((1, "foo", 2); recursive = true) == x
+    @test GapObj((1, "foo", 2); recursive = true) == x
     x = GAP.evalstr("[1,JuliaEvalString(\"\\\"foo\\\"\"),2]")
-    @test GAP.julia_to_gap((1, "foo", 2)) == x
+    @test GapObj((1, "foo", 2)) == x
   end
 
   @testset "Ranges" begin
     r = GAP.evalstr("[]")
-    @test GAP.julia_to_gap(1:0) == r
-    @test GAP.julia_to_gap(1:1:0) == r
+    @test GapObj(1:0) == r
+    @test GapObj(1:1:0) == r
     r = GAP.evalstr("[ 1 ]")
-    @test GAP.julia_to_gap(1:1) == r
-    @test GAP.julia_to_gap(1:1:1) == r
+    @test GapObj(1:1) == r
+    @test GapObj(1:1:1) == r
     r = GAP.evalstr("[ 4 .. 13 ]")
-    @test GAP.julia_to_gap(4:13) == r
-    @test GAP.julia_to_gap(4:1:13) == r
+    @test GapObj(4:13) == r
+    @test GapObj(4:1:13) == r
     r = GAP.evalstr("[ 1, 4 .. 10 ]")
-    @test GAP.julia_to_gap(1:3:10) == r
-    @test_throws GAP.ConversionError GAP.julia_to_gap(1:2^62)
+    @test GapObj(1:3:10) == r
+    @test_throws GAP.ConversionError GapObj(1:2^62)
 
-    r = GAP.julia_to_gap(1:2:11, IdDict(), recursive = false)
-    @test r == GAP.julia_to_gap(1:2:11)
+    r = GapObj(1:2:11, IdDict(), recursive = false)
+    @test r == GapObj(1:2:11)
     @test GAP.gap_to_julia(GAP.Globals.TNAM_OBJ(r)) == "list (range,ssort)"
     r = GAP.Obj(1:10)
     @test GAP.gap_to_julia(GAP.Globals.TNAM_OBJ(r)) == "list (range,ssort)"
@@ -427,25 +427,25 @@ end
     y = Dict{Symbol,Any}(:foo => 1, :bar => "foo")
     z = GAP.evalstr("rec( foo := 1, bar := JuliaEvalString(\"\\\"foo\\\"\") )")
     # ... recursive conversion
-    @test GAP.julia_to_gap(y; recursive = true) == x
+    @test GapObj(y; recursive = true) == x
     # ... non-recursive conversion
-    @test GAP.julia_to_gap(y) == z
+    @test GapObj(y) == z
 
     # also test the case were the top level is a GapObj but inside
     # there are Julia objects
-    @test GAP.julia_to_gap(z; recursive=true) == x
-    @test GAP.julia_to_gap(z; recursive=false) == z  # nothing happens without recursion
+    @test GapObj(z; recursive=true) == x
+    @test GapObj(z; recursive=false) == z  # nothing happens without recursion
   end
 
   @testset "Conversions with identical sub-objects" begin
     l = [1]
     yy = [l, l]
     # ... recursive conversion
-    conv = GAP.julia_to_gap(yy; recursive = true)
-    @test conv[1] isa GAP.GapObj
+    conv = GapObj(yy; recursive = true)
+    @test conv[1] isa GapObj
     @test conv[1] === conv[2]
     # ... non-recursive conversion
-    conv = GAP.julia_to_gap(yy; recursive = false)
+    conv = GapObj(yy; recursive = false)
     @test isa(conv[1], Vector{Int64})
     @test conv[1] === conv[2]
 
@@ -455,9 +455,9 @@ end
     l[1] = x
     l[2] = x
     @test l[1] === l[2]
-    res = GAP.julia_to_gap(l)
+    res = GapObj(l)
     @test res[1] === res[2]
-    res = GAP.julia_to_gap(l, recursive=true)
+    res = GapObj(l, recursive=true)
     @test res[1] === res[2]
 
     # a GAP record with identical Julia subobjects
@@ -465,9 +465,9 @@ end
     setproperty!(r, :a, x)
     setproperty!(r, :b, x)
     @test r.a === r.b
-    res = GAP.julia_to_gap(r)
+    res = GapObj(r)
     @test res.a === res.b
-    res = GAP.julia_to_gap(r, recursive=true)
+    res = GapObj(r, recursive=true)
     @test res.a === res.b
   end
 
@@ -476,11 +476,11 @@ end
     yy[1] = yy
     yy[2] = yy
     # ... recursive conversion
-    conv = GAP.julia_to_gap(yy; recursive = true)
+    conv = GapObj(yy; recursive = true)
     @test conv[1] === conv
     @test conv[1] === conv[2]
     # ... non-recursive conversion
-    conv = GAP.julia_to_gap(yy; recursive = false)
+    conv = GapObj(yy; recursive = false)
     @test conv[1] !== conv
     @test conv[1] === conv[2]
   end
@@ -488,29 +488,29 @@ end
   @testset "converting a dictionary with circular refs" begin
     d = Dict{String,Any}("a" => 1)
     d["b"] = d
-    conv = GAP.julia_to_gap(d; recursive = true)
+    conv = GapObj(d; recursive = true)
     @test conv === conv.b
   end
 
   @testset "Test converting lists with 'nothing' in them -> should be converted to a hole in the list" begin
     xx = GAP.evalstr("[1,,1]")
-    @test GAP.julia_to_gap([1, nothing, 1]) == xx
+    @test GapObj([1, nothing, 1]) == xx
   end
 
   @testset "Convert GAP objects recursively" begin
-    val = GAP.julia_to_gap([])
+    val = GapObj([])
     val[1] = [1, 2]
     val[2] = [3, 4]
-    nonrec = GAP.julia_to_gap(val)
+    nonrec = GapObj(val)
     @test nonrec[1] == [1, 2]
-    rec = GAP.julia_to_gap(val, recursive = true)
-    @test rec[1] == GAP.julia_to_gap([1, 2])
-    @test GAP.julia_to_gap(1, recursive = false) == 1
+    rec = GapObj(val, recursive = true)
+    @test rec[1] == GapObj([1, 2])
+    @test GapObj(1, recursive = false) == 1
   end
 
   @testset "Test function conversion" begin
     return_first(args...) = args[1]
-    return_first_gap = GAP.julia_to_gap(return_first)
+    return_first_gap = GapObj(return_first)
     @test GAP.Globals.IsFunction(return_first) == false
     @test GAP.Globals.IsFunction(return_first_gap) == true
     list = GAP.evalstr("[1,2,3]")

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -416,6 +416,7 @@ end
     @test_throws GAP.ConversionError GAP.julia_to_gap(1:2^62)
 
     r = GAP.julia_to_gap(1:2:11, IdDict(), recursive = false)
+    @test r == GAP.julia_to_gap(1:2:11)
     @test GAP.gap_to_julia(GAP.Globals.TNAM_OBJ(r)) == "list (range,ssort)"
     r = GAP.Obj(1:10)
     @test GAP.gap_to_julia(GAP.Globals.TNAM_OBJ(r)) == "list (range,ssort)"
@@ -447,6 +448,27 @@ end
     conv = GAP.julia_to_gap(yy; recursive = false)
     @test isa(conv[1], Vector{Int64})
     @test conv[1] === conv[2]
+
+    # a GAP list with identical Julia subobjects
+    l = GapObj([])
+    x = BigInt(2)^100
+    l[1] = x
+    l[2] = x
+    @test l[1] === l[2]
+    res = GAP.julia_to_gap(l)
+    @test res[1] === res[2]
+    res = GAP.julia_to_gap(l, recursive=true)
+    @test res[1] === res[2]
+
+    # a GAP record with identical Julia subobjects
+    r = GapObj(Dict{String, String}())
+    setproperty!(r, :a, x)
+    setproperty!(r, :b, x)
+    @test r.a === r.b
+    res = GAP.julia_to_gap(r)
+    @test res.a === res.b
+    res = GAP.julia_to_gap(r, recursive=true)
+    @test res.a === res.b
   end
 
   @testset "converting a list with circular refs" begin

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -33,7 +33,7 @@
     @test ! has_cendersub(G)
     @test has_dersub(G)  # the previous call has set the value
     ggens = GAP.Globals.GeneratorsOfGroup(G)
-    set_cendersub(G, GAP.Globals.Subgroup(G, GAP.GapObj([ggens[1]])))
+    set_cendersub(G, GAP.Globals.Subgroup(G, GapObj([ggens[1]])))
     @test has_cendersub(G)
     @test GAP.Globals.HasCentre(GAP.Globals.DerivedSubgroup(G))
     @test GAP.Globals.Size(GAP.Globals.Centre(G)) == 1
@@ -53,9 +53,9 @@ end
     @test_throws ErrorException @gap (1,2)(3,4)
 
     x = GAP.g"foo"
-    @test x == GAP.julia_to_gap("foo")
+    @test x == GapObj("foo")
     x = GAP.g"1:\n, 2:\", 3:\\, 4:\b, 5:\r, 6:\c, 7:\001"
-    @test x == GAP.julia_to_gap("1:\n, 2:\", 3:\\, 4:\b, 5:\r, 6:\003, 7:\001")
+    @test x == GapObj("1:\n, 2:\", 3:\\, 4:\b, 5:\r, 6:\003, 7:\001")
     @test_throws ErrorException g"\\"
 
 end
@@ -68,7 +68,7 @@ end
     @test GapObj(TestType1(a)) === a
 
     struct TestType2 X::GapObj end
-    GAP.@install function GAP.GapObj(x::TestType2) return x.X; end
+    GAP.@install function GapObj(x::TestType2) return x.X; end
     @test GapObj(TestType2(a)) === a
 
     @test_throws ErrorException @macroexpand GAP.@install Obj(x::Bool)

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -71,7 +71,7 @@ end
     GAP.@install function GAP.GapObj(x::TestType2) return x.X; end
     @test GapObj(TestType2(a)) === a
 
-    @test_throws ErrorException GAP.install_macro_helper(:(GAP.@install true))
-    @test_throws ErrorException GAP.install_macro_helper(:(GAP.@install Obj(x::Bool) = x))
-    @test_throws ErrorException GAP.install_macro_helper(:(GAP.@install GapObj(x::Bool, y::Bool) = x))
+    @test_throws ErrorException @macroexpand GAP.@install Obj(x::Bool)
+    @test_throws ErrorException @macroexpand GAP.@install Obj(x::Bool) = x
+    @test_throws ErrorException @macroexpand GAP.@install GapObj(x::Bool, y::Bool) = x
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -68,6 +68,10 @@ end
     @test GapObj(TestType1(a)) === a
 
     struct TestType2 X::GapObj end
-    GAP.@install function GapObj(x::TestType2) return x.X; end
+    GAP.@install function GAP.GapObj(x::TestType2) return x.X; end
     @test GapObj(TestType2(a)) === a
+
+    @test_throws ErrorException GAP.install_macro_helper(:(GAP.@install true))
+    @test_throws ErrorException GAP.install_macro_helper(:(GAP.@install Obj(x::Bool) = x))
+    @test_throws ErrorException GAP.install_macro_helper(:(GAP.@install GapObj(x::Bool, y::Bool) = x))
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -71,7 +71,10 @@ end
     GAP.@install function GapObj(x::TestType2) return x.X; end
     @test GapObj(TestType2(a)) === a
 
+  if VERSION >= v"1.7"
+    # needs the improved `@macroexpand` from Julia 1.7
     @test_throws ErrorException @macroexpand GAP.@install Obj(x::Bool)
     @test_throws ErrorException @macroexpand GAP.@install Obj(x::Bool) = x
     @test_throws ErrorException @macroexpand GAP.@install GapObj(x::Bool, y::Bool) = x
+  end
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -59,3 +59,15 @@ end
     @test_throws ErrorException g"\\"
 
 end
+
+@testset "@install GapObj" begin
+    a = GAP.evalstr("(1,2)")
+
+    struct TestType1 X::GapObj end
+    GAP.@install GapObj(x::TestType1) = x.X
+    @test GapObj(TestType1(a)) === a
+
+    struct TestType2 X::GapObj end
+    GAP.@install function GapObj(x::TestType2) return x.X; end
+    @test GapObj(TestType2(a)) === a
+end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -60,14 +60,15 @@ end
 
 end
 
+struct TestType1 X::GapObj end
+struct TestType2 X::GapObj end
+
 @testset "@install GapObj" begin
     a = GAP.evalstr("(1,2)")
 
-    struct TestType1 X::GapObj end
     GAP.@install GapObj(x::TestType1) = x.X
     @test GapObj(TestType1(a)) === a
 
-    struct TestType2 X::GapObj end
     GAP.@install function GapObj(x::TestType2) return x.X; end
     @test GapObj(TestType2(a)) === a
 

--- a/test/packages.jl
+++ b/test/packages.jl
@@ -24,7 +24,7 @@
 #TODO: How to guarantee two installed versions with different paths?
 
     # - a package that was not yet loaded (only once in a Julia session)
-    if ! GAP.Globals.IsPackageLoaded(GAP.GapObj("autodoc"))
+    if ! GAP.Globals.IsPackageLoaded(GapObj("autodoc"))
       path = string(GAP.Globals.GAPInfo.PackagesInfo.autodoc[1].InstallationPath)
       @test GAP.Packages.load(path)
     end


### PR DESCRIPTION
This is a first attempt to issue #1025.
The ideas are the same as in pull request #777, which deals with "the other direction", that is, the conversion from GAP to Julia:

- Make the recursive conversion safe. Up to now, we have ad-hoc delegation from `julia_to_gap` methods with three arguments back to a `julia_to_gap` with only one argument.
- Make the conversion more efficient. Up to now, a dictionary for tracking subobjects is created by default in the methods in question, also in situations where this dictionary is not used later on.
- Make the installation of new conversion methods simpler. Up to now it happens (for example in Oscar.jl) that the installation of a `GapObj` method for some Oscar objects does not work as expected for vectors of these objects, or that changes in GAP.jl break the intended behaviour of `GapObj` methods in Oscar.jl (see #1025).

The conversion from Julia to GAP is simpler than that from GAP to Julia for example because we need not care about caching different Julia target types for the same GAP object. On the other hand, the direction from Julia to GAP shall cover also the constructor `GapObj` in situations where one wants to fetch an existing GAP object stored in a Julia object.

The current changes mean that all Julia to GAP conversions have to be installed via `GapObj_internal` methods that have three arguments.
Then `GapObj` needs only default methods that delegate to `GapObj_internal`.

If we proceed like this then these changes are breaking.
For Oscar.jl, they mean that the `julia_to_gap` and `GapObj` methods installed there have to be rewritten.
(Currently the master branch of Oscar.jl has 23 `julia_to_gap` methods, half of them in `src/GAP/oscar_to_gap`.)

Here are the technical details.

- introduce `GapObj_internal`, which takes always three arguments: the Julia object to be converted, the auxiliary cache object, and a Boolean indicating whether recursive conversion is wanted

- turn all `julia_to_gap` methods into `GapObj_internal` methods

- define default `GapObj` methods (with 1 to 3 arguments) that call `GapObj_internal`

- admit `nothing` as an allowed value for the auxiliary cache object, and create dictionary objects only inside the methods in question where they are needed; introduce the type `GapCacheDict` for that

- provide a macro for the installation of unary `GapObj` methods (i.e., methods that do not require the recursive tracking of subobjects w.r.t. object identity) via the syntax `GAP.@install GapObj(x::T) = f(x)`