### PR TITLE
support a timeout parameter for GAP's `Download`

### DIFF
--- a/src/packages.jl
+++ b/src/packages.jl
@@ -18,56 +18,47 @@ function __init__()
 end
 
 function init_packagemanager()
-#TODO:
-# As soon as GAP.jl can rely on a good enough version of PackageManager
-# we need not replace `PKGMAN_DownloadURL` anymore.
-# (And the function should be renamed.)
     res = load("PackageManager")
     @assert res
 
     global DOWNLOAD_HELPER[] = Downloads.Downloader(; grace=0.1)
 
+    res = load("utils", "0.77")  # a version that contains `Download`
+    @assert res
+    @assert hasproperty(Globals, :Download_Methods)
+
     # overwrite PKGMAN_DownloadURL
-    replace_global!(:PKGMAN_DownloadURL, function(url)
-      try
-        buffer = Downloads.download(String(url), IOBuffer(), downloader=DOWNLOAD_HELPER[])
-        return GapObj(Dict{Symbol, Any}(:success => true, :result => String(take!(buffer))), recursive=true)
-      catch
-        return GapObj(Dict{Symbol, Any}(:success => false), recursive=true)
-      end
-    end)
+    replace_global!(:PKGMAN_DownloadURL, Globals.Download)
 
     # Install a method (based on Julia's Downloads package) as the first choice
     # for the `Download` function from GAP's utils package,
     # in order to make this function independent of the availability of some
     # external program that is not guaranteed by an explicit dependency.
-    res = load("utils")
-    @assert res
-    if hasproperty(Globals, :Download_Methods)
-      # provide a Julia function as a `Download` method
-      r = Dict{Symbol, Any}(
-           :name => "via Julia's Downloads.download",
-           :isAvailable => Globals.ReturnTrue,
-           :download => function(url, opt)
-             try
-               if hasproperty(opt, :target)
-                 Downloads.download(String(url), String(opt.target), downloader=DOWNLOAD_HELPER[])
-                 return GapObj(Dict{Symbol, Any}(:success => true), recursive=true)
-               else
-                 buffer = Downloads.download(String(url), IOBuffer(), downloader=DOWNLOAD_HELPER[])
-                 return GapObj(Dict{Symbol, Any}(:success => true, :result => String(take!(buffer))), recursive=true)
-               end
-             catch e
-               return GapObj(Dict{Symbol, Any}(:success => false,
-                                               :error => GapObj(string(e))),
-                             recursive=true)
-             end
-           end)
+    r = Dict{Symbol, Any}(
+         :name => "via Julia's Downloads.download",
+         :isAvailable => Globals.ReturnTrue,
+         :download => function(url, opt)
+            try
+              timeout = hasproperty(opt, :maxTime) ? Real(opt.maxTime) : Inf
+              if hasproperty(opt, :target)
+                Downloads.download(String(url), String(opt.target);
+                  downloader=DOWNLOAD_HELPER[], timeout=timeout)
+                return GapObj(Dict{Symbol, Any}(:success => true), recursive=true)
+              else
+                buffer = Downloads.download(String(url), IOBuffer();
+                  downloader=DOWNLOAD_HELPER[], timeout=timeout)
+                return GapObj(Dict{Symbol, Any}(:success => true, :result => String(take!(buffer))), recursive=true)
+              end
+            catch e
+              return GapObj(Dict{Symbol, Any}(:success => false,
+                                              :error => GapObj(string(e))),
+                            recursive=true)
+            end
+          end)
 
-      # put the new method in the first position
-      meths = Globals.Download_Methods
-      Wrappers.Add(meths, GapObj(r, recursive=true), 1)
-    end
+    # Put the new method in the first position.
+    meths = Globals.Download_Methods
+    Wrappers.Add(meths, GapObj(r, recursive=true), 1)
 
     # monkey patch PackageManager so that we can disable removal of
     # package directories for debugging purposes


### PR DESCRIPTION
The `Download` function from GAP's `utils` package will support an optional `maxTime`, where a positive integer means that the download shall be aborted after that many seconds, see gap-packages/utils/pull/81.

`GAP.jl` provides a method for `Download` that is based on Julia's `Downloads.jl` package.  The proposed changes are intended to support the timeout support for this method.

Additionally, the function `PKGMAN_DownloadURL` now gets replaced by the `Download` function from the `utils` package, instead of separate code; this way, the timeout handling holds also for these downloads.