### PR TITLE
fix access to Julia docstrings from the GAP session

### DIFF
--- a/pkg/JuliaInterface/gap/helpstring.g
+++ b/pkg/JuliaInterface/gap/helpstring.g
@@ -526,7 +526,7 @@ BindGlobal( "HELP_Info", function( str, onlyexact )
   elif Length(str) > 0 and str[1] = '?'  then
       str := str{[2..Length(str)]};    
       NormalizeWhitespace(str);
-      match:= HELP_DESC_MATCHES( books, str, false, onlyexact );
+      match:= HELP_DESC_MATCHES( books, str, false, onlyexact : HELP_TOPIC:= origstr );
       if match[1] = true then
           add( books, str );
       fi;
@@ -538,7 +538,7 @@ fi;
 
   # search for this topic
   else
-    match:= HELP_DESC_MATCHES( books, str, true, onlyexact );
+    match:= HELP_DESC_MATCHES( books, str, true, onlyexact : HELP_TOPIC:= origstr );
     if match[1] = true then
       add( books, str );
 if IsRecord( match[2] ) then

--- a/pkg/JuliaInterface/gap/juliahelp.g
+++ b/pkg/JuliaInterface/gap/juliahelp.g
@@ -133,9 +133,8 @@ HELP_BOOK_HANDLER.juliahelpformat:= rec(
         # Give up.
         return [ [], [] ];
       fi;
-      
-      res:= JuliaToGAP( IsString,
-                Julia.GAP.julia_help_string( module.( func ) ) );
+      func:= Julia.GAP.UnwrapJuliaFunc( module.( func ) );
+      res:= JuliaToGAP( IsString, Julia.GAP.julia_help_string( func ) );
 
       # Store the information such that `HelpData` will find it.
       HELP_BOOKS_INFO.julia.entries:= [ [ orig_topic, res ] ];

--- a/pkg/JuliaInterface/tst/help.tst
+++ b/pkg/JuliaInterface/tst/help.tst
@@ -1,4 +1,4 @@
-#@local HelpTestFunction
+#@local HelpTestFunction, str
 gap> START_TEST( "help.tst" );
 
 #
@@ -49,6 +49,19 @@ true
 gap> HelpTestFunction( "unknow" );
 true
 gap> HelpTestFunction( "something for which no match is found" );
+true
+
+# help for documented Julia functions
+gap> HelpString( "Julia:wrap_rng" ) = "Help: no matching entry found";
+true
+gap> str:= HelpString( "Julia:GAP.wrap_rng" );; # is not exported from GAP
+gap> PositionSublist( str, "wrap_rng" ) <> fail;
+true
+gap> str:= HelpString( "Julia:GapObj" );; # is exported from GAP
+gap> PositionSublist( str, "GapObj" ) <> fail;
+true
+gap> str:= HelpString( "Julia:sqrt" );; # is from Julia.Base
+gap> PositionSublist( str, "sqrt" ) <> fail;
 true
 
 #


### PR DESCRIPTION
- call `Julia.GAP.UnwrapJuliaFunc` on the argument of `Julia.GAP.julia_help_string`
- make `HelpString` work for Julia functions such that the fix can be tested easily
- add tests

(I noticed the problem in the context of renaming `julia_to_gap` for #1029, but the fix is independent from that pull request.)