### PR TITLE
CI-distro: enable some GAP package tests to figure out why and where they crash

### DIFF
--- a/.github/workflows/CI-distro.yml
+++ b/.github/workflows/CI-distro.yml
@@ -61,15 +61,11 @@ jobs:
           - ubuntu-latest
         gap-package: ${{fromJSON(needs.generate-matrix.outputs.gap-packages)}}
         exclude:
-          - gap-package: 'atlasrep'                   # random segfaults during testing
           - gap-package: 'autodoc'                    # tries and fails to build its own documentation, inside the (partially write protected) artifacts dir
           - gap-package: 'example'                    # no jll
           - gap-package: 'examplesforhomalg'          # `Error, found no GAP executable in PATH`
-          - gap-package: 'guava'                      # random test failures in `guava-3.19/tst/guava.tst:649`: Syntax error: expression expected in /tmp/gaptempfile.i8tlxS:1 GUAVA_TEMP_VAR := � &
           - gap-package: 'hap'                        # `polymake command not found. Please set POLYMAKE_COMMAND by hand`
           - gap-package: 'hapcryst'                   # `polymake command not found. Please set POLYMAKE_COMMAND by hand`
-          - gap-package: 'help'                       # test failure in HeLP-4.0/tst/yes_4ti2.tst:39
-          - gap-package: 'io'                         # segfaults, most likely due to child process handling
           - gap-package: 'itc'                        # dependency `xgap` has no jll
           - gap-package: 'localizeringforhomalg'      # `Error, found no GAP executable in PATH`
           - gap-package: 'normalizinterface'          # Tests fail: NormalizInterface currently bundles Normaliz 3.9.3 and its test suite is tuned to that, but our JLL builds it against normaliz_jll which has 3.10.2


### PR DESCRIPTION
CC @ThomasBreuer 