### PR TITLE
Try to fix treehash.yml

### DIFF
--- a/.github/workflows/treehash.yml
+++ b/.github/workflows/treehash.yml
@@ -36,7 +36,7 @@ jobs:
             using GAP_pkg_juliainterface_jll
             jll = GAP_pkg_juliainterface_jll.find_artifact_dir()
             jll_hash = GitTools.tree_hash(joinpath(jll, "src"))
-            bundled = joinpath(@__DIR__, "..", "pkg", "JuliaInterface")
+            bundled = joinpath(@__DIR__, "pkg", "JuliaInterface")
             bundled_hash = GitTools.tree_hash(joinpath(bundled, "src"))
             jll_hash == bundled_hash || error("tree hash is $src_hash, but JLL uses $jll_hash")
             '

--- a/.github/workflows/treehash.yml
+++ b/.github/workflows/treehash.yml
@@ -38,7 +38,7 @@ jobs:
             jll_hash = GitTools.tree_hash(joinpath(jll, "src"))
             bundled = joinpath(@__DIR__, "pkg", "JuliaInterface")
             bundled_hash = GitTools.tree_hash(joinpath(bundled, "src"))
-            jll_hash == bundled_hash || error("tree hash is $src_hash, but JLL uses $jll_hash")
+            jll_hash == bundled_hash || error("tree hash is $bundled_hash, but JLL uses $jll_hash")
             '
       # next verify that GAP.jl still runs when forced to rebuild juliainterface;
       # as a side effect this also reduce code coverage fluctuation when


### PR DESCRIPTION
#1201 was merged while it still had IOErrors (see https://github.com/oscar-system/GAP.jl/actions/runs/16021466950/job/45199247052#step:6:23).

Please only merge this, once the job fails with a treehash mismatch