### PR TITLE
Try to make `etc/ci_test.sh` work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ Manifest.toml
 /tags
 *.log
 /coverage/
+*.gcov
 /override/

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -10,7 +10,7 @@ mkdir -p coverage
 cd pkg/JuliaInterface
 pwd
 # Force recompilation of JuliaInterface with coverage instrumentation
-FORCE_JULIAINTERFACE_COMPILATION=true JULIAINTERFACE_WITH_COVERAGE=true ${GAP} --nointeract
+CFLAGS="--coverage" LDFLAGS="--coverage" FORCE_JULIAINTERFACE_COMPILATION=true ${GAP} --nointeract
 ${GAP} makedoc.g
 ${GAP} --cover ../../coverage/JuliaInterface.coverage tst/testall.g || AnyFailures=Yes
 gcov -o gen/src/ src/*.c*

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -9,7 +9,8 @@ mkdir -p coverage
 #
 cd pkg/JuliaInterface
 pwd
-FORCE_JULIAINTERFACE_COMPILATION=true ${GAP} --nointeract # re-compile JuliaInterface
+# Force recompilation of JuliaInterface with coverage instrumentation
+CFLAGS=--coverage FORCE_JULIAINTERFACE_COMPILATION=true ${GAP} --nointeract
 ${GAP} makedoc.g
 ${GAP} --cover ../../coverage/JuliaInterface.coverage tst/testall.g || AnyFailures=Yes
 gcov -o gen/src/ src/*.c*
@@ -20,7 +21,6 @@ cd pkg/JuliaExperimental
 pwd
 ${GAP} makedoc.g
 ${GAP} --cover ../../coverage/JuliaExperimental.coverage tst/testall.g || AnyFailures=Yes
-#gcov -o gen/src/ src/*.c* # there is no src/ folder anymore
 cd ../..
 
 if [ ${AnyFailures} = Yes ]

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -14,8 +14,8 @@ CFLAGS="--coverage" LDFLAGS="--coverage" FORCE_JULIAINTERFACE_COMPILATION=true $
 ${GAP} makedoc.g
 ${GAP} --cover ../../coverage/JuliaInterface.coverage tst/testall.g || AnyFailures=Yes
 gcov -o gen/src/ src/*.c*
-# Force recompilation of JuliaInterface without coverage instrumentation
-FORCE_JULIAINTERFACE_COMPILATION=true ${GAP} --nointeract
+# Remove JuliaInterface with coverage instrumentation
+make clean
 cd ../..
 
 #

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -9,9 +9,10 @@ mkdir -p coverage
 #
 cd pkg/JuliaInterface
 pwd
+FORCE_JULIAINTERFACE_COMPILATION=true ${GAP} --nointeract # re-compile JuliaInterface
 ${GAP} makedoc.g
 ${GAP} --cover ../../coverage/JuliaInterface.coverage tst/testall.g || AnyFailures=Yes
-gcov -o gen/src/.libs src/*.c*
+gcov -o gen/src/ src/*.c*
 cd ../..
 
 #
@@ -19,7 +20,7 @@ cd pkg/JuliaExperimental
 pwd
 ${GAP} makedoc.g
 ${GAP} --cover ../../coverage/JuliaExperimental.coverage tst/testall.g || AnyFailures=Yes
-gcov -o gen/src/.libs src/*.c*
+#gcov -o gen/src/ src/*.c* # there is no src/ folder anymore
 cd ../..
 
 if [ ${AnyFailures} = Yes ]

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -10,10 +10,12 @@ mkdir -p coverage
 cd pkg/JuliaInterface
 pwd
 # Force recompilation of JuliaInterface with coverage instrumentation
-CFLAGS=--coverage FORCE_JULIAINTERFACE_COMPILATION=true ${GAP} --nointeract
+FORCE_JULIAINTERFACE_COMPILATION=true JULIAINTERFACE_WITH_COVERAGE=true ${GAP} --nointeract
 ${GAP} makedoc.g
 ${GAP} --cover ../../coverage/JuliaInterface.coverage tst/testall.g || AnyFailures=Yes
 gcov -o gen/src/ src/*.c*
+# Force recompilation of JuliaInterface without coverage instrumentation
+FORCE_JULIAINTERFACE_COMPILATION=true ${GAP} --nointeract
 cd ../..
 
 #

--- a/pkg/JuliaInterface/Makefile.in
+++ b/pkg/JuliaInterface/Makefile.in
@@ -3,6 +3,7 @@
 #
 KEXT_NAME = JuliaInterface
 KEXT_SOURCES = src/JuliaInterface.c src/calls.c src/convert.c src/sync.c
+KEXT_CFLAGS = -ftest-coverage
 
 # include shared GAP package build system
 GAPPATH = @GAPPATH@

--- a/pkg/JuliaInterface/Makefile.in
+++ b/pkg/JuliaInterface/Makefile.in
@@ -3,7 +3,6 @@
 #
 KEXT_NAME = JuliaInterface
 KEXT_SOURCES = src/JuliaInterface.c src/calls.c src/convert.c src/sync.c
-KEXT_CFLAGS = -ftest-coverage
 
 # include shared GAP package build system
 GAPPATH = @GAPPATH@

--- a/src/julia-config.jl
+++ b/src/julia-config.jl
@@ -37,6 +37,10 @@ function ldflags()
     elseif !Sys.isapple()
         fl = fl * " -Wl,--export-dynamic"
     end
+    env_var = get(ENV, "LDFLAGS", nothing)
+    if !isnothing(env_var)
+        fl = fl * " " * env_var
+    end
     return fl
 end
 
@@ -62,6 +66,10 @@ function cflags()
     print(flags, " -I", include)
     if Sys.isunix()
         print(flags, " -fPIC")
+    end
+    env_var = get(ENV, "CFLAGS", nothing)
+    if !isnothing(env_var)
+        print(flags, " ", env_var)
     end
     return String(take!(flags))
 end

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -215,10 +215,6 @@ function build_JuliaInterface(sysinfo::Dict{String, String})
     JULIA_CFLAGS = filter(c -> c != '\'', cflags())
     JULIA_LDFLAGS = filter(c -> c != '\'', ldflags())
     JULIA_LIBS = filter(c -> c != '\'', ldlibs())
-    if get(ENV, "JULIAINTERFACE_WITH_COVERAGE", "false") == "true"
-        JULIA_CFLAGS *= " --coverage"
-        JULIA_LDFLAGS *= " --coverage"
-    end
 
     jipath = joinpath(@__DIR__, "..", "pkg", "JuliaInterface")
     cd(jipath) do

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -212,13 +212,17 @@ function build_JuliaInterface(sysinfo::Dict{String, String})
     # paths involve spaces, but then we likely will haves problem in other
     # places; in any case, if anybody ever cares about this, we can work on
     # finding a better solution.
-    JULIA_CPPFLAGS = filter(c -> c != '\'', cflags())
+    JULIA_CFLAGS = filter(c -> c != '\'', cflags())
     JULIA_LDFLAGS = filter(c -> c != '\'', ldflags())
     JULIA_LIBS = filter(c -> c != '\'', ldlibs())
+    if get(ENV, "JULIAINTERFACE_WITH_COVERAGE", "false") == "true"
+        JULIA_CFLAGS *= " --coverage"
+        JULIA_LDFLAGS *= " --coverage"
+    end
 
     jipath = joinpath(@__DIR__, "..", "pkg", "JuliaInterface")
     cd(jipath) do
-        withenv("CFLAGS" => JULIA_CPPFLAGS,
+        withenv("CFLAGS" => JULIA_CFLAGS,
                 "LDFLAGS" => JULIA_LDFLAGS * " " * JULIA_LIBS) do
             run(pipeline(`./configure $(gaproot())`, stdout="build.log"))
             run(pipeline(`make V=1 -j$(Sys.CPU_THREADS)`, stdout="build.log", append=true))


### PR DESCRIPTION
`etc/ci_test.sh` gets called as part of the testsuite of GAP.jl.

Already for a long time, `gcov` prints some errors in CI, see e.g. https://github.com/oscar-system/GAP.jl/actions/runs/10700854945/job/29665504736#step:6:468. On newer gcov version (my system uses gcc/gcov 14.2.1, while the ubuntu CI runners use 11.2.0), instead of just printing the error, this returns a non-zero exit code and thus aborts the script.
This PR contains three small changes in the hopes to fix this:
1. The gcov contained a wrong path. This is changed for JuliaInterface. Since JuliaExperimental doesn't have any c files anymore, gcov cannot give any coverage for them. So this line gets disabled.
1. The build flags of JuliaInterface now contain the needed flag to create coverage files during compilation. This would of course be nice to have only in CI cases and not always, but I don't know how to do that.
1. I added a force re-compilation of JuliaInterface before running its tests. On CI, this shouldn't change anything, but locally, I had an issue that changes to the Makefile (see previous point) didn't get picked up automatically. This forces it instead.

Alternatively, we could just remove the two lines regarding `gcov` from `etc/ci_test.sh` completely.

cc @ThomasBreuer 