### PR TITLE
Ensure all gap_to_julia method handle 'recursive' kwarg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,17 @@
 
 ## Version 0.13.0-DEV (released YYYY-MM-DD)
 
-- Update to GAP 4.14.0
+- **Breaking:** Update to GAP 4.14.0
+- **Breaking:** Require `gap_to_julia` methods to handle `recursive`
+  keyword argument (e.g. by adding `; recursive::Bool = true` to the
+  argument list and otherwise ignoring it)
 - Add `GAP.Packages.build_recursive(name)`
 - Change `GAP.Packages.build(name)` to no longer try to build the package if
   it is already installed
-- Instead of downloading a single huge "artifact" containing all deposited GAP
-  packages, we now use (and download) one artifact per GAP package.
+- Use individual artifacts for each GAP package distributed with GAP,
+  instead of a single huge "artifact" containing all of them and which
+  has to be downloaded for each update (now we can update GAP packages
+  individually)
 - Use precompiled binaries for the following GAP packages:
   - 4ti2interface
   - ace

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -85,7 +85,7 @@ The following `gap_to_julia` conversions are supported by GAP.jl.
 | `IsMatrixObj` | `Matrix{Any}`            | `Matrix{T}`           |
 | `IsRecord`    | `Dict{Symbol, Any}`      | `Dict{Symbol, T}`     |
 """
-function gap_to_julia(t::T, x::Any) where {T<:Type}
+function gap_to_julia(t::T, x::Any; recursive::Bool = true) where {T<:Type}
     ## Default for conversion:
     ## Base case for conversion (least specialized method): Allow converting any
     ## Julia object x to type T, provided that the type of x is a subtype of T;
@@ -110,12 +110,10 @@ function gap_to_julia(t::T, x::Any) where {T<:Type}
     return x
 end
 
-## Switch recursion on by default.
 ## If no method for the given arguments supports 'recursion_dict'
 ## then assume that it is not needed.
 gap_to_julia(type_obj, obj, recursion_dict::Union{Nothing,RecDict}; recursive::Bool = true) =
     gap_to_julia(type_obj, obj; recursive)
-gap_to_julia(type_obj, obj; recursive::Bool = true) = gap_to_julia(type_obj, obj)
 
 ## Default
 gap_to_julia(::Type{Any}, x::GapObj; recursive::Bool = true) =
@@ -295,8 +293,8 @@ function gap_to_julia(
 end
 
 ## Ranges
-gap_to_julia(::Type{T}, obj::GapObj) where {T<:UnitRange} = T(obj)
-gap_to_julia(::Type{T}, obj::GapObj) where {T<:StepRange} = T(obj)
+gap_to_julia(::Type{T}, obj::GapObj; recursive::Bool = true) where {T<:UnitRange} = T(obj)
+gap_to_julia(::Type{T}, obj::GapObj; recursive::Bool = true) where {T<:StepRange} = T(obj)
 
 ## Dictionaries
 function gap_to_julia(
@@ -326,7 +324,7 @@ function gap_to_julia(
 end
 
 ## Generic conversions
-gap_to_julia(x::Any) = x
+gap_to_julia(x::Any; recursive::Bool = true) = x
 
 function gap_to_julia(x::GapObj; recursive::Bool = true)
     GAP_IS_INT(x) && return gap_to_julia(BigInt, x)


### PR DESCRIPTION
... instead of relying on a dodgy catch-all method which handles that kwarg

The required changes for Oscar.jl are in https://github.com/oscar-system/Oscar.jl/pull/4419 

Also update CHANGES.md to point out breaking changes