### PR TITLE
Allow AbstractAlgebra 0.45

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -56,7 +56,7 @@ lib4ti2_jll = "1493ae25-0f90-5c0e-a06c-8c5077d6d66f"
 nauty_jll = "55c6dc9b-343a-50ca-8ff2-b71adb3733d5"
 
 [compat]
-AbstractAlgebra = "0.41.11, 0.42.1, 0.43, 0.44"
+AbstractAlgebra = "0.41.11, 0.42.1, 0.43, 0.44, 0.45"
 Artifacts = "1.6"
 BinaryWrappers = "0.1.3"
 Compat = "4.11"


### PR DESCRIPTION
The new version should contain no changes that are breaking for GAP.jl.

@fingolfin could you please prepare a patch release with this?