### PR TITLE
Add CI with GAP to scheduled tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ on:
   schedule:
       # Every day at 3:08 AM UTC
       - cron: '8 3 * * *'
+  workflow_dispatch:
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull

--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -7,6 +7,10 @@ on:
       - 'release-*'
     tags: '*'
   pull_request:
+  schedule:
+      # Every day at 3:08 AM UTC
+      - cron: '8 3 * * *'
+  workflow_dispatch:
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -1,14 +1,14 @@
 name: OscarCI
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
-     branches:
-       - master
+    branches:
+      - 'master'
+      - 'release-*'
+    tags: '*'
+  pull_request:
   schedule:
-      # Every day at 3:08 AM UTC (Tutorial tests initiated at 2:00AM)
+      # Every day at 3:08 AM UTC
       - cron: '8 3 * * *'
   workflow_dispatch:
 


### PR DESCRIPTION
make triggers consistent between all the jobs:
- add workflow_dispatch
- add CI with GAP to schedule
- Make push and PR triggers consistent