### PR TITLE
Optimize conversion of GAP strings to Julia

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@
   - simpcomp
   - singular
   - zeromqinterface
+- Optimize conversion of GAP strings to Julia strings, symbols or `Vector{UInt8}`
 
 ## Version 0.12.3 (released 2025-01-01)
 

--- a/pkg/JuliaExperimental/gap/numfield.g
+++ b/pkg/JuliaExperimental/gap/numfield.g
@@ -809,7 +809,7 @@ InstallMethod( Characteristic,
       # We need this for matrix groups over residue class rings.
       # Nemo does not support it.
       return JuliaToGAP( IsInt,
-                 Julia.Base.getfield( R, JuliaSymbol( "n" ) ) );
+                 Julia.Base.getfield( R, Julia.Symbol( "n" ) ) );
     else
       return JuliaToGAP( IsInt, Julia.Nemo.characteristic( R ) );
     fi;

--- a/pkg/JuliaExperimental/gap/singular.g
+++ b/pkg/JuliaExperimental/gap/singular.g
@@ -215,8 +215,8 @@ InstallMethod( ContextGAPSingular,
                     Julia.Singular.polynomial_ring,
                     [ FContext!.JuliaDomainPointer, names ],
                     rec( cached:= true,
-                         ordering:= JuliaSymbol( ordering ),
-                         ordering2:= JuliaSymbol( ordering2 ),
+                         ordering:= Julia.Symbol( ordering ),
+                         ordering2:= Julia.Symbol( ordering2 ),
                          degree_bound:= degree_bound ) );
 
     # Create the GAP wrappers.

--- a/pkg/JuliaExperimental/gap/zmodnz.g
+++ b/pkg/JuliaExperimental/gap/zmodnz.g
@@ -81,7 +81,7 @@ InstallMethod( ContextGAPNemo,
 
       ElementJuliaToGAP:= function( C, obj )
         return JuliaToGAP( IsInt, Julia.Base.getfield( obj,
-                   JuliaSymbol( "data" ) ) ) * One( C!.GAPDomain );
+                   Julia.Symbol( "data" ) ) ) * One( C!.GAPDomain );
 #T Deal with the case of ZZRingElem!
       end,
 

