### PR TITLE
More C code refactoring

### DIFF
--- a/pkg/JuliaInterface/gap/JuliaInterface.gi
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gi
@@ -4,8 +4,9 @@
 # Implementations
 #
 
-BindGlobal( "_JULIA_FUNCTION_TYPE", _JuliaGetGlobalVariableByModule( "Function", _JuliaGetCoreModule() ) );
-BindGlobal( "_JULIA_ISA", _WrapJuliaFunction( _JuliaGetGlobalVariableByModule( "isa", _JuliaGetCoreModule() ) ) );
+BindGlobal( "_JuliaCoreModule", _JuliaGetGlobalVariableByModule( "Core", _JuliaGetMainModule() ) );
+BindGlobal( "_JULIA_FUNCTION_TYPE", _JuliaGetGlobalVariableByModule( "Function", _JuliaCoreModule ) );
+BindGlobal( "_JULIA_ISA", _WrapJuliaFunction( _JuliaGetGlobalVariableByModule( "isa", _JuliaCoreModule ) ) );
 BindGlobal( "_JULIA_GAP", _JuliaGetGapModule() );
 
 InstallMethod( ViewString,

--- a/pkg/JuliaInterface/gap/JuliaInterface.gi
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gi
@@ -4,8 +4,8 @@
 # Implementations
 #
 
-BindGlobal( "_JULIA_FUNCTION_TYPE", _JuliaGetGlobalVariableByModule( "Function", "Core" ) );
-BindGlobal( "_JULIA_ISA", _WrapJuliaFunction( _JuliaGetGlobalVariableByModule( "isa", "Core" ) ) );
+BindGlobal( "_JULIA_FUNCTION_TYPE", _JuliaGetGlobalVariableByModule( "Function", _JuliaGetCoreModule() ) );
+BindGlobal( "_JULIA_ISA", _WrapJuliaFunction( _JuliaGetGlobalVariableByModule( "isa", _JuliaGetCoreModule() ) ) );
 BindGlobal( "_JULIA_GAP", _JuliaGetGapModule() );
 
 InstallMethod( ViewString,
@@ -89,7 +89,7 @@ function( obj )
     return JuliaToGAP( IsList, Julia.GAP.get_symbols_in_module( obj ), true );
 end);
 
-InstallValue( Julia, _JuliaGetGlobalVariableByModule( "Main", "Main" ) );
+InstallValue( Julia, _JuliaGetMainModule() );
 
 InstallGlobalFunction( "JuliaIncludeFile",
 function( filename, module_name... )

--- a/pkg/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/JuliaInterface/src/JuliaInterface.c
@@ -207,11 +207,6 @@ static Obj Func_JuliaGetGlobalVariableByModule(Obj self, Obj name, Obj module)
     return gap_julia(value);
 }
 
-static Obj Func_JuliaGetCoreModule(Obj self)
-{
-    return NewJuliaObj((jl_value_t *)jl_core_module);
-}
-
 static Obj Func_JuliaGetGapModule(Obj self)
 {
     return NewJuliaObj((jl_value_t *)gap_module);
@@ -252,7 +247,6 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(JuliaEvalString, 1, "string"),
     GVAR_FUNC(_JuliaGetGlobalVariableByModule, 2, "name, module"),
     GVAR_FUNC(JuliaSymbol, 1, "name"),
-    GVAR_FUNC(_JuliaGetCoreModule, 0, ""),
     GVAR_FUNC(_JuliaGetGapModule, 0, ""),
     GVAR_FUNC(_JuliaGetMainModule, 0, ""),
     { 0 } /* Finish with an empty entry */

--- a/pkg/JuliaInterface/tst/utils.tst
+++ b/pkg/JuliaInterface/tst/utils.tst
@@ -49,15 +49,7 @@ gap> _JuliaGetGlobalVariableByModule(0, 0);
 Error, _JuliaGetGlobalVariableByModule: <name> must be a string (not the integ\
 er 0)
 gap> _JuliaGetGlobalVariableByModule("sqrt", 0);
-Error, _JuliaGetGlobalVariableByModule: <module> must be a string or a Julia m\
-odule
-gap> _JuliaGetGlobalVariableByModule("sqrt", Julia.Base.sqrt);
-Error, _JuliaGetGlobalVariableByModule: <module> must be a string or a Julia m\
-odule
-gap> _JuliaGetGlobalVariableByModule("Base","sqrt");
-Error, sqrt is not a module
-gap> _JuliaGetGlobalVariableByModule("sqrt","Base");
-<Julia: sqrt>
+Error, _JuliaGetGlobalVariableByModule: <module> must be a Julia module
 gap> _JuliaGetGlobalVariableByModule("sqrt", Julia.Base);
 <Julia: sqrt>
 


### PR DESCRIPTION
- instead of retrieving Julia modules by a string name and assuming they are bound in `Main`, add dedicated kernel functions for fetching `Main` and `Core` modules
- remove internal `get_module` helper