### PR TITLE
Stop wrapping Julia modules in special objects

### DIFF
--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -109,8 +109,7 @@
 #! However not every object living on the Julia side is in this filter.
 #! For example Julia booleans and small <C>Int</C> values are directly
 #! translated to GAP booleans and small integers, while for Julia functions
-#! and wrappers dedicated wrappers are used for improved efficiency
-#! respectively additional features.
+#! dedicated wrappers are used to improve efficiency and add features.
 #! @BeginExampleSession
 #! gap> JuliaEvalString( "x = 4" );;
 #! gap> Julia.x;
@@ -118,8 +117,6 @@
 #! gap> IsJuliaObject( Julia.x );
 #! false
 #! gap> IsJuliaObject( Julia.sqrt );
-#! false
-#! gap> IsJuliaObject( Julia.Main );
 #! false
 #! @EndExampleSession
 DeclareCategory( "IsJuliaObject", IsObject );
@@ -138,14 +135,10 @@ BindGlobal("TheTypeJuliaObject", NewType( JuliaObjectFamily, IsJuliaObject ));
 #!  This admits implementing high-level wrapper objects
 #!  for &Julia; objects that behave just like the &Julia; objects
 #!  when used as arguments in calls to &Julia; functions.
-#!  <!-- No other functionality is implemented for IsJuliaWrapper -->
 #!
 #!  Objects in <Ref Filt="IsJuliaWrapper" Label="for IsObject"/>
 #!  should <E>not</E> be in the filter
 #!  <Ref Filt="IsJuliaObject" Label="for IsObject"/>.
-#!
-#!  For example, any Julia modules such as <C>Julia.Base</C> are
-#!  in the filter <Ref Filt="IsJuliaWrapper" Label="for IsObject"/>.
 DeclareCategory( "IsJuliaWrapper", IsObject );
 
 #! @Arguments obj
@@ -153,18 +146,6 @@ DeclareCategory( "IsJuliaWrapper", IsObject );
 #!  is an attribute for &GAP; objects in the filter
 #!  <Ref Filt="IsJuliaWrapper" Label="for IsObject"/>.
 #!  The value must be a &Julia; object.
-#! @BeginExampleSession
-#! gap> Julia;
-#! <Julia module Main>
-#! gap> IsJuliaObject( Julia );
-#! false
-#! gap> IsJuliaWrapper( Julia );
-#! true
-#! gap> ptr:= JuliaPointer( Julia );
-#! <Julia: Main>
-#! gap> IsJuliaObject( ptr );
-#! true
-#! @EndExampleSession
 DeclareAttribute( "JuliaPointer", IsJuliaWrapper );
 
 #! @Arguments obj
@@ -181,10 +162,10 @@ DeclareAttribute( "JuliaPointer", IsJuliaWrapper );
 #! gap> Julia.GAP.julia_to_gap;
 #! <Julia: julia_to_gap>
 #! @EndExampleSession
-DeclareCategory( "IsJuliaModule", IsJuliaWrapper and IsRecord  );
+DeclareCategory( "IsJuliaModule", IsJuliaObject and IsRecord  );
 
 BindGlobal( "TheFamilyOfJuliaModules", NewFamily( "TheFamilyOfJuliaModules" ) );
-BindGlobal( "TheTypeOfJuliaModules", NewType( TheFamilyOfJuliaModules, IsJuliaModule and IsAttributeStoringRep ) );
+BindGlobal( "TheTypeOfJuliaModules", NewType( TheFamilyOfJuliaModules, IsJuliaModule and HasName ) );
 
 #! @Section Creating &Julia; objects
 
@@ -271,9 +252,7 @@ DeclareGlobalVariable( "Julia" );
 #! @BeginExampleSession
 #! gap> JuliaTypeInfo( Julia.GAP );
 #! "Module"
-#! gap> JuliaTypeInfo( JuliaPointer( Julia.GAP ) );
-#! "Module"
-#! gap> JuliaTypeInfo( JuliaEvalString( "sqrt(2)" ) );
+#! gap> JuliaTypeInfo( Julia.sqrt(2) );
 #! "Float64"
 #! gap> JuliaTypeInfo( 1 );
 #! "Int64"

--- a/pkg/JuliaInterface/read.g
+++ b/pkg/JuliaInterface/read.g
@@ -5,11 +5,6 @@
 #
 ReadPackage( "JuliaInterface", "gap/JuliaInterface.gi");
 
