### PR TITLE
 change the show method for GAP objects

### DIFF
--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -22,7 +22,7 @@ end
 
 function Base.show(io::IO, obj::Union{GapObj,FFE})
     stri = show_string(io, obj)
-    print(io, "GAP: $stri")
+    print(AbstractAlgebra.pretty(io), AbstractAlgebra.LowercaseOff(), "GAP: $stri")
 end
 
 function Base.string(obj::Union{GapObj,FFE})

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -153,3 +153,10 @@ end
     @test gs3 == [random(GRS, G) for _=1:30]
 
 end
+
+@testset "printing" begin
+    io = IOBuffer()
+    io = AbstractAlgebra.pretty(io)
+    print(io, AbstractAlgebra.Lowercase(), GapObj([1, 2, 3]))
+    @test String(take!(io)) == "GAP: [ 1, 2, 3 ]"
+end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -156,7 +156,7 @@ end
 
 @testset "printing" begin
     io = IOBuffer()
-    io = AbstractAlgebra.pretty(io)
-    print(io, AbstractAlgebra.Lowercase(), GapObj([1, 2, 3]))
+    io = GAP.AbstractAlgebra.pretty(io)
+    print(io, GAP.AbstractAlgebra.Lowercase(), GapObj([1, 2, 3]))
     @test String(take!(io)) == "GAP: [ 1, 2, 3 ]"
 end


### PR DESCRIPTION
Some systems use AbstractAlgebra's `show` magic.
For example Oscar applies it also to GAP objects,
with the effect that "GAP" gets turned into "gAP" by `Lowercase()` calls.

For example, try in Oscar `g = GL(3,GF(2)); GapObj(g); g.ring_iso`
and get
```
Map defined by a julia-function with inverse
  from prime field of characteristic 2
  to gAP: GF(2)
```

Now GAP.jl knows AbstractAlgebra.jl,
and we can protect the `show` strings of GAP objects
against decapitalization.