### PR TITLE
versioninfo: use our own JLL list instead of querying Pkg

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -363,11 +363,11 @@ include("constructors.jl")
 include("julia_to_gap.jl")
 include("utils.jl")
 include("help.jl")
-include("packages.jl")
 include("prompt.jl")
 include("exec.jl")
 include("doctestfilters.jl")
 
 include("GAP_pkg.jl")
+include("packages.jl")
 
 end

--- a/src/GAP_pkg.jl
+++ b/src/GAP_pkg.jl
@@ -36,11 +36,18 @@ const gap_pkgs_with_overrides = [
     "zeromqinterface"
     ]
 
+const gap_pkg_jlls = []
+
 # import JLLs from above
 for pkg in gap_pkgs_with_overrides
     jll = Symbol("GAP_pkg_$(pkg)_jll")
-    @eval import $jll
+    @eval begin
+      import $jll
+      push!(gap_pkg_jlls, $jll)
+    end
 end
+
+push!(gap_pkg_jlls, Setup.GAP_pkg_juliainterface_jll)
 
 # GAP package "4ti2interface" uses executables from lib4ti2_jll
 import lib4ti2_jll

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -5,7 +5,7 @@ import Downloads
 import Pidfile
 import Pkg
 import ...GAP: disable_error_handler, Globals, GapObj, replace_global!, RNamObj, sysinfo, Wrappers
-import ...GAP: gap_pkg_jlls, Compat, GAP_jll
+import ...GAP: gap_pkg_jlls, Compat, Setup
 
 const DEFAULT_PKGDIR = Ref{String}()
 const DOWNLOAD_HELPER = Ref{Downloads.Downloader}()
@@ -564,7 +564,7 @@ function versioninfo(io::IO = stdout; GAP::Bool = false, jll::Bool = false, full
   if jll
     deps = gap_pkg_jlls
     if GAP
-      deps = vcat(deps, [GAP_jll])
+      deps = vcat(deps, [Setup.GAP_jll, Setup.GAP_lib_jll])
     end
     jlldeps = [(name = string(nameof(x)), version = Compat.pkgversion(x)) for x in deps]
     sort!(jlldeps, by = x -> x.name)

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -5,6 +5,7 @@ import Downloads
 import Pidfile
 import Pkg
 import ...GAP: disable_error_handler, Globals, GapObj, replace_global!, RNamObj, sysinfo, Wrappers
+import ...GAP: gap_pkg_jlls, Compat, GAP_jll
 
 const DEFAULT_PKGDIR = Ref{String}()
 const DOWNLOAD_HELPER = Ref{Downloads.Downloader}()
@@ -561,14 +562,12 @@ function versioninfo(io::IO = stdout; GAP::Bool = false, jll::Bool = false, full
                 paths[i])
   end
   if jll
-    deps = collect(values(Pkg.dependencies()))
-    jlldeps = filter(x -> startswith(x.name, "GAP_pkg_"), deps)
-    sort!(jlldeps, by = x -> x.name)
+    deps = gap_pkg_jlls
     if GAP
-      jllname = "GAP_jll"
-      jllpos = findfirst(x -> x.name == jllname, deps)
-      pushfirst!(jlldeps, deps[jllpos])
+      deps = vcat(deps, [GAP_jll])
     end
+    jlldeps = [(name = string(nameof(x)), version = Compat.pkgversion(x)) for x in deps]
+    sort!(jlldeps, by = x -> x.name)
     jllnamewidth = maximum([length(d.name) for d in jlldeps]) + 2
     println(io, padding, "building on:")
     for d in jlldeps


### PR DESCRIPTION
Using `Pkg.dependencies` was brittle in the past, I'd rather avoid it ...

Also show `GAP_lib_jll` version.