### PR TITLE
Avoid OtherPackagesLoadedInAdvance

### DIFF
--- a/pkg/JuliaInterface/PackageInfo.g
+++ b/pkg/JuliaInterface/PackageInfo.g
@@ -101,7 +101,6 @@ Dependencies := rec(
   GAP := ">= 4.11",    # need compatible code in GAP's src/julia_gc.c
   NeededOtherPackages := [ ],
   SuggestedOtherPackages := [ ],
-  OtherPackagesLoadedInAdvance := [ [ "GAPDoc", "1.6.6" ] ], # need StripEscapeSequences
   ExternalConditions := [ ],
 ),
 

--- a/pkg/JuliaInterface/gap/utils.gi
+++ b/pkg/JuliaInterface/gap/utils.gi
@@ -105,7 +105,7 @@ BindGlobal( "MatchURLs", function(str, prefix...)
 
   # evaluate "url"s for all matches
   urls := List(Concatenation(matches), a->
-              [a[1].bookname, StripEscapeSequences(a[1].entries[a[2]][1]),
+              [a[1].bookname, _StripEscapeSequences(a[1].entries[a[2]][1]),
                HELP_BOOK_HANDLER.(a[1].handler).HelpData(a[1], a[2], "url")]);
 
   # substitute GAP roots by prefix


### PR DESCRIPTION
Recent GAP versions include _StripEscapeSequences, use that instead of
StripEscapeSequences from GAPDoc
