### PR TITLE
Remove call to `Base.GC.gc(true)` in `__init__`

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -143,9 +143,6 @@ function initialize(argv::Vector{String})
         handle_signals,
     )
 
-    # HACK HACK HACK workaround
-    Base.GC.gc(true)
-
     ## At this point, the GAP module has not been completely initialized, and
     ## hence is not yet available under the global binding "GAP"; but
     ## JuliaInterface needs to access it. To make that possible, we dlopen


### PR DESCRIPTION
This was a workaround for weird GC related errors I was seeing for a while. My guess is that these were ramifications of the argv issue recently fixed by adding `_saved_argv` (see PR #1110).

We'll see if CI passes. If not, time to investigate this more.