### PR TITLE
Call `setup_overrides` earlier during launch

### DIFF
--- a/pkg/JuliaInterface/read.g
+++ b/pkg/JuliaInterface/read.g
@@ -40,3 +40,6 @@ DirectoriesPackagePrograms := function(name)
     return [ Directory( override ) ];
 end;
 MakeReadOnlyGlobal("DirectoriesPackagePrograms");
+
+# setup JLL overrides
+Julia.GAP.setup_overrides();

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -210,9 +210,6 @@ function initialize(argv::Vector{String})
     GAP.Globals.Read(GapObj(joinpath(@__DIR__, "..", "gap", "exec.g")))
     @debug "finished reading gap/exec.g"
 
-    # setup JLL overrides
-    setup_overrides()
-
     # If we are in "stand-alone mode", stop here
     if handle_signals
         ccall((:SyInstallAnswerIntr, libgap), Cvoid, ())


### PR DESCRIPTION
... so that the overrides are ready by the time GAP's package autoloading runs.

So that e.g. `IO` and `orb` are loaded when GAP launches.