### PR TITLE
Allow AA v0.44

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -48,7 +48,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 nauty_jll = "55c6dc9b-343a-50ca-8ff2-b71adb3733d5"
 
 [compat]
-AbstractAlgebra = "0.41.11, 0.42.1, 0.43"
+AbstractAlgebra = "0.41.11, 0.42.1, 0.43, 0.44"
 Artifacts = "1.6"
 BinaryWrappers = "0.1.3"
 Compat = "4.4.0"


### PR DESCRIPTION
Can we also backport this as 0.12.2 to allow working on making OSCAR compatible before GAP.jl 0.13.0 is finished?