### PR TITLE
Fix expect tests on macos

### DIFF
--- a/etc/julia.expect
+++ b/etc/julia.expect
@@ -29,6 +29,7 @@ expect "julia> "
 # test tab completing of a GAP record
 send -- "GAP.Globals.GAPInfo.MaxNrArgs"
 expect "GAP.Globals.GAPInfo.MaxNrArgs"
+sleep 0.5
 send -- "\t"
 expect "Method"
 send -- "\r"


### PR DESCRIPTION
Maybe resolves https://github.com/oscar-system/GAP.jl/issues/1178, at least with this change I can no longer reproduce in on munk.

I have honestly no idea why this should change anything, but it seems it does.

Makes https://github.com/oscar-system/GAP.jl/pull/1185 obsolete and thus closes https://github.com/oscar-system/GAP.jl/pull/1185.