### PR TITLE
CI: don't specify runner arch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,17 +33,13 @@ jobs:
           - '1.10'
           - '~1.11.0-0'
           - 'nightly'
-        julia-arch:
-          - x64
         os:
           - ubuntu-latest
         include:
           # Add a few macOS jobs (not too many, the number we can run in parallel is limited)
           - julia-version: '1.10'
-            julia-arch: x64
             os: macOS-latest
           - julia-version: 'nightly'
-            julia-arch: x64
             os: macOS-latest
 
     steps:
@@ -56,7 +52,6 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
-          arch: ${{ matrix.julia-arch }}
         id: setup-julia
       - name: "Cache artifacts"
         uses: julia-actions/cache@v2


### PR DESCRIPTION
macOS runners use native ARM these days, don't request x86 on them