### PR TITLE
Use length instead of Wrappers.Length

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -263,7 +263,7 @@ function BitVector(obj::GapObj)
     !Wrappers.IsBlist(obj) && throw(ConversionError(obj, BitVector))
     # TODO: a much better conversion would be possible, at least if `obj` is
     # in IsBlistRep, then we could essentially memcpy data
-    len = Wrappers.Length(obj)::Int
+    len = length(obj)
     result = BitVector(undef, len)
     for i = 1:len
         result[i] = obj[i]::Bool
@@ -457,7 +457,7 @@ julia> UnitRange{Int32}(val)
 
 function (::Type{T})(obj::GapObj) where {T<:UnitRange}
     !Wrappers.IsRange(obj) && throw(ConversionError(obj, T))
-    len = Wrappers.Length(obj)::Int
+    len = length(obj)
     if len == 0
         # construct an empty UnitRange object
         result = 1:0
@@ -498,7 +498,7 @@ StepRange{Int8, Int8}
 
 function(::Type{T})(obj::GapObj) where {T<:StepRange}
     !Wrappers.IsRange(obj) && throw(ConversionError(obj, T))
-    len = Wrappers.Length(obj)::Int
+    len = length(obj)
     if len == 0
         # construct an empty StepRange object
         start = 1

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -249,7 +249,7 @@ function gap_to_julia(::Type{Set{T}}, obj::GapObj; recursive::Bool = true) where
     else
         throw(ConversionError(obj, Set{T}))
     end
-    len_list = Wrappers.Length(obj)::Int
+    len_list = length(obj)
     new_array = Vector{T}(undef, len_list)
     if recursive
         recursion_dict = IdDict()
@@ -281,7 +281,7 @@ function gap_to_julia(
     if !haskey(recursion_dict, obj)
         parameters = T.parameters
         len = length(parameters)
-        Wrappers.Length(obj) == len ||
+        length(obj) == len ||
             throw(ArgumentError("length of $obj does not match type $T"))
         list = [
             gap_to_julia(parameters[i], obj[i], recursion_dict; recursive)

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -10,13 +10,13 @@ import GAP: @wrap
 @wrap ASS_LIST(x::Any, i::Int, v::Any)::Nothing
 @wrap ASS_MAT(x::Any, i::Int, j::Int, v::Any)::Nothing
 @wrap ASS_REC(x::Any, y::Int, v::Any)::Nothing
-@wrap AsSet(x::Any)::Any
+@wrap AsSet(x::GapObj)::GapObj
 @wrap ASSS_LIST(x::Any, y::Any, v::Any)::Any
 @wrap CopyToStringRep(x::Any)::Any
 @wrap DenominatorRat(x::Any)::GapInt
 @wrap DIFF(x::Any, y::Any)::Any
 @wrap Difference(x::Any, y::Any)::Any
-@wrap DuplicateFreeList(x::Any)::Any
+@wrap DuplicateFreeList(x::GapObj)::GapObj
 @wrap ELM_LIST(x::Any, i::Int)::Any
 @wrap ELM_MAT(x::Any, i::Int, j::Int)::Any
 @wrap ELM_REC(x::Any, y::Int)::Any
@@ -47,7 +47,7 @@ import GAP: @wrap
 @wrap IsString(x::Any)::Bool
 @wrap IsStringRep(x::Any)::Bool
 @wrap IsVectorObj(x::Any)::Bool
-@wrap Iterator(x::Any)::Any
+@wrap Iterator(x::Any)::GapObj
 @wrap Length(x::Any)::GapInt
 @wrap LoadPackage(x::GapObj, y::GapObj, z::Bool)::Any
 @wrap LowercaseString(x::GapObj)::GapObj


### PR DESCRIPTION
Works because we have a method

    Base.length(x::GapObj) = Wrappers.Length(x)::Int

and because a few GAP wrappers are strengthened to assert their
return types, thus making the code which calls `length` more
type stable.
