### PR TITLE
Add libstdc++ workaround for CI with julia 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,6 +59,9 @@ jobs:
           arch: ${{ matrix.julia-arch }}
       - name: "Cache artifacts"
         uses: julia-actions/cache@v2
+      - name: "workaround libstdc++ issue for julia 1.6"
+        if: matrix.julia-version == '1.6' && runner.os == 'Linux'
+        run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@v1
       - name: "Run tests"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
+        id: setup-julia
       - name: "Cache artifacts"
         uses: julia-actions/cache@v2
       - name: "workaround libstdc++ issue for julia 1.6"

--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -52,6 +52,9 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
+      - name: "workaround libstdc++ issue for julia 1.6"
+        if: matrix.julia-version == '1.6' && runner.os == 'Linux'
+        run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: Checkout GAP
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v2
+        id: setup-julia
         with:
           version: ${{ matrix.julia-version }}
       - name: "workaround libstdc++ issue for julia 1.6"

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -71,6 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v2
+        id: setup-julia
         with:
           version: ${{ matrix.julia-version }}
       - name: "workaround libstdc++ issue for julia 1.6"

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -73,6 +73,9 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
+      - name: "workaround libstdc++ issue for julia 1.6"
+        if: matrix.julia-version == '1.6' && runner.os == 'Linux'
+        run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: re-using OscarDevTools checkout
         if: github.repository == 'oscar-system/OscarDevTools.jl'
         run: |


### PR DESCRIPTION
Maybe (hopefully) resolves https://github.com/oscar-system/GAP.jl/issues/1071.

This just adds the patch from https://github.com/oscar-system/GAP.jl/issues/1071#issuecomment-2527552438.