### PR TITLE
set an exit code in `pkg/JuliaInterface/makedoc.g`

### DIFF
--- a/pkg/JuliaInterface/makedoc.g
+++ b/pkg/JuliaInterface/makedoc.g
@@ -7,6 +7,13 @@ if fail = LoadPackage("AutoDoc", ">= 2014.03.27") then
     Error("AutoDoc version 2014.03.27 is required.");
 fi;
 
+# collect output messages
+outputstring:= "";;
+outputstream:= OutputTextString(outputstring, true);;
+SetPrintFormattingStatus(outputstream, false);
+SetInfoOutput(InfoGAPDoc, outputstream);
+SetInfoOutput(InfoWarning, outputstream);
+
 AutoDoc(rec(
     autodoc := true,
     extract_examples:= true,
@@ -17,4 +24,19 @@ AutoDoc(rec(
     ),
 ));
 
+CloseStream(outputstream);
+UnbindInfoOutput(InfoGAPDoc);
+UnbindInfoOutput(InfoWarning);
+Print(outputstring);
+
+# evaluate the outputs
+outputstring:= ReplacedString(outputstring, "\c", "");;
+errors:= Filtered(SplitString(outputstring, "\n"),
+           x -> StartsWith(x, "#W ") and x <> "#W There are overfull boxes:");;
+if Length(errors) = 0 then
+  QuitGap(true);
+else
+  Print(errors, "\n");
+  QuitGap(false);
+fi;
 QUIT;


### PR DESCRIPTION
like in gap-system/gap#5835:

Detect whether errors like broken references occur when the JuliaInterface manual gets built.