### PR TITLE
Move `gap_packages_rootdir` into a scratch space

### DIFF
--- a/src/packages.jl
+++ b/src/packages.jl
@@ -3,10 +3,11 @@ module Packages
 
 import Downloads
 import Pidfile
+import Scratch: @get_scratch!
 import ...GAP: disable_error_handler, Globals, GapObj, replace_global!, RNamObj, Wrappers
 import ...GAP: gap_pkg_jlls, Compat, GAP_VERSION, GAP_jll, GAP_lib_jll
 
-gap_packages_rootdir() = joinpath(Base.DEPOT_PATH[1], "gaproot", "v$(GAP_VERSION.major).$(GAP_VERSION.minor)")
+gap_packages_rootdir() = @get_scratch!("v$(GAP_VERSION.major).$(GAP_VERSION.minor)")
 
 const DEFAULT_PKGDIR = Ref(joinpath(gap_packages_rootdir(), "pkg"))
 const DOWNLOAD_HELPER = Ref{Downloads.Downloader}()


### PR DESCRIPTION
... instead of `~/.julia/gaproot/v4.14/`

Pro: scratch spaces are garbage collected, while I'd still have `~/.julia/gaproot/v4.12` around if I hadn't manually deleted it.

Con: harder for users to "find" this dir if they need to (it is now `~/.julia/scratchspaces/c863536a-3901-11e9-33e7-d5cd0df7b904/v4.14/`), though of course they can call `GAP.Packages.gap_packages_rootdir()`

(But I know the location `~/.julia/gaproot/` "by heart" while I am sure I'll have to look up the UUID each time).