### PR TITLE
Disable AvailabilityTest checking for skipping install of packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GAP"
 uuid = "c863536a-3901-11e9-33e7-d5cd0df7b904"
 authors = ["Thomas Breuer <sam@math.rwth-aachen.de>", "Sebastian Gutsche <gutsche@mathematik.uni-siegen.de>", "Max Horn <horn@mathematik.uni-kl.de>"]
-version = "0.11.2"
+version = "0.11.3"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -267,18 +267,6 @@ function install(spec::String, version::String = "";
           # then we can still try to install the required version.)
           version == string(getproperty(info, spec)[2]) && return true
         end
-        info = Globals.GAPInfo.PackagesInfo
-        if hasproperty(info, spec)
-          # The package is not yet loaded but may be available.
-          # If an available version has the required version number
-          # then nothing is to do.
-          for inforec in getproperty(info, spec)
-            if version == string(getproperty(inforec, :Version))
-              fun = getproperty(inforec, :AvailabilityTest)
-              fun() == true && return true
-            end
-          end
-        end
         res = Globals.InstallPackage(GapObj(spec), GapObj(version), interactive; debug)
       end
       if quiet || debug

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -275,7 +275,7 @@ function install(spec::String, version::String = "";
           for inforec in getproperty(info, spec)
             if version == string(getproperty(inforec, :Version))
               fun = getproperty(inforec, :AvailabilityTest)
-              fun() && return true
+              fun() == true && return true
             end
           end
         end


### PR DESCRIPTION
In some edge-cases a package is available, but one of its transitive dependencies is not. This piece of code would have skipped any installation in this case.
We (@ThomasBreuer and I) ran into this in https://github.com/oscar-system/Oscar.jl/pull/3688, because `recog` is available, but its transitive dependency `io` needs compilation.