### PR TITLE
Hack to avoid warning about Downloads package

### DIFF
--- a/pkg/JuliaInterface/gap/JuliaInterface.gi
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gi
@@ -131,6 +131,10 @@ InstallGlobalFunction( JuliaImportPackage, function( pkgname )
     if JuliaEvalString( callstring ) = true then
         return true;
     else
+      # HACK: avoid warning "The Julia package 'Downloads' cannot be loaded"
+      # with older versions of the GAP PackageManager
+      if pkgname = "Downloads" then return false; fi;
+
       Info( InfoWarning, 1,
             "The Julia package '", pkgname, "' cannot be loaded." );
       return false;


### PR DESCRIPTION
The "proper" fix will come eventually with the new packagemanager. But in the meantime this should fix #1040 for users.