### PR TITLE
Remove a bunch of files from mutable GAP root

### DIFF
--- a/src/setup.jl
+++ b/src/setup.jl
@@ -184,18 +184,6 @@ function regenerate_gaproot()
         write("$gaproot_mutable/gac", gac)
         chmod("$gaproot_mutable/gac", 0o755)
 
-        # 
-        mkpath(joinpath(gaproot_mutable, "bin"))
-        for d in (("include/gap", "src"), ("lib", "lib"), ("bin/gap", "gap"))
-            force_symlink(joinpath(gap_prefix, d[1]), joinpath(gaproot_mutable, d[2]))
-        end
-
-        # emulate the "compat mode" of the GAP build system, to help certain
-        # packages like Browse with an outdated build system
-        mkpath(joinpath(gaproot_mutable, "bin", sysinfo["GAParch"]))
-        force_symlink("../../gac",
-                      joinpath(gaproot_mutable, "bin", sysinfo["GAParch"], "gac"))
-
         # create a `pkg` directory with symlinks to all the GAP packages artifacts
         mkpath(joinpath(gaproot_mutable, "pkg"))
         pkg_artifacts = filter(startswith("GAP_pkg_"), keys(TOML.parsefile(find_artifacts_toml(@__FILE__))))


### PR DESCRIPTION
- GAP dropped its compat mode, so we can follow suite, and not
  worry about providing a `bin/$GAPARCH/gac` symlink
- no distributed GAP package still uses `#include "src/compiled.h"`
  so get rid of the symlink from `GAPDIR/include/gap` to `src`
- there is no need to symlink the `lib` directory containing the
  `libgap` shared library (I am not sure why we did this at all?)
- finally, the symlink from `GAPDIR/bin/gap` to `gap` can be removed
  as (a) that executable can't be executed directly anyway, and (b)
  all GAP packages in the distro these days find the GAP executable
  by looking its path up on `sysinfo.gap`
