### PR TITLE
Revamp GAP package overrides

### DIFF
--- a/src/GAP_pkg.jl
+++ b/src/GAP_pkg.jl
@@ -1,40 +1,46 @@
+import Artifacts: @artifact_str
 using BinaryWrappers
 
-const pkg_bindirs = Dict{Symbol, String}()
+function gap_pkg_artifact_dir(pkgname)
+  d = @artifact_str("GAP_pkg_$(pkgname)")
+  return joinpath(d, only(readdir(d)))
+end
+
+const pkg_bindirs = Dict{String, String}()
 
 for pkg in [
-    :ace,
-    :anupq,
-    :browse,
-    #:caratinterface,
-    :cddinterface,
-    :cohomolo,
-    :crypting,
-    #:curlinterface,
-    :cvec,
-    :datastructures,
-    :deepthought,
-    :digraphs,
-    :edim,
-    #:example,          # not useful
-    :ferret,
-    :float,
-    :fplsa,
-    :gauss,
-    #:grape,            # handled via nauty_jll below
-    :guava,
-    :io,
-    :json,
-    #:jupyterkernel,    # useful?
-    :kbmag,
-    :normalizinterface,
-    :nq,
-    :orb,
-    :profiling,
-    #:semigroups,
-    :simpcomp,
-    #:xgap,             # useful?
-    #:zeromqinterface,
+    "ace"
+    "anupq"
+    "browse"
+    #"caratinterface"
+    "cddinterface"
+    "cohomolo"
+    "crypting"
+    #"curlinterface"
+    "cvec"
+    "datastructures"
+    "deepthought"
+    "digraphs"
+    "edim"
+    #"example"          # not useful
+    "ferret"
+    "float"
+    "fplsa"
+    "gauss"
+    #"grape"            # handled via nauty_jll below
+    "guava"
+    "io"
+    "json"
+    #"jupyterkernel"    # useful?
+    "kbmag"
+    "normalizinterface"
+    "nq"
+    "orb"
+    "profiling"
+    #"semigroups"
+    "simpcomp"
+    #"xgap"             # useful?
+    #"zeromqinterface"
     ]
     jll = Symbol("GAP_pkg_$(pkg)_jll")
     @eval begin
@@ -44,7 +50,7 @@ for pkg in [
         # a kernel extension `lib/gap/BLAH.so`.
         #
         # This fails if a package has both executables and a kernel extension.
-        pkg_bindirs[Symbol($(string(pkg)))] =
+        pkg_bindirs[realpath(gap_pkg_artifact_dir($pkg))] =
               if isdir(joinpath($jll.find_artifact_dir(), "bin"))
                   @generate_wrappers($jll)
               else
@@ -55,11 +61,14 @@ end
 
 # Special case for GAP package "grape" which uses `dreadnaut` from nauty_jll
 import nauty_jll
-pkg_bindirs[:grape] = @generate_wrappers(nauty_jll)
+pkg_bindirs[realpath(gap_pkg_artifact_dir("grape"))] = @generate_wrappers(nauty_jll)
 
-function setup_gap_pkg_overrides()
-    @debug "running setup_gap_pkg_overrides()"
-    for (pkg, dir) in pkg_bindirs
-        setproperty!(GAP.Globals.DirectoriesPackageProgramsOverrides, pkg, GapObj(dir))
+function find_override(installationpath::String)
+    rp = realpath(installationpath)
+    op = get(pkg_bindirs, rp, nothing)
+    if op !== nothing
+        @debug "DirectoriesPackagePrograms override detected:\n    $installationpath\n => $op"
+        return op
     end
+    return joinpath(installationpath, "bin", String(GAP.Globals.GAPInfo.Architecture))
 end


### PR DESCRIPTION
Previously we only checked for the package name to decide whether to
override the result of DirectoriesPackagePrograms. However, this is
problematic if e.g. we provide a kernel extension for version 1.0 of a
GAP package, but the user tries to load version 2.0 which may have an
incompatible kernel extension.

Therefore the new code is much stricter: we check whether the specific
version of the package for which `DirectoriesPackagePrograms` was called
is the one we provide via an artifact, and only then do we activate the
override.