### PR TITLE
Enable more deprecation errors in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,7 +70,7 @@ jobs:
         run: julia --color=yes -e 'using Pkg ; Pkg.add(["Singular", "Nemo"]) ; using Singular, Nemo'
       - name: "GAP tests"
         run: |
-          julia --project=. -e 'import GAP; GAP.create_gap_sh("/tmp")'
+          julia --project=. --depwarn=error -e 'import GAP; GAP.create_gap_sh("/tmp")'
           export GAP="/tmp/gap.sh -A --quitonbreak --norepl"
           etc/ci_test.sh
 

--- a/pkg/JuliaExperimental/julia/numfield.jl
+++ b/pkg/JuliaExperimental/julia/numfield.jl
@@ -60,11 +60,11 @@ end
 
 
 """
-    CoefficientVectorOfNumberFieldElement( elm::Nemo.nf_elem, d::Int )
+    CoefficientVectorOfNumberFieldElement( elm::Nemo.AbsSimpleNumFieldElem, d::Int )
 > Return the coefficient vector of the number field element `elm`,
 > as an array of length `d` and consisting of `Nemo.QQFieldElem` objects.
 """
-function CoefficientVectorOfNumberFieldElement( elm::Nemo.nf_elem, d::Int )
+function CoefficientVectorOfNumberFieldElement( elm::Nemo.AbsSimpleNumFieldElem, d::Int )
     local arr, i
 
     arr = Vector{Nemo.QQFieldElem}( undef, d )
@@ -77,7 +77,7 @@ end
 
 
 """
-    CoefficientVectorsNumDenOfNumberFieldElement( elm::Nemo.nf_elem, d::Int )
+    CoefficientVectorsNumDenOfNumberFieldElement( elm::Nemo.AbsSimpleNumFieldElem, d::Int )
 > Return the tuple that consists of the coefficient vectors
 > of the numerators and the denominators of the coefficient vector
 > of the number field element `elm`,

--- a/pkg/JuliaExperimental/julia/realcyc.jl
+++ b/pkg/JuliaExperimental/julia/realcyc.jl
@@ -21,7 +21,7 @@ import Nemo
 > of the root of unity `exp( 2*pi*I*(k-1) // N )`.
 """
 function arbCyc( coeffs::Vector, R::Nemo.ArbField )
-    val::Nemo.arb = zero( R )
+    val::Nemo.ArbFieldElem = zero( R )
     N::Int = length( coeffs )
     for k = 1:N
       if coeffs[k] != 0
@@ -45,7 +45,7 @@ function isPositiveRealPartCyc( coeffs::Vector )
     prec::Int = 16
     while true
       R::Nemo.ArbField = Nemo.ArbField( prec )
-      x::Nemo.arb = arbCyc( coeffs, R )
+      x::Nemo.ArbFieldElem = arbCyc( coeffs, R )
       if Nemo.is_positive( x )
         return ( true, prec )
       elseif Nemo.is_negative( x )


### PR DESCRIPTION
I am running into some deprecation error issues in https://github.com/oscar-system/GAP.jl/pull/1212, so I looked for a missing `--depwarn=error`, and this should be it.

This PR will also get updates for all the deprecation errors I will encounter.