### PR TITLE
Reduce number of doctest runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,9 +107,6 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
-      - name: "Run doctests"
-        run: |
-          julia --project=docs --color=yes test/doctest.jl
       - name: "Build GAP manual"
         run: |
           julia --project=. -e 'import GAP; GAP.create_gap_sh("/tmp")'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -137,7 +137,7 @@ DocMeta.setdocmeta!(GAP, :DocTestSetup, :(using GAP, GAP.Random); recursive = tr
 makedocs(
     sitename = "GAP.jl",
     modules = [GAP],
-    doctest = true,
+    doctest = false,
     doctestfilters = GAP.GAP_doctestfilters,
     pages = GAP.GAP_docs_pages,
 )


### PR DESCRIPTION
Currently we run the doctests in CI in the following cases:
1. In each `CI / test` run of the julia version-OS-matrix once via https://github.com/oscar-system/GAP.jl/blob/a8f197af7a48cddbefe324c7d570ddd0b9a992da/test/runtests.jl#L26
2. In the `CI / Documentation` job **twice**. One time explicitly from the workflow yml configuration file, and another time by passing `doctest = true` to `makedocs`.

I don't really care about the `makedocs` case. But I really would like to remove the step from the documentation building workflow as a preliminary step towards working on https://github.com/oscar-system/GAP.jl/issues/964.