### PR TITLE
Fix Oscar downstream tests

### DIFF
--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - name: "workaround libstdc++ issue for julia 1.6"
-        if: matrix.julia-version == '1.6' && runner.os == 'Linux'
+        if: matrix.julia-version == '~1.6.0-0' && runner.os == 'Linux'
         run: rm -f ${{ steps.setup-julia.outputs.julia-bindir }}/../lib/julia/libstdc++.so.6
       - name: re-using OscarDevTools checkout
         if: github.repository == 'oscar-system/OscarDevTools.jl'


### PR DESCRIPTION
The workaround was already added in https://github.com/oscar-system/GAP.jl/pull/1073, but we missed that the OscarDevTools jobs have a different julia version than all other jobs.

cc @benlorenz 