--- a/pkg/JuliaInterface/gap/JuliaInterface.gi
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gi
@@ -60,7 +60,7 @@ end );
 InstallMethod( \.\:\=,
                [ "IsJuliaModule", "IsPosInt and IsSmallIntRep", "IsObject" ],
   function( module, rnum, obj )
-    Julia.GAP._setglobal( module, JuliaSymbol( NameRNam( rnum ) ), obj );
+    Julia.GAP._setglobal( module, Julia.Symbol( NameRNam( rnum ) ), obj );
 end );
 
 InstallMethod( IsBound\.,

--- a/pkg/JuliaInterface/gap/adapter.gi
+++ b/pkg/JuliaInterface/gap/adapter.gi
@@ -65,7 +65,7 @@ BindGlobal("_JL_RNAM_TO_JULIA_SYMBOL", function(rnam)
     if ISB_REC(_JL_RNAM_TO_JULIA_SYMBOL_CACHE, rnam) then
         symbol := ELM_REC(_JL_RNAM_TO_JULIA_SYMBOL_CACHE, rnam);
     else;
-        symbol := JuliaSymbol( NameRNam( rnam ) );
+        symbol := Julia.Symbol( NameRNam( rnam ) );
         ASS_REC(_JL_RNAM_TO_JULIA_SYMBOL_CACHE, rnam, symbol);
     fi;
     return symbol;

--- a/pkg/JuliaInterface/gap/convert.gd
+++ b/pkg/JuliaInterface/gap/convert.gd
@@ -524,7 +524,7 @@ DeclareConstructor("JuliaToGAP", [IsObject, IsObject, IsBool]);
 #![ 1, 2 ]
 #!gap> jr:= GAPToJulia( r, false );
 #!&lt;Julia: Dict{Symbol,Any}(:a => 1,:b => GAP: [ 1, 2, 3 ])>
-#!gap> Julia.Base.get( jr, JuliaSymbol( "b" ), fail );
+#!gap> Julia.Base.get( jr, Julia.Symbol( "b" ), fail );
 #![ 1, 2, 3 ]
 #!</Example>
 DeclareGlobalFunction("GAPToJulia");

--- a/pkg/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/JuliaInterface/src/JuliaInterface.c
@@ -156,20 +156,6 @@ static Obj FuncJuliaEvalString(Obj self, Obj string)
     return gap_julia(result);
 }
 
-// Returns a julia object GAP object that holds the pointer to a julia symbol
-// :<name>.
-static Obj FuncJuliaSymbol(Obj self, Obj name)
-{
-    BEGIN_GAP_SYNC();
-    RequireStringRep("JuliaSymbol", name);
-
-    // jl_symbol never throws an exception and always returns a valid
-    // result, so no need for extra checks.
-    jl_sym_t * julia_symbol = jl_symbol(CONST_CSTR_STRING(name));
-    END_GAP_SYNC();
-    return NewJuliaObj((jl_value_t *)julia_symbol);
-}
-
 // internal wrapper for jl_boundp to deal with API change in Julia 1.12
 static int gap_jl_boundp(jl_module_t * m, jl_sym_t * var)
 {
@@ -246,7 +232,6 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(IS_JULIA_FUNC, 1, "obj"),
     GVAR_FUNC(JuliaEvalString, 1, "string"),
     GVAR_FUNC(_JuliaGetGlobalVariableByModule, 2, "name, module"),
-    GVAR_FUNC(JuliaSymbol, 1, "name"),
     GVAR_FUNC(_JuliaGetGapModule, 0, ""),
     GVAR_FUNC(_JuliaGetMainModule, 0, ""),
     { 0 } /* Finish with an empty entry */

--- a/pkg/JuliaInterface/tst/utils.tst
+++ b/pkg/JuliaInterface/tst/utils.tst
@@ -27,12 +27,10 @@ gap> Julia.Core.Tuple(1);
 <Julia: (1,)>
 
 ##
-gap> JuliaSymbol("someSymbol");
+gap> Julia.Symbol("someSymbol");
 <Julia: :someSymbol>
-gap> JuliaSymbol("");
+gap> Julia.Symbol("");
 <Julia: Symbol("")>
-gap> JuliaSymbol(1);
-Error, JuliaSymbol: <name> must be a string (not the integer 1)
 
 ##
 gap> _JuliaGetGlobalVariableByModule(0, 0);

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -232,7 +232,13 @@ julia> Symbol(str)
 
 ```
 """
-Core.Symbol(obj::GapObj) = Symbol(String(obj))
+function Core.Symbol(obj::GapObj)
+    if Wrappers.IsStringRep(obj)
+      s, len = UNSAFE_CSTR_STRING(obj)
+      return ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int), s, len)
+    end
+    return Symbol(String(obj))
+end
 
 @doc """
     BitVector(obj::GapObj)

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -120,42 +120,42 @@ gap_to_julia(type_obj, obj; recursive::Bool = true) = gap_to_julia(type_obj, obj
 ## Default
 gap_to_julia(::Type{Any}, x::GapObj; recursive::Bool = true) =
     gap_to_julia(x; recursive)
-gap_to_julia(::Type{Any}, x::Any) = x
-gap_to_julia(::T, x::Nothing) where {T<:Type} = nothing
-gap_to_julia(::Type{Any}, x::Nothing) = nothing
+gap_to_julia(::Type{Any}, x::Any; recursive::Bool = true) = x
+gap_to_julia(::T, x::Nothing; recursive::Bool = true) where {T<:Type} = nothing
+gap_to_julia(::Type{Any}, x::Nothing; recursive::Bool = true) = nothing
 
 ## Handle "conversion" to GAP.Obj and GapObj (may occur in recursions).
-gap_to_julia(::Type{Obj}, x::Obj) = x
-gap_to_julia(::Type{GapObj}, x::GapObj) = x
+gap_to_julia(::Type{Obj}, x::Obj; recursive::Bool = true) = x
+gap_to_julia(::Type{GapObj}, x::GapObj; recursive::Bool = true) = x
 
 ## Integers
-gap_to_julia(::Type{T}, x::GapInt) where {T<:Integer} = T(x)
+gap_to_julia(::Type{T}, x::GapInt; recursive::Bool = true) where {T<:Integer} = T(x)
 
 ## Rationals
-gap_to_julia(::Type{Rational{T}}, x::GapInt) where {T<:Integer} = Rational{T}(x)
+gap_to_julia(::Type{Rational{T}}, x::GapInt; recursive::Bool = true) where {T<:Integer} = Rational{T}(x)
 
 ## Floats
-gap_to_julia(::Type{T}, obj::GapObj) where {T<:AbstractFloat} = T(obj)
+gap_to_julia(::Type{T}, obj::GapObj; recursive::Bool = true) where {T<:AbstractFloat} = T(obj)
 
 ## Chars
-gap_to_julia(::Type{Char}, obj::GapObj) = Char(obj)
-gap_to_julia(::Type{Cuchar}, obj::GapObj) = Cuchar(obj)
+gap_to_julia(::Type{Char}, obj::GapObj; recursive::Bool = true) = Char(obj)
+gap_to_julia(::Type{Cuchar}, obj::GapObj; recursive::Bool = true) = Cuchar(obj)
 
 ## Strings
-gap_to_julia(::Type{String}, obj::GapObj) = String(obj)
+gap_to_julia(::Type{String}, obj::GapObj; recursive::Bool = true) = String(obj)
 
 ## Symbols
-gap_to_julia(::Type{Symbol}, obj::GapObj) = Symbol(obj)
+gap_to_julia(::Type{Symbol}, obj::GapObj; recursive::Bool = true) = Symbol(obj)
 
 ## Convert GAP string to Vector{UInt8}
-function gap_to_julia(::Type{Vector{UInt8}}, obj::GapObj)
+function gap_to_julia(::Type{Vector{UInt8}}, obj::GapObj; recursive::Bool = true)
     Wrappers.IsStringRep(obj) && return CSTR_STRING_AS_ARRAY(obj)
     Wrappers.IsList(obj) && return UInt8[gap_to_julia(UInt8, obj[i]) for i = 1:length(obj)]
     throw(ConversionError(obj, Vector{UInt8}))
 end
 
 ## BitVectors
-gap_to_julia(::Type{BitVector}, obj::GapObj) = BitVector(obj)
+gap_to_julia(::Type{BitVector}, obj::GapObj; recursive::Bool = true) = BitVector(obj)
 
 ## Vectors
 function gap_to_julia(


### PR DESCRIPTION
... be it to Julia strings, symbols, or `Vector{UInt8}`

Multiple things were optimized:

- For conversion to `Vector{UInt8}` we used to do call `deepcopy` on the output of `unsafe_wrap`, but `copy` is sufficient and avoids allocating an `IdDict`; but even better is to create a `Vector{UInt8}` of the right size and then use `unsafe_copyto!`.
- We also called `deepcopy` on the output of `unsafe_string`, but that was completely unnecessary as `unsafe_string` actually copies the data passed to it (unlike `unsafe_wrap`).
- A new internal helper `UNSAFE_CSTR_STRING` avoid using `ccall` to get the data inside a GAP string
- For conversion to symbols we now `ccall` the Julia kernel function `jl_symbol_n`
- Writing `Vector{UInt8}(s)` was slower than `gap_to_julia(Vector{UInt8}, s)` because the former invoked `gap_to_julia(Vector{UInt8}, s; recursive=true)` and this then went into a generic conversion method; by extending the method for `gap_to_julia(Vector{UInt8}, s)` to also take (and then ignore) the `recursive` keyword argument, this overhead (and the creation of yet another dictionary) could be avoided.

As a result we can replace the kernel function `JuliaSymbol` by `Julia.Symbol` as that is at least as efficient now.

Benchmarks using `ChairMarks.jl`, before this patch:

    julia> s = GAP.Obj("abc")
    GAP: "abc"

    julia> @b String($s)
    94.880 ns (4 allocs: 368 bytes)

    julia> @b GAP.gap_to_julia(String, $s)
    94.531 ns (4 allocs: 368 bytes)

    julia> @b Symbol($s)
    163.811 ns (4 allocs: 368 bytes)

    julia> @b GAP.gap_to_julia(Symbol, $s)
    161.397 ns (4 allocs: 368 bytes)

    julia> @b Vector{UInt8}($s)
    1.148 μs (10 allocs: 480 bytes)

    julia> @b GAP.gap_to_julia(Vector{UInt8}, $s)
    142.219 ns (7 allocs: 480 bytes)

After this patch:

    julia> s = GAP.Obj("abc")
    GAP: "abc"

    julia> @b String($s)
    14.297 ns (1 allocs: 24 bytes)

    julia> @b GAP.gap_to_julia(String, $s)
    14.310 ns (1 allocs: 24 bytes)

    julia> @b Symbol($s)
    72.098 ns

    julia> @b GAP.gap_to_julia(Symbol, $s)
    72.044 ns

    julia> @b Vector{UInt8}($s)
    21.397 ns (2 allocs: 64 bytes)
    
    julia> @b GAP.gap_to_julia(Vector{UInt8}, $s)
    21.409 ns (2 allocs: 64 bytes)
