### PR TITLE
Support keyword arguments in `CallJuliaFunctionWithCatch`, and a few other improvements

### DIFF
--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -237,6 +237,24 @@ DeclareGlobalFunction( "JuliaImportPackage" );
 
 
 #! @Section Access to &Julia; objects
+#!  Not all &Julia; syntax features are supported in &GAP;.
+#!  For important ones, the interface provides &GAP; functions or
+#!  helper functions written in &Julia; to use them in &GAP;.
+#!  For example, <Ref Func="CallJuliaFunctionWithCatch"/> allows one to use
+#!  &Julia;'s try/catch statements.
+#!
+#!  Here is a selection of other workarounds for &Julia; syntax features.
+#!  <List>
+#!  <Item>
+#!    &Julia;'s <C>RefValue</C> objects can be handled as follows.
+#!    If <C>x</C> is such an object then its value can be fetched with
+#!    <C>Julia.GAP.getindex( x )</C>,
+#!    a value <C>v</C> of the right type can be set with
+#!    <C>Julia.GAP.setindex( x, v )</C>,
+#!    and one can check with <C>Julia.GAP.isassigned( x )</C>
+#!    whether <C>x</C> has a value.
+#!  </Item>
+#!  </List>
 
 ## Internal
 BindGlobal( "_JuliaFunctions", rec( ) );
@@ -299,6 +317,19 @@ DeclareGlobalFunction( "JuliaFunction" );
 #! gap> Julia.Main.x;
 #! 1
 #! @EndExampleSession
+#!
+#!  Note that not all &Julia; variables are directly visible in its
+#!  <C>Main</C> module.
+#!  For example, &Julia; variables from the interface to &GAP; are defined
+#!  in the &Julia; module <C>GAP</C> or its submodules.
+#!  It is safe to access this module as <C>Julia.GAP</C>.
+#!
+#! @BeginExampleSession
+#! gap> Julia.GAP;
+#! <Julia module GAP>
+#! gap> Julia.GAP.prompt;
+#! <Julia: prompt>
+#! @EndExampleSession
 DeclareGlobalVariable( "Julia" );
 
 #! @Arguments name
@@ -331,11 +362,13 @@ DeclareGlobalFunction( "JuliaModule" );
 #! @EndExampleSession
 DeclareGlobalFunction( "JuliaTypeInfo" );
 
-#! @Arguments juliafunc, arguments
+#! @Arguments juliafunc, arguments[, arec]
 #! @Returns a record.
 #! @Description
 #!  The function calls the &Julia; function <A>juliafunc</A>
-#!  with arguments in the &GAP; list <A>arguments</A>,
+#!  with ordinary arguments in the &GAP; list <A>arguments</A>
+#!  and optionally with keyword arguments given by the component names (keys)
+#!  and values of the &GAP; record <A>arec</A>,
 #!  and returns a record with the components <C>ok</C> and <C>value</C>.
 #!  If no error occurred then <C>ok</C> has the value <K>true</K>,
 #!  and <C>value</C> is the value returned by <A>juliafunc</A>.
@@ -358,6 +391,15 @@ DeclareGlobalFunction( "JuliaTypeInfo" );
 #! false
 #! gap> res.value{ [ 1 .. Position( res.value, '(' )-1 ] };
 #! "LinearAlgebra.SingularException"
+#! gap> fun:= Julia.range;;
+#! gap> CallJuliaFunctionWithCatch( fun, [ 2, 10 ], rec( step:= 2 ) );
+#! rec( ok := true, value := <Julia: 2:2:10> )
+#! gap> res:= CallJuliaFunctionWithCatch( fun, [ 2, 10 ],
+#! >              rec( step:= GAPToJulia( "a" ) ) );;
+#! gap> res.ok;
+#! false
+#! gap> res.value{ [ 1 .. Position( res.value, '(' )-1 ] };
+#! "MethodError"
 #! @EndExampleSession
 DeclareGlobalFunction( "CallJuliaFunctionWithCatch" );
 
@@ -461,8 +503,8 @@ DeclareGlobalFunction( "CallJuliaFunctionWithKeywordArguments" );
 #!  <List>
 #!  <Item>
 #!    <Ref Oper="CallFuncList" BookName="ref"/>,
