### PR TITLE
Copy treehash CI job from Singular.jl

### DIFF
--- a/.github/workflows/treehash.yml
+++ b/.github/workflows/treehash.yml
@@ -11,8 +11,8 @@ on:
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull
-  # requests, we limit to 1 concurrent job, but for the master branch we don't
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # requests, we limit to 1 concurrent job, but for the default repository branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref_name != github.event.repository.default_branch || github.run_number }}
   # Cancel intermediate builds, but only if it is a pull request build.
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 


### PR DESCRIPTION
Resolves https://github.com/oscar-system/GAP.jl/issues/778.

This is a CI job that fails if either the GAP_pkg_juliainterface_jll is outdated (w.r.t. the current source code), or a forced rebuild of juliainterface does not work.
Contrary to the discussion in #778 I would only use this CI job when preparing a release (aka the same way as in Singular.jl).

We should **never** make a release when this job fails. Instead, GAP_pkg_juliainterface_jll should be updated first.

(This would probably have prevented me not noticing the offset in the 0.14.0 release, thus leading to https://github.com/oscar-system/GAP.jl/pull/1200)