### PR TITLE
Add `GAP.Packages.build(name)`

### DIFF
--- a/docs/src/packages.md
+++ b/docs/src/packages.md
@@ -13,6 +13,7 @@ GAP.Packages.load
 GAP.Packages.install
 GAP.Packages.update
 GAP.Packages.remove
+GAP.Packages.build
 GAP.Packages.locate_package
 ```
 


### PR DESCRIPTION
Some progress towards https://github.com/oscar-system/GAP.jl/issues/1065.

As pointed out in https://github.com/oscar-system/GAP.jl/issues/1065#issuecomment-2491560696, this function may need to copy a package from an artifact directory to the user pkgdir to have it in a location that is both writable and `PackageManager:CompilePackage` does not complain about.