### PR TITLE
Fix dir names inside `gaproot/pkg/`

### DIFF
--- a/src/setup.jl
+++ b/src/setup.jl
@@ -199,8 +199,9 @@ function regenerate_gaproot()
         # create a `pkg` directory with symlinks to all the GAP packages artifacts
         mkpath(joinpath(gaproot_mutable, "pkg"))
         pkg_artifacts = filter(startswith("GAP_pkg_"), keys(TOML.parsefile(find_artifacts_toml(@__FILE__))))
-        for name in pkg_artifacts
-            force_symlink(@artifact_str(name), joinpath(gaproot_mutable, "pkg", name))
+        for artifact_name in pkg_artifacts
+            pkg_name = artifact_name[9:end]
+            force_symlink(@artifact_str(artifact_name), joinpath(gaproot_mutable, "pkg", pkg_name))
         end
 
     end # mkpidlock


### PR DESCRIPTION
This changes it back from this dir containing dirs of the form `GAP_pkg_foobar` to just `foobar`. I suspect that this was an unintended side-effect from #1069.

Note: After this PR is merged, everyone with a dev version of GAP should remove all scratchspaces that have been used between #1069 was merged and this one here. Otherwise, GAP may get confused because all distro packages are available twice.