### PR TITLE
setup_override_dir.jl: allow passing args to configure

### DIFF
--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -63,11 +63,11 @@ jobs:
           mv GAPROOT /tmp/GAPROOT
           cd /tmp/GAPROOT
           ./autogen.sh
-          ./configure
+          ./configure --enable-Werror
           make -j`nproc`
       - name: "Override bundled GAP"
         run: |
-          julia --proj=override etc/setup_override_dir.jl /tmp/GAPROOT /tmp/gap_jll_override
+          julia --proj=override etc/setup_override_dir.jl /tmp/GAPROOT /tmp/gap_jll_override --enable-Werror
       - name: "Run tests"
         run: |
            julia --proj=override etc/run_with_override.jl /tmp/gap_jll_override --depwarn=error -e "using Pkg; Pkg.test(\"GAP\")"

--- a/etc/setup_override_dir.jl
+++ b/etc/setup_override_dir.jl
@@ -10,7 +10,12 @@ length(ARGS) >= 1 || error("must provide path of GAP source directory as first a
 length(ARGS) >= 2 || error("must provide path of destination directory as second argument")
 gap_prefix = popfirst!(ARGS)
 prefix = popfirst!(ARGS)
-debugmode = length(ARGS) > 0 && ARGS[1] == "--debug"
+if length(ARGS) > 0 && ARGS[1] == "--debug"
+  debugmode = true
+  popfirst!(ARGS)
+else
+  debugmode = false
+end
 
 # TODO: should the user be allowed to provide a tmp_gap_build_dir ? that might
 # be handy for incremental updates
@@ -94,6 +99,7 @@ push!(extraargs, "CPPFLAGS=-DUSE_GAP_INSIDE_JULIA=1")
     --with-gc=julia
     --with-julia=$(juliabin)
     $(extraargs)
+    $(ARGS)
     `)
 
 @info "Building GAP in $(tmp_gap_build_dir)"


### PR DESCRIPTION
Also use that to treat warnings as error in some CI tests.