-#!    delegating to <C>Julia.Core._apply</C>
-#!    (this yields the function call syntax in &GAP;,
+#!    delegating to &Julia;'s <C>func(args...)</C> syntax;
+#!    this yields the function call syntax in &GAP;,
 #!    it is installed also for objects in
 #!    <Ref Filt="IsJuliaWrapper" Label="for IsObject"/>,
 #!  </Item>
@@ -470,10 +512,8 @@ DeclareGlobalFunction( "CallJuliaFunctionWithKeywordArguments" );
 #!    access to and assignment of entries of arrays, via
 #!    <Ref Oper="\[\]" BookName="ref"/>,
 #!    <Ref Oper="\[\]\:\=" BookName="ref"/>,
-#!    <!-- <Ref Oper="MatElm" BookName="ref"/>, and
-#!    <Ref Oper="SetMatElm" BookName="ref"/>, -->
-#!    and the (up to &GAP; 4.11 undocumented) operations <C>MatElm</C> and
-#!    <C>SetMatElm</C>,
+#!    <Ref Oper="MatElm" BookName="ref"/>, and
+#!    <Ref Oper="SetMatElm" BookName="ref"/>,
 #!    delegating to
 #!    <C>Julia.Base.getindex</C> and
 #!    <C>Julia.Base.setindex</C>,
@@ -532,7 +572,6 @@ DeclareGlobalFunction( "CallJuliaFunctionWithKeywordArguments" );
 #! gap> m + m;
 #! <Julia: [2 4; 6 8]>
 #! @EndExampleSession
-#TODO: add the cross-references to MatElm, SetMatElm when they are documented
 
 #! @InsertChunk JuliaHelpInGAP
 

--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -362,13 +362,13 @@ DeclareGlobalFunction( "JuliaModule" );
 #! @EndExampleSession
 DeclareGlobalFunction( "JuliaTypeInfo" );
 
-#! @Arguments juliafunc, arguments[, arec]
+#! @Arguments juliafunc, arguments[, kwargs]
 #! @Returns a record.
 #! @Description
 #!  The function calls the &Julia; function <A>juliafunc</A>
 #!  with ordinary arguments in the &GAP; list <A>arguments</A>
 #!  and optionally with keyword arguments given by the component names (keys)
-#!  and values of the &GAP; record <A>arec</A>,
+#!  and values of the &GAP; record <A>kwargs</A>,
 #!  and returns a record with the components <C>ok</C> and <C>value</C>.
 #!  If no error occurred then <C>ok</C> has the value <K>true</K>,
 #!  and <C>value</C> is the value returned by <A>juliafunc</A>.
@@ -403,17 +403,17 @@ DeclareGlobalFunction( "JuliaTypeInfo" );
 #! @EndExampleSession
 DeclareGlobalFunction( "CallJuliaFunctionWithCatch" );
 
-#! @Arguments juliafunc, arguments, arec
+#! @Arguments juliafunc, arguments, kwargs
 #! @Returns the result of the &Julia; function call.
 #! @Description
 #!  The function calls the &Julia; function <A>juliafunc</A>
 #!  with ordinary arguments in the &GAP; list <A>arguments</A>
 #!  and keyword arguments given by the component names (keys) and values
-#!  of the record <A>arec</A>,
+#!  of the record <A>kwargs</A>,
 #!  and returns the function value.
 #!
 #!  Note that the entries of <A>arguments</A> and the components of
-#!  <A>arec</A> are not implicitly converted to &Julia;.
+#!  <A>kwargs</A> are not implicitly converted to &Julia;.
 #! @BeginExampleSession
 #! gap> CallJuliaFunctionWithKeywordArguments( Julia.Base.round,
 #! >        [ GAPToJulia( Float( 1/3 ) ) ], rec( digits:= 5 ) );

