### PR TITLE
Add docs preview for PRs

### DIFF
--- a/.github/workflows/CleanupDocPreview.yml
+++ b/.github/workflows/CleanupDocPreview.yml
@@ -1,0 +1,29 @@
+name: Cleanup Doc Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup-doc-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - name: Delete preview
+        run: |
+            if [ -d "previews/PR$PRNUM" ]; then
+              git config user.name "Documenter.jl"
+              git config user.email "documenter@juliadocs.github.io"
+              git rm -rf "previews/PR$PRNUM"
+              git commit -m "delete preview for $PRNUM"
+              git push origin gh-pages:gh-pages
+            fi
+        env:
+            PRNUM: ${{ github.event.number }}
+
+# adapted from here:
+# https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#gh-pages-Branch
+# without history cleanup

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -142,4 +142,7 @@ makedocs(
     pages = GAP.GAP_docs_pages,
 )
 
-deploydocs(repo = "github.com/oscar-system/GAP.jl.git")
+deploydocs(
+  repo = "github.com/oscar-system/GAP.jl.git",
+  push_preview = true,
+)


### PR DESCRIPTION
This is just copy-pasted from the Oscar repo.

It would be great to have something like this to make sure that e.g. https://github.com/oscar-system/GAP.jl/pull/1127 work as expected and do not break the documentation completely, before merging such PRs.