-## Ensure that the Julia module GAP is always accessible as Julia.GAP,
-## even while it is still being initialized, and also if it not actually
-## exported to the Julia Main module
-Julia!.storage.GAP := _WrapJuliaModule( "GAP", _JuliaGetGapModule() );
-
 ReadPackage( "JuliaInterface", "gap/adapter.gi");
 ReadPackage( "JuliaInterface", "gap/calls.gi");
 ReadPackage( "JuliaInterface", "gap/convert.gi");

--- a/pkg/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/JuliaInterface/src/JuliaInterface.c
@@ -21,6 +21,7 @@ static jl_datatype_t * JULIA_GAPFFE_type;
 
 static jl_datatype_t * gap_datatype_mptr;
 
+static Obj  TheTypeOfJuliaModules;
 static Obj  TheTypeJuliaObject;
 static UInt T_JULIA_OBJ;
 
@@ -114,7 +115,10 @@ jl_value_t * GET_JULIA_OBJ(Obj o)
 
 static Obj JuliaObjectTypeFunc(Obj o)
 {
-    return TheTypeJuliaObject;
+    if (jl_typeis(GET_JULIA_OBJ(o), jl_module_type))
+        return TheTypeOfJuliaModules;
+    else
+        return TheTypeJuliaObject;
 }
 
 Obj NewJuliaObj(jl_value_t * v)
@@ -282,6 +286,7 @@ static Int InitKernel(StructInitInfo * module)
     // init filters and functions
     InitHdlrFuncsFromTable(GVarFuncs);
 
+    InitCopyGVar("TheTypeOfJuliaModules", &TheTypeOfJuliaModules);
     InitCopyGVar("TheTypeJuliaObject", &TheTypeJuliaObject);
 
     T_JULIA_OBJ = RegisterPackageTNUM("JuliaObject", JuliaObjectTypeFunc);

--- a/pkg/JuliaInterface/tst/utils.tst
+++ b/pkg/JuliaInterface/tst/utils.tst
@@ -56,7 +56,7 @@ gap> _JuliaGetGlobalVariableByModule("Base","sqrt");
 Error, sqrt is not a module
 gap> _JuliaGetGlobalVariableByModule("sqrt","Base");
 <Julia: sqrt>
-gap> _JuliaGetGlobalVariableByModule("sqrt", JuliaPointer(Julia.Base));
+gap> _JuliaGetGlobalVariableByModule("sqrt", Julia.Base);
 <Julia: sqrt>
 
 ##
@@ -84,6 +84,16 @@ Error, GetJuliaScratchspace: <key> must be a string
 gap> path:= GetJuliaScratchspace( "test_scratch" );;
 gap> IsDirectoryPath( path );
 true
+
+# Julia modules should not get cached, see #1044
+gap> JuliaEvalString("module foo  x = 1 end");
+<Julia module Main.foo>
+gap> Julia.foo.x;
+1
+gap> JuliaEvalString("module foo  x = 2 end");
+<Julia module Main.foo>
+gap> Julia.foo.x;
+2
 
 ##
 gap> STOP_TEST( "utils.tst" );


### PR DESCRIPTION
This resolves issues with outdated caches in our module wrappers.

We added these wrappers to serve as a cache. But we already exempted Julia functions from this. For which we create wrapper objects -- so arguably the cache would make most sense for them... But this can cause inconsistencies, hence @ThomasBreuer remove this in PR #423 four years ago.

So the only thing we cached were the wrapper objects for Julia modules. And the only reasons we needed those wrappers were ...
1. to be able to do caching (haha),
2. to be able to supply the "fake" `Julia.GAP` as a way to access the `GAP` Julia module,
3. for some printing tweaks.

This PR achieves all of the above by adjusting the GAP type for Julia object slightly, we now indicate whether we are seeing a Julia module by setting a suitable filter. As an added bonus, this now also works with modules access by any other means, e.g. returned by a `JuliaEvalString` or a Julia function.

The part I like least is the new hack to make `Julia.GAP` possible. A long-term alternative to this might be to provide a different clean way to access this -- e.g. perhaps we should provide a global GAP variable `GAP_jl` which contains the GAP module? (We could also just call it `GAP` but I feel this might be reeeaaally confusing to GAP users, so I'd rather not). For symmetry in Oscar we could also add `Oscar_jl` as an alias for the `Oscar` global. 

But all of that is beyond this PR. We could file it as a separate issue if care enough.

Resolves #1044
Closes #1045
