### PR TITLE
Improve compatibility with JET

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -9,11 +9,15 @@
 ##  SPDX-License-Identifier: LGPL-3.0-or-later
 ##
 
-const GapObj = @ccall libgap.GAP_DeclareGapObj(:GapObj::Symbol, GAP::Module, Any::Any)::Any
+_declare_gap_obj() = @ccall libgap.GAP_DeclareGapObj(:GapObj::Symbol, GAP::Module, Any::Any)::Any
 
-const SmallBag = @ccall libgap.GAP_DeclareBag(:SmallBag::Symbol, GAP::Module, Any::Any, 0::Cint)::Any
+_declare_bag(sym::Symbol, large::Bool) = @ccall libgap.GAP_DeclareBag(sym::Symbol, GAP::Module, Any::Any, large::Cint)::Any
 
-const LargeBag = @ccall libgap.GAP_DeclareBag(:LargeBag::Symbol, GAP::Module, Any::Any, 1::Cint)::Any
+const GapObj = _declare_gap_obj()::Type
+
+const SmallBag = _declare_bag(:SmallBag::Symbol, false)
+
+const LargeBag = _declare_bag(:LargeBag::Symbol, true)
 
 
 """


### PR DESCRIPTION
Move top level @ccall into helper functions. Avoids the problem
described at <https://github.com/aviatesk/JET.jl/issues/734>.

Mind you, `using JET ; report_package("GAP")` still runs into an
error, but at least a different one.