### PR TITLE
fix the availability check in `Packages.install`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GAP"
 uuid = "c863536a-3901-11e9-33e7-d5cd0df7b904"
 authors = ["Thomas Breuer <sam@math.rwth-aachen.de>", "Sebastian Gutsche <gutsche@mathematik.uni-siegen.de>", "Max Horn <horn@mathematik.uni-kl.de>"]
-version = "0.11.2"
+version = "0.11.3"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -274,8 +274,8 @@ function install(spec::String, version::String = "";
           # then nothing is to do.
           for inforec in getproperty(info, spec)
             if version == string(getproperty(inforec, :Version))
-              fun = getproperty(inforec, :AvailabilityTest)
-              fun() && return true
+              res = Globals.TestPackageAvailability(GapObj(spec), GapObj(version))
+              res !== Globals.fail && return true
             end
           end
         end

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -272,12 +272,8 @@ function install(spec::String, version::String = "";
           # The package is not yet loaded but may be available.
           # If an available version has the required version number
           # then nothing is to do.
-          for inforec in getproperty(info, spec)
-            if version == string(getproperty(inforec, :Version))
-              res = Globals.TestPackageAvailability(GapObj(spec), GapObj(version))
-              res !== Globals.fail && return true
-            end
-          end
+          res = Globals.TestPackageAvailability(GapObj(spec), GapObj(version))
+          res !== Globals.fail && return true
         end
         res = Globals.InstallPackage(GapObj(spec), GapObj(version), interactive; debug)
       end


### PR DESCRIPTION
This is an alternative to #1037.

Here we try to keep the check whether a not yet loaded GAP package is already installed, i.e., `Packages.load` would return `true`.
The previous code was wrong in the sense that it did not consider the availability of the needed packages. Now we call the right GAP function, which tests also the needed packages.