### PR TITLE
Ensure binary wrappers are set up each time GAP.jl is loaded

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -155,6 +155,9 @@ function initialize(argv::Vector{String})
     # also declare a global GAP variable with the path to JuliaInterface.so
     AssignGlobalVariable("_path_JuliaInterface_so", MakeString(JuliaInterface_path()))
 
+    # setup JLL overrides
+    setup_overrides()
+
     # now load init.g
     @debug "about to read init.g"
     if ccall((:READ_GAP_ROOT, libgap), Int64, (Ptr{Cchar},), "lib/init.g") == 0

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -155,9 +155,6 @@ function initialize(argv::Vector{String})
     # also declare a global GAP variable with the path to JuliaInterface.so
     AssignGlobalVariable("_path_JuliaInterface_so", MakeString(JuliaInterface_path()))
 
-    # setup JLL overrides
-    setup_overrides()
-
     # now load init.g
     @debug "about to read init.g"
     if ccall((:READ_GAP_ROOT, libgap), Int64, (Ptr{Cchar},), "lib/init.g") == 0
@@ -212,6 +209,9 @@ function initialize(argv::Vector{String})
 
     GAP.Globals.Read(GapObj(joinpath(@__DIR__, "..", "gap", "exec.g")))
     @debug "finished reading gap/exec.g"
+
+    # setup JLL overrides
+    setup_overrides()
 
     # If we are in "stand-alone mode", stop here
     if handle_signals

--- a/src/GAP_pkg.jl
+++ b/src/GAP_pkg.jl
@@ -1,14 +1,7 @@
 import Artifacts: @artifact_str
 using BinaryWrappers
 
-function gap_pkg_artifact_dir(pkgname)
-  d = @artifact_str("GAP_pkg_$(pkgname)")
-  return joinpath(d, only(readdir(d)))
-end
-
-const pkg_bindirs = Dict{String, String}()
-
-for pkg in [
+const gap_pkgs_with_overrides = [
     "ace"
     "anupq"
     "browse"
@@ -42,26 +35,43 @@ for pkg in [
     #"xgap"             # useful?
     "zeromqinterface"
     ]
+
+# import JLLs from above
+for pkg in gap_pkgs_with_overrides
     jll = Symbol("GAP_pkg_$(pkg)_jll")
-    @eval begin
-        import $jll
+    @eval import $jll
+end
+
+# GAP package "grape" uses `dreadnaut` from nauty_jll
+import nauty_jll
+
+const pkg_bindirs = Dict{String, String}()
+
+function gap_pkg_artifact_dir(pkgname)
+  d = @artifact_str("GAP_pkg_$(pkgname)")
+  return joinpath(d, only(readdir(d)))
+end
+
+function setup_overrides()
+    for pkg in gap_pkgs_with_overrides
+        jll = getproperty(GAP, Symbol("GAP_pkg_$(pkg)_jll"))
+
         # Crude heuristic: if the JLL has a `bin` directory then we assume it
         # contains executables the packages uses; otherwise assume it contains
         # a kernel extension `lib/gap/BLAH.so`.
         #
         # This fails if a package has both executables and a kernel extension.
-        pkg_bindirs[realpath(gap_pkg_artifact_dir($pkg))] =
-              if isdir(joinpath($jll.find_artifact_dir(), "bin"))
-                  @generate_wrappers($jll)
+        pkg_bindirs[realpath(gap_pkg_artifact_dir(pkg))] =
+              if isdir(joinpath(jll.find_artifact_dir(), "bin"))
+                  @generate_wrappers(jll)
               else
-                  joinpath($jll.find_artifact_dir(), "lib", "gap")
+                  joinpath(jll.find_artifact_dir(), "lib", "gap")
               end
     end
-end
 
-# Special case for GAP package "grape" which uses `dreadnaut` from nauty_jll
-import nauty_jll
-pkg_bindirs[realpath(gap_pkg_artifact_dir("grape"))] = @generate_wrappers(nauty_jll)
+    # GAP package "grape" uses `dreadnaut` from nauty_jll
+    pkg_bindirs[realpath(gap_pkg_artifact_dir("grape"))] = @generate_wrappers(nauty_jll)
+end
 
 function find_override(installationpath::String)
     rp = realpath(installationpath)


### PR DESCRIPTION
... not just during precompilation