--- a/pkg/JuliaInterface/gap/calls.gi
+++ b/pkg/JuliaInterface/gap/calls.gi
@@ -22,20 +22,20 @@ InstallMethod( CallFuncList,
     end );
 
 InstallGlobalFunction( CallJuliaFunctionWithCatch,
-    function( julia_obj, args, arec... )
+    function( julia_obj, args, kwargs... )
     local res;
 
     args := GAPToJulia( _JL_Vector_Any, args, false );
     if IsFunction( julia_obj ) then
       julia_obj:= Julia.GAP.UnwrapJuliaFunc( julia_obj );
     fi;
-    if Length( arec ) = 0 then
+    if Length( kwargs ) = 0 then
       res:= Julia.GAP.call_with_catch( julia_obj, args );
-    elif Length( arec ) = 1 and IsRecord( arec[1] ) then
-      arec := GAPToJulia( _JL_Dict_Any, arec[1], false );
-      res:= Julia.GAP.call_with_catch( julia_obj, args, arec );
+    elif Length( kwargs ) = 1 and IsRecord( kwargs[1] ) then
+      kwargs := GAPToJulia( _JL_Dict_Any, kwargs[1], false );
+      res:= Julia.GAP.call_with_catch( julia_obj, args, kwargs );
     else
-      Error( "usage: CallJuliaFunctionWithCatch( <julia_obj>, <args>, <arec>" );
+      Error( "usage: CallJuliaFunctionWithCatch( <julia_obj>, <args>[, <kwargs>]" );
     fi;
     if res[1] then
       return rec( ok:= true, value:= res[2] );
@@ -45,7 +45,7 @@ InstallGlobalFunction( CallJuliaFunctionWithCatch,
 end );
 
 InstallGlobalFunction( CallJuliaFunctionWithKeywordArguments,
-    { julia_obj, args, arec } -> Julia.GAP.kwarg_wrapper( julia_obj,
+    { julia_obj, args, kwargs } -> Julia.GAP.kwarg_wrapper( julia_obj,
                                      # non-recursive conversions
                                      GAPToJulia( _JL_Vector_Any, args, false ),
-                                     GAPToJulia( _JL_Dict_Any, arec, false ) ) );
+                                     GAPToJulia( _JL_Dict_Any, kwargs, false ) ) );

--- a/pkg/JuliaInterface/gap/calls.gi
+++ b/pkg/JuliaInterface/gap/calls.gi
@@ -12,7 +12,7 @@ InstallMethod( CallFuncList,
     [ "IsJuliaObject", "IsList" ],
     function( julia_obj, args )
         args := GAPToJulia( _JL_Vector_Any, args, false );
-        return Julia.Core._apply( julia_obj, args );
+        return Julia.GAP._apply( julia_obj, args );
     end );
 
 InstallMethod( CallFuncList,
@@ -22,14 +22,21 @@ InstallMethod( CallFuncList,
     end );
 
 InstallGlobalFunction( CallJuliaFunctionWithCatch,
-    function( julia_obj, args )
+    function( julia_obj, args, arec... )
     local res;
 
     args := GAPToJulia( _JL_Vector_Any, args, false );
     if IsFunction( julia_obj ) then
       julia_obj:= Julia.GAP.UnwrapJuliaFunc( julia_obj );
     fi;
-    res:= Julia.GAP.call_with_catch( julia_obj, args );
+    if Length( arec ) = 0 then
+      res:= Julia.GAP.call_with_catch( julia_obj, args );
+    elif Length( arec ) = 1 and IsRecord( arec[1] ) then
+      arec := GAPToJulia( _JL_Dict_Any, arec[1], false );
+      res:= Julia.GAP.call_with_catch( julia_obj, args, arec );
+    else
+      Error( "usage: CallJuliaFunctionWithCatch( <julia_obj>, <args>, <arec>" );
+    fi;
     if res[1] then
       return rec( ok:= true, value:= res[2] );
     else

--- a/pkg/JuliaInterface/tst/utils.tst
+++ b/pkg/JuliaInterface/tst/utils.tst
@@ -19,6 +19,8 @@ gap> res.ok;
 false
 gap> StartsWith( res.value, "DomainError" );
 true
+gap> CallJuliaFunctionWithCatch( Julia.Base.sqrt, [ 4 ], rec() );
+rec( ok := true, value := <Julia: 2.0> )
 
 ##
 gap> JuliaEvalString(fail);


### PR DESCRIPTION
(motivated mainly by gap-packages/PackageManager/pull/134 and the issues mentioned there)

- support keyword arguments in `CallJuliaFunctionWithCatch`

- do not use the deprecated and undocumented `Core._apply`

- update the initializations in `init_packagemanager`: Replacing `PKGMAN_DownloadURL` is no longer needed, replacing `PKGMAN_RemoveDir` was in a wrong place.

- start better documentation of Julia syntax features