### PR TITLE
Remove build step from setup job in `CI-distro.yml`

### DIFF
--- a/.github/workflows/CI-distro.yml
+++ b/.github/workflows/CI-distro.yml
@@ -30,10 +30,6 @@ jobs:
         uses: julia-actions/setup-julia@v2
         with:
           version: '1'
-      - name: "Cache artifacts"
-        uses: julia-actions/cache@v2
-      - name: "Build package"
-        uses: julia-actions/julia-buildpkg@v1
       - name: Get list of GAP packages
         id: set-matrix
         run: julia --project=. -e '


### PR DESCRIPTION
All the job needs to do is to find the `Artifact.toml` and parse some things there. This does not require us to build GAP.jl beforehand, saving some few CI minutes and a CI cache.