### PR TITLE
Drop `use_jl_reinit_foreign_type` in favor of `true`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -9,18 +9,11 @@
 ##  SPDX-License-Identifier: LGPL-3.0-or-later
 ##
 
-if use_jl_reinit_foreign_type()
-    const GapObj = @ccall libgap.GAP_DeclareGapObj(:GapObj::Symbol, GAP::Module, Any::Any)::Any
+const GapObj = @ccall libgap.GAP_DeclareGapObj(:GapObj::Symbol, GAP::Module, Any::Any)::Any
 
-    const SmallBag = @ccall libgap.GAP_DeclareBag(:SmallBag::Symbol, GAP::Module, Any::Any, 0::Cint)::Any
+const SmallBag = @ccall libgap.GAP_DeclareBag(:SmallBag::Symbol, GAP::Module, Any::Any, 0::Cint)::Any
 
-    const LargeBag = @ccall libgap.GAP_DeclareBag(:LargeBag::Symbol, GAP::Module, Any::Any, 1::Cint)::Any
-
-else
-
-import GAP_jll: GapObj
-
-end
+const LargeBag = @ccall libgap.GAP_DeclareBag(:LargeBag::Symbol, GAP::Module, Any::Any, 1::Cint)::Any
 
 
 """

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -15,6 +15,5 @@ using Aqua
     Aqua.test_all(
         GAP;
         ambiguities=false, # some from AbstractAlgebra.jl show up here
-        piracies=(GAP.use_jl_reinit_foreign_type() ? true : (treat_as_own=[GapObj],))
     )
 end

--- a/test/adapter.jl
+++ b/test/adapter.jl
@@ -82,9 +82,5 @@ end
 
     ioc = IOContext(io, :module => nothing);
     print(ioc, GapObj)
-    if GAP.use_jl_reinit_foreign_type()
-        @test String(take!(io)) == "GAP.GapObj"
-    else
-        @test String(take!(io)) == "GAP_jll.GapObj"
-    end
+    @test String(take!(io)) == "GAP.GapObj"
 end


### PR DESCRIPTION
Since all supported julia version return `true` anyway.