### PR TITLE
Rewrite the GAP to Julia conversion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,16 @@
 - **Breaking:** Remove `julia_to_gap` (code which called it, say as
   `julia_to_gap(val)`, can instead use `GapObj(val)`; code that provided
   custom methods for it should instead use the `GAP.@install` macro).
+- **Breaking:** Rewrite GAP to Julia conversion (similar to how we rewrote the
+  Julia to GAP conversion in 0.12.0), in order to speed it up, reduce
+  allocations, and make future improvements easier. This should not affect
+  most code, but anyone implementing custom `gap_to_julia` methods should now
+  instead define `gap_to_julia_intern` methods. Other code should generally
+  avoid using `gap_to_julia` and instead call explicit constructors. For
+  example, instead of `gap_to_julia(Vector{Int}, x)` write `Vector{Int}(x)`.
+  And instead of `gap_to_julia(x)` (which "guesses") a conversion, use an
+  explicit type conversion, so e.g. `Int(x)` or `Vector{Int}(x)` etc. -- this
+  improves the readability of your code.
 - Add a package extension for [Nemo.jl](https://github.com/Nemocas/Nemo.jl/)
   that defines conversion methods for some of its basic types to/from GAP.
 - Improve support for upcoming Julia 1.13.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
   Julia to GAP conversion in 0.12.0), in order to speed it up, reduce
   allocations, and make future improvements easier. This should not affect
   most code, but anyone implementing custom `gap_to_julia` methods should now
-  instead define `gap_to_julia_intern` methods. For example, change
+  instead define `gap_to_julia_internal` methods. For example, change
 
       GAP.gap_to_julia(::Type{MyType}, obj::GapObj; recursive::Bool = true) = ...
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,12 +10,20 @@
   Julia to GAP conversion in 0.12.0), in order to speed it up, reduce
   allocations, and make future improvements easier. This should not affect
   most code, but anyone implementing custom `gap_to_julia` methods should now
-  instead define `gap_to_julia_intern` methods. Other code should generally
-  avoid using `gap_to_julia` and instead call explicit constructors. For
-  example, instead of `gap_to_julia(Vector{Int}, x)` write `Vector{Int}(x)`.
-  And instead of `gap_to_julia(x)` (which "guesses") a conversion, use an
-  explicit type conversion, so e.g. `Int(x)` or `Vector{Int}(x)` etc. -- this
-  improves the readability of your code.
+  instead define `gap_to_julia_intern` methods. For example, change
+
+      GAP.gap_to_julia(::Type{MyType}, obj::GapObj; recursive::Bool = true) = ...
+
+  to
+
+      GAP.gap_to_julia_internal(::Type{MyType}, obj::GapObj, ::GAP.JuliaCacheDict,
+                                ::Val{recursive}) where recursive = ...
+
+  Other code should generally avoid using `gap_to_julia` and instead call
+  explicit constructors. For example, instead of `gap_to_julia(Vector{Int},
+  x)` write `Vector{Int}(x)`. And instead of `gap_to_julia(x)` (which
+  "guesses") a conversion, use an explicit type conversion, so e.g. `Int(x)`
+  or `Vector{Int}(x)` etc. -- this improves the readability of your code.
 - Add a package extension for [Nemo.jl](https://github.com/Nemocas/Nemo.jl/)
   that defines conversion methods for some of its basic types to/from GAP.
 - Improve support for upcoming Julia 1.13.

--- a/docs/src/internal.md
+++ b/docs/src/internal.md
@@ -9,6 +9,9 @@ DocTestSetup = :(using GAP)
 GAP.versioninfo
 GAP.get_symbols_in_module
 GAP.GAP
-GAP.RecDict
+GAP.RecDict_g
+GAP.RecDict_j
+GAP.gap_to_julia_internal
+GAP._gap_to_julia
 GAP.kwarg_wrapper
 ```

--- a/ext/NemoExt/gap_to_nemo.jl
+++ b/ext/NemoExt/gap_to_nemo.jl
@@ -26,7 +26,7 @@ function ZZRingElem(obj::GapObj)
   end
 end
 
-GAP.gap_to_julia(::Type{ZZRingElem}, obj::GapInt; recursive::Bool = true) = ZZRingElem(obj)
+GAP.gap_to_julia_internal(::Type{ZZRingElem}, obj::GapInt, ::GAP.JuliaCacheDict, ::Val{recursive}) where recursive = ZZRingElem(obj)
 (::ZZRing)(obj::GapObj) = ZZRingElem(obj)
 
 ##
@@ -38,7 +38,7 @@ function QQFieldElem(obj::GapObj)
   return QQFieldElem(ZZRingElem(Wrappers.NumeratorRat(obj)), ZZRingElem(Wrappers.DenominatorRat(obj)))
 end
 
-GAP.gap_to_julia(::Type{QQFieldElem}, obj::GapInt; recursive::Bool = true) = QQFieldElem(obj)
+GAP.gap_to_julia_internal(::Type{QQFieldElem}, obj::GapInt, ::GAP.JuliaCacheDict, ::Val{recursive}) where recursive = QQFieldElem(obj)
 (::QQField)(obj::GapObj) = QQFieldElem(obj)
 
 ##
@@ -64,7 +64,7 @@ function ZZMatrix(obj::GapObj)
   return m
 end
 
-GAP.gap_to_julia(::Type{ZZMatrix}, obj::GapObj; recursive::Bool = true) = ZZMatrix(obj)
+GAP.gap_to_julia_internal(::Type{ZZMatrix}, obj::GapObj, ::GAP.JuliaCacheDict, ::Val{recursive}) where recursive = ZZMatrix(obj)
 
 ##
 ## matrix of GAP rationals or integers to `QQMatrix`
@@ -81,7 +81,7 @@ function QQMatrix(obj::GapObj)
   return m
 end
 
-GAP.gap_to_julia(::Type{QQMatrix}, obj::GapObj; recursive::Bool = true) = QQMatrix(obj)
+GAP.gap_to_julia_internal(::Type{QQMatrix}, obj::GapObj, ::GAP.JuliaCacheDict, ::Val{recursive}) where recursive = QQMatrix(obj)
 
 ##
 ## generic matrix() method for GAP matrices which converts each element on its

--- a/pkg/JuliaInterface/tst/convert.tst
+++ b/pkg/JuliaInterface/tst/convert.tst
@@ -112,10 +112,18 @@ gap> GAP_jl.Obj(x);
 #
 gap> int := GAPToJulia( Julia.Base.Int64, 11 );
 11
+gap> int = GAPToJulia( 11, true );
+true
 gap> JuliaToGAP(IsInt,  int );
 11
 gap> GAP_jl.Obj( int );
 11
+
+#
+gap> GAPToJulia( Z(3) );
+Z(3)
+gap> GAPToJulia( Z(3), false );
+Z(3)
 
 #
 gap> x := JuliaEvalString("BigInt(123)");;
@@ -190,6 +198,8 @@ gap> GAPToJulia( true );
 true
 gap> GAPToJulia( false );
 false
+gap> GAPToJulia( true, false );
+true
 
 ##
 gap> list:= GAPToJulia( [ 1, 2, 3 ] );

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -338,9 +338,12 @@ include("macros.jl")
 include("wrappers.jl")
 
 include("adapter.jl")
+
+include("conversion.jl")
 include("gap_to_julia.jl")
 include("constructors.jl")
 include("julia_to_gap.jl")
+
 include("utils.jl")
 include("help.jl")
 include("prompt.jl")

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -14,10 +14,10 @@ Obj(x::Obj) = x
 GapObj(x::GapObj) = x
 
 ## Handle conversion of Julia objects to GAP objects
-Obj(obj; recursive::Bool = false) = GapObj_internal(obj, nothing, Val(recursive))::Obj
+Obj(obj; recursive::Bool = false) = GapObj_internal(obj, nothing, BoolVal(recursive))::Obj
 
-Obj(obj, recursive::Bool) = GapObj_internal(obj, nothing, Val(recursive))::Obj
-GapObj(obj, recursive::Bool) = GapObj_internal(obj, nothing, Val(recursive))::Obj
+Obj(obj, recursive::Bool) = GapObj_internal(obj, nothing, BoolVal(recursive))::Obj
+GapObj(obj, recursive::Bool) = GapObj_internal(obj, nothing, BoolVal(recursive))::Obj
 
 ## Conversion to gap integers
 GapInt(x::Integer) = GapObj(x)

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -1,0 +1,96 @@
+#############################################################################
+##
+##  This file is part of GAP.jl, a bidirectional interface between Julia and
+##  the GAP computer algebra system.
+##
+##  Copyright of GAP.jl and its parts belongs to its developers.
+##  Please refer to its README.md file for details.
+##
+##  SPDX-License-Identifier: LGPL-3.0-or-later
+##
+
+
+#############################################################################
+##
+## some utilities
+
+## Show a specific error on conversion failure.
+struct ConversionError <: Base.Exception
+    obj::Any
+    jl_type::Any
+end
+
+Base.showerror(io::IO, e::ConversionError) =
+    print(io, "failed to convert $(typeof(e.obj)) to $(e.jl_type):\n $(e.obj)")
+
+
+"""
+    RecDict_j = IdDict{Tuple{Any, Type}, Any}
+
+An internal type of GAP.jl used for tracking conversion results in `gap_to_julia`.
+The value stored at the key `(obj, T)` is the result
+of the GAP to Julia conversion of `obj` that has type `T`.
+Note that several Julia types can occur for the same GAP object.
+
+Lookups for the key `(obj, T)` in an `IdDict` are successful if the conversion
+result of an object identical to `obj` with target type `T` has been stored
+in the dictionary.
+
+Note that comparing two `GapObj`s with `===` yields the same result as
+comparing them with `GAP.Globals.IsIdenticalObj`
+because `GapObj` is a mutable type.
+"""
+const RecDict_j = IdDict{Tuple{Any, Type}, Any}
+
+const JuliaCacheDict = Union{Nothing,RecDict_j}
+
+
+"""
+    RecDict_g = IdDict{Any,Any}
+
+An internal type of GAP.jl used for tracking conversion results in `julia_to_gap`.
+The value stored at the key `obj` is the result
+of the Julia to GAP conversion of `obj`.
+"""
+const RecDict_g = IdDict{Any,Any}
+
+const GapCacheDict = Union{Nothing,RecDict_g}
+
+
+# helper functions for recursion in conversion from GAP to Julia
+function recursion_info_j(::Type{T}, obj, recursive::Bool, recursion_dict::JuliaCacheDict) where {T}
+    if recursive && recursion_dict === nothing
+        return RecDict_j()
+    else
+        return recursion_dict
+    end
+end
+
+function handle_recursion_g(obj, ::Type{T}, ret_val, rec::Bool, rec_dict::JuliaCacheDict) where T
+    if rec_dict !== nothing
+      # We assume that `obj` is not yet cached.
+      rec_dict[(obj, T)] = ret_val
+    end
+    return rec ? rec_dict : nothing
+end
+
+
+# helper functions for recursion (conversion from Julia to GAP)
+function recursion_info_g(::Type{T}, obj, recursive::Bool, recursion_dict::GapCacheDict) where {T}
+    rec = recursive && _needs_tracking_julia_to_gap(T)
+    if rec && recursion_dict === nothing
+        rec_dict = RecDict_g()
+    else
+        rec_dict = recursion_dict
+    end
+
+    return rec, rec_dict
+end
+
+function handle_recursion(obj, ret_val, rec::Bool, rec_dict::GapCacheDict)
+    if rec_dict !== nothing
+        # We assume that `obj` is not yet cached.
+        rec_dict[obj] = ret_val
+    end
+    return rec ? rec_dict : nothing
+end

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -66,14 +66,6 @@ function recursion_info_j(::Type{T}, obj, recursive::Bool, recursion_dict::Julia
     end
 end
 
-function handle_recursion_g(obj, ::Type{T}, ret_val, rec::Bool, rec_dict::JuliaCacheDict) where T
-    if rec_dict !== nothing
-      # We assume that `obj` is not yet cached.
-      rec_dict[(obj, T)] = ret_val
-    end
-    return rec ? rec_dict : nothing
-end
-
 
 # helper functions for recursion (conversion from Julia to GAP)
 function recursion_info_g(::Type{T}, obj, recursive::Bool, recursion_dict::GapCacheDict) where {T}
@@ -83,11 +75,11 @@ function recursion_info_g(::Type{T}, obj, recursive::Bool, recursion_dict::GapCa
     else
         rec_dict = recursion_dict
     end
-
+    
     return rec, rec_dict
 end
 
-function handle_recursion(obj, ret_val, rec::Bool, rec_dict::GapCacheDict)
+function handle_recursion(obj, ret_val, rec::Bool, rec_dict::Union{Nothing,IdDict})
     if rec_dict !== nothing
         # We assume that `obj` is not yet cached.
         rec_dict[obj] = ret_val

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -68,7 +68,7 @@ end
 
 
 # helper functions for recursion (conversion from Julia to GAP)
-function recursion_info_g(::Type{T}, obj, recursive::Bool, recursion_dict::GapCacheDict) where {T}
+function recursion_info_g(::Type{T}, obj, ret_val, recursive::Bool, recursion_dict::GapCacheDict) where {T}
     rec = recursive && _needs_tracking_julia_to_gap(T)
     if rec && recursion_dict === nothing
         rec_dict = RecDict_g()
@@ -76,7 +76,12 @@ function recursion_info_g(::Type{T}, obj, recursive::Bool, recursion_dict::GapCa
         rec_dict = recursion_dict
     end
     
-    return rec, rec_dict
+   if rec_dict !== nothing
+        # We assume that `obj` is not yet cached.
+        rec_dict[obj] = ret_val
+    end
+    return rec ? rec_dict : nothing
+
 end
 
 function handle_recursion(obj, ret_val, rec::Bool, rec_dict::Union{Nothing,IdDict})

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -91,3 +91,12 @@ function handle_recursion(obj, ret_val, rec::Bool, rec_dict::Union{Nothing,IdDic
     end
     return rec ? rec_dict : nothing
 end
+
+
+# Helper to make use of `Val{true}` and `Val{false}` more efficient:
+# whenever we use patterns like `Val(recursive)` this throws a curve ball
+# to the Julia optimizer, as it cannot infer the type of the result.
+# But in fact we know only two types are possible: `Val{true}` and `Val{false}`.
+# By explicitly "unrolling" this, the compiler can perform a union split
+# to replace the dynamic dispatch with a non-dynamic dispatch
+BoolVal(x::Bool) = x ? Val(true) : Val(false)

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -174,21 +174,20 @@ function gap_to_julia_internal(
     end
 
     recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
-    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
 
-    len_list = length(newobj)
-    new_array = Vector{T}(undef, len_list)
-    for i = 1:len_list
+    ret_val = Set{T}()
+
+    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
+    handle_recursion((obj, TT), ret_val, recursive, rec_dict)
+
+    for i = 1:length(newobj)
         current_obj = ElmList(newobj, i)
         if recursive && !isbitstype(typeof(current_obj))
-            new_array[i] =
-                gap_to_julia_internal(T, current_obj, rec_dict, Val(recursive))
+            push!(ret_val, gap_to_julia_internal(T, current_obj, rec_dict, Val(recursive)))
         else
-            new_array[i] = current_obj
+            push!(ret_val, current_obj)
         end
     end
-    ret_val = TT(new_array)
-    handle_recursion((obj, TT), ret_val, recursive, rec_dict)
     return ret_val
 end
 

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -90,10 +90,10 @@ function gap_to_julia_internal(
     recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
 
     len_list = length(obj)
-    new_array = TT(undef, len_list)
+    ret_val = TT(undef, len_list)::TT
 
     rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
-    recursion_dict = handle_recursion((obj, TT), new_array, recursive, rec_dict)
+    recursion_dict = handle_recursion((obj, TT), ret_val, recursive, rec_dict)
 
     for i = 1:len_list
         if islist
@@ -104,14 +104,14 @@ function gap_to_julia_internal(
             current_obj = Wrappers.ELM_LIST(obj, i)
         end
         if recursive && !isbitstype(typeof(current_obj))
-            new_array[i] =
+            ret_val[i] =
                 gap_to_julia_internal(T, current_obj, recursion_dict, Val(recursive))
         else
-            new_array[i] = current_obj
+            ret_val[i] = current_obj
         end
     end
 
-    return new_array::TT
+    return ret_val::TT
 end
 
 ## Matrices or lists of lists
@@ -135,21 +135,21 @@ function gap_to_julia_internal(
     recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
 
     elm = Wrappers.ELM_MAT
-    new_array = TT(undef, nrows, ncols)
+    ret_val = TT(undef, nrows, ncols)::TT
 
     rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
-    recursion_dict = handle_recursion((obj, TT), new_array, recursive, rec_dict)
+    recursion_dict = handle_recursion((obj, TT), ret_val, recursive, rec_dict)
 
     for i = 1:nrows, j = 1:ncols
         current_obj = elm(obj, i, j)
         if recursive && !isbitstype(typeof(current_obj))
-            new_array[i, j] =
+            ret_val[i, j] =
                 gap_to_julia_internal(T, current_obj, recursion_dict, Val(recursive))
         else
-            new_array[i, j] = current_obj
+            ret_val[i, j] = current_obj
         end
     end
-    return new_array::TT
+    return ret_val
 end
 
 ## Sets
@@ -234,23 +234,23 @@ function gap_to_julia_internal(
 
     recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
 
-    dict = TT()
+    ret_val = TT()
 
     rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
-    recursion_dict = handle_recursion((obj, TT), dict, recursive, rec_dict)
+    recursion_dict = handle_recursion((obj, TT), ret_val, recursive, rec_dict)
 
     names = Wrappers.RecNames(obj)
     names_list = Vector{Symbol}(names)
     for key in names_list
       current_obj = getproperty(obj, key)
       if recursive && !isbitstype(typeof(current_obj))
-        dict[key] =
+        ret_val[key] =
           gap_to_julia_internal(T, current_obj, recursion_dict, Val(true))
       else
-        dict[key] = current_obj
+        ret_val[key] = current_obj
       end
     end
-    return dict
+    return ret_val
 end
 
 ## Generic method:

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -9,6 +9,10 @@
 ##  SPDX-License-Identifier: LGPL-3.0-or-later
 ##
 
+#############################################################################
+##
+## some utilities
+
 ## Show a specific error on conversion failure.
 struct ConversionError <: Base.Exception
     obj::Any
@@ -19,17 +23,325 @@ Base.showerror(io::IO, e::ConversionError) =
     print(io, "failed to convert $(typeof(e.obj)) to $(e.jl_type):\n $(e.obj)")
 
 """
-    RecDict
+    RecDict_j
 
 An internal type of GAP.jl used for tracking conversion results in `gap_to_julia`.
 """
-const RecDict = IdDict{Any,Any}
+const RecDict_j = IdDict{Any, IdDict{Type, Any}}
 
-const GapCacheDict = Union{Nothing,RecDict}
+const JuliaCacheDict = Union{Nothing,RecDict_j}
 
-## Conversion from GAP to Julia
+
+#############################################################################
+##
+## the function `gap_to_julia_internal`
+
 """
-    gap_to_julia(type, x, recursion_dict::Union{Nothing,RecDict}=nothing; recursive::Bool=true)
+    gap_to_julia_internal(::Type{T}, x::Any, rec_dict::JuliaCacheDict, ::Val{recursive}) where {T, recursive}
+
+returns an object of type `T` that corresponds to the GAP object `x`.
+
+The function `gap_to_julia` may call `gap_to_julia_internal`,
+but the other direction is not allowed.
+
+New methods for the conversion from GAP to Julia shall be implemented via
+methods for `gap_to_julia_internal` not for `gap_to_julia`.
+"""
+function gap_to_julia_internal end
+
+## Handle "conversion" to GAP.Obj and GapObj (may occur in recursions).
+gap_to_julia_internal(::Type{Obj}, x::Obj, ::JuliaCacheDict, ::Val{recursive}) where recursive = x
+gap_to_julia_internal(::Type{GapObj}, x::GapObj, ::JuliaCacheDict, ::Val{recursive}) where recursive = x
+
+## Integers
+gap_to_julia_internal(::Type{T}, x::GapInt, ::JuliaCacheDict, ::Val{recursive}) where {T<:Integer, recursive} = T(x)
+
+## Rationals
+gap_to_julia_internal(::Type{Rational{T}}, x::GapInt, ::JuliaCacheDict, ::Val{recursive}) where {T<:Integer, recursive} = Rational{T}(x)
+
+## Floats
+gap_to_julia_internal(::Type{T}, obj::GapObj, ::JuliaCacheDict, ::Val{recursive}) where {T<:AbstractFloat, recursive} = T(obj)
+
+## Chars
+gap_to_julia_internal(::Type{Char}, obj::GapObj, ::JuliaCacheDict, ::Val{recursive}) where recursive = Char(obj)
+gap_to_julia_internal(::Type{Cuchar}, obj::GapObj, ::JuliaCacheDict, ::Val{recursive}) where recursive = Cuchar(obj)
+
+## Strings
+gap_to_julia_internal(::Type{String}, obj::GapObj, ::JuliaCacheDict, ::Val{recursive}) where recursive = String(obj)
+
+## Symbols
+gap_to_julia_internal(::Type{Symbol}, obj::GapObj, ::JuliaCacheDict, ::Val{recursive}) where recursive = Symbol(obj)
+
+## Convert GAP string to Vector{UInt8}
+function gap_to_julia_internal(::Type{Vector{UInt8}}, obj::GapObj, ::JuliaCacheDict, ::Val{recursive}) where recursive
+    Wrappers.IsStringRep(obj) && return CSTR_STRING_AS_ARRAY(obj)
+    Wrappers.IsList(obj) && return UInt8[gap_to_julia_internal(UInt8, obj[i], nothing, Val(false)) for i = 1:length(obj)]
+    throw(ConversionError(obj, Vector{UInt8}))
+end
+
+## BitVectors
+gap_to_julia_internal(::Type{BitVector}, obj::GapObj, ::JuliaCacheDict, ::Val{recursive}) where recursive = BitVector(obj)
+
+## Ranges
+gap_to_julia_internal(::Type{T}, obj::GapObj, recursion_dict::JuliaCacheDict, ::Val{recursive}) where {T<:UnitRange, recursive} = T(obj)
+gap_to_julia_internal(::Type{T}, obj::GapObj, recursion_dict::JuliaCacheDict, ::Val{recursive}) where {T<:StepRange, recursive} = T(obj)
+
+## Functions
+function gap_to_julia_internal(::Type{Function}, obj::GapObj, ::JuliaCacheDict, ::Val{recursive}) where recursive
+  Wrappers.IS_JULIA_FUNC(obj) && return UnwrapJuliaFunc(obj)
+  throw(ConversionError(obj, Function))
+end
+
+
+## Now come conversions that support recursion.
+
+# helper functions for recursion in conversion from GAP to Julia
+function recursion_info_g(::Type{T}, obj, recursive::Bool, recursion_dict::JuliaCacheDict) where {T}
+    if recursive && recursion_dict === nothing
+        return RecDict_j()
+    else
+        return recursion_dict
+    end
+end
+
+function handle_recursion_g(obj, ::Type{T}, ret_val, rec::Bool, rec_dict::JuliaCacheDict) where T
+    if rec_dict !== nothing
+      if !haskey(rec_dict, obj)
+        rec_dict[obj] = IdDict{Type, Any}()
+      end
+      rec_dict[obj][T] = ret_val
+    end
+    return rec ? rec_dict : nothing
+end
+
+
+## Vectors
+function gap_to_julia_internal(
+    TT::Type{Vector{T}},
+    obj::GapObj,
+    recursion_dict::JuliaCacheDict,
+    ::Val{recursive},
+) where {T, recursive}
+
+    recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && haskey(recursion_dict[obj], TT) && return recursion_dict[obj][TT]
+    rec_dict = recursion_info_g(TT, obj, recursive, recursion_dict)
+
+    if Wrappers.IsList(obj)
+        islist = true
+    elseif Wrappers.IsVectorObj(obj)
+        islist = false
+        ELM_LIST = Wrappers.ELM_LIST
+    else
+        throw(ConversionError(obj, TT))
+    end
+
+    len_list = length(obj)
+    new_array = TT(undef, len_list)
+    recursion_dict = handle_recursion_g(obj, TT, new_array, recursive, rec_dict)
+    for i = 1:len_list
+        if islist
+            current_obj = ElmList(obj, i)  # returns 'nothing' for holes in the list
+        else
+            # vector objects aren't lists,
+            # but the function for accessing entries is `ELM_LIST`
+            current_obj = ELM_LIST(obj, i)
+        end
+        if recursive && !isbitstype(typeof(current_obj))
+            new_array[i] =
+                gap_to_julia_internal(T, current_obj, recursion_dict, Val(recursive))
+        else
+            new_array[i] = current_obj
+        end
+    end
+
+    return new_array::TT
+end
+
+## Matrices or lists of lists
+function gap_to_julia_internal(
+    TT::Type{Matrix{T}},
+    obj::GapObj,
+    recursion_dict::JuliaCacheDict,
+    ::Val{recursive},
+) where {T, recursive}
+
+    recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && haskey(recursion_dict[obj], TT) && return recursion_dict[obj][TT]
+    rec_dict = recursion_info_g(TT, obj, recursive, recursion_dict)
+
+    if Wrappers.IsMatrixObj(obj)
+        nrows = Wrappers.NumberRows(obj)::Int
+        ncols = Wrappers.NumberColumns(obj)::Int
+    elseif Wrappers.IsList(obj)
+        nrows = length(obj)
+        ncols = nrows == 0 ? 0 : length(obj[1])
+    else
+        throw(ConversionError(obj, TT))
+    end
+
+    elm = Wrappers.ELM_MAT
+    new_array = TT(undef, nrows, ncols)
+    recursion_dict = handle_recursion_g(obj, TT, new_array, recursive, rec_dict)
+
+    for i = 1:nrows, j = 1:ncols
+        current_obj = elm(obj, i, j)
+        if recursive && !isbitstype(typeof(current_obj))
+            new_array[i, j] =
+                gap_to_julia_internal(T, current_obj, recursion_dict, Val(recursive))
+        else
+            new_array[i, j] = current_obj
+        end
+    end
+    return new_array::TT
+end
+
+## Sets
+## Assume that the argument `obj` of this function is not self-referential,
+## for example we cannot really sort a self-referential GAP list.
+## Then we need not worry about creating the result in the end,
+## and then adding it to the dictionary that is needed for the recursion.
+function gap_to_julia_internal(
+    TT::Type{Set{T}},
+    obj::GapObj,
+    recursion_dict::JuliaCacheDict,
+    ::Val{recursive},
+) where {T, recursive}
+
+    recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && haskey(recursion_dict[obj], TT) && return recursion_dict[obj][TT]
+    rec_dict = recursion_info_g(TT, obj, recursive, recursion_dict)
+
+    if Wrappers.IsCollection(obj)
+        newobj = Wrappers.AsSet(obj)
+    elseif Wrappers.IsList(obj)
+        # The list entries may be not comparable via `<`.
+        newobj = Wrappers.DuplicateFreeList(obj)
+    else
+        throw(ConversionError(obj, TT))
+    end
+    len_list = length(newobj)
+    new_array = Vector{T}(undef, len_list)
+    for i = 1:len_list
+        current_obj = ElmList(newobj, i)
+        if recursive && !isbitstype(typeof(current_obj))
+            new_array[i] =
+                gap_to_julia_internal(T, current_obj, rec_dict, Val(recursive))
+        else
+            new_array[i] = current_obj
+        end
+    end
+    ret_val = TT(new_array)
+    handle_recursion_g(obj, TT, ret_val, recursive, rec_dict)
+    return ret_val
+end
+
+## Tuples
+## Note that the tuple type prescribes the types of the entries,
+## thus we have to convert at least also the next layer,
+## even if `recursive == false` holds.
+function gap_to_julia_internal(
+    ::Type{T},
+    obj::GapObj,
+    recursion_dict::JuliaCacheDict,
+    ::Val{recursive},
+) where {T<:Tuple, recursive}
+
+    recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && haskey(recursion_dict[obj], T) && return recursion_dict[obj][T]
+    rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
+
+    !Wrappers.IsList(obj) && throw(ConversionError(obj, T))
+    parameters = T.parameters
+    len = length(parameters)
+    length(obj) == len ||
+        throw(ArgumentError("length of $obj does not match type $T"))
+    list = [
+        gap_to_julia_internal(parameters[i], obj[i], rec_dict, Val(recursive))
+        for i = 1:len
+    ]
+
+    ret_val = T(list)
+    recursion_dict = handle_recursion_g(obj, T, ret_val, recursive, rec_dict)
+    return ret_val
+end
+
+## Dictionaries
+function gap_to_julia_internal(
+    TT::Type{Dict{Symbol,T}},
+    obj::GapObj,
+    recursion_dict::JuliaCacheDict,
+    ::Val{recursive},
+) where {T, recursive}
+
+    recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && haskey(recursion_dict[obj], TT) && return recursion_dict[obj][TT]
+    rec_dict = recursion_info_g(TT, obj, recursive, recursion_dict)
+
+    !Wrappers.IsRecord(obj) && throw(ConversionError(obj, TT))
+    dict = TT()
+    recursion_dict = handle_recursion_g(obj, TT, dict, recursive, rec_dict)
+
+    names = Wrappers.RecNames(obj)
+    names_list = Vector{Symbol}(names)
+    for key in names_list
+      current_obj = getproperty(obj, key)
+      if recursive && !isbitstype(typeof(current_obj))
+        dict[key] =
+          gap_to_julia_internal(T, current_obj, recursion_dict, Val(true))
+      else
+        dict[key] = current_obj
+      end
+    end
+    return dict
+end
+
+## Generic method:
+## If it gets called then none of the more special methods is applicable.
+## - If `obj` is a `GapObj` to be "converted" to a supertype `T` of its type
+##   then return `obj` except if recursive conversion is requested.
+##   In the latter case check whether the default Julia type for `obj` is a
+##   subtype of `T`, and if yes then convert `obj` to that type.
+## - If `obj` is not a `GapObj` then recursion has no meaning,
+##   and either `obj` has already the type `T` (and we return `obj`
+##   or we give up because the GAP to Julia conversion is not the right
+##   situation.
+##
+function gap_to_julia_internal(
+    ::Type{T},
+    obj::Any,
+    recursion_dict::JuliaCacheDict,
+    ::Val{recursive},
+) where {T, recursive}
+
+  if obj isa GapObj
+    (obj isa T) && !recursive && return obj
+    D, rec = _default_type(obj, recursive)
+    (D === T || !(D <: T)) && throw(ConversionError(obj, T))
+    return gap_to_julia_internal(D, obj, recursion_dict, Val(rec))
+  else
+    (obj isa T) && return obj
+    throw(ConversionError(obj, T))
+  end
+end
+
+
+#############################################################################
+##
+## the function `gap_to_julia`
+##
+## - If no target type is given and if `obj` is a `GapObj`
+##   then choose a default Julia type.
+##
+## - If no type is given and if `obj` is another `GAP.Obj`
+##   then return the input.
+##
+## - If a type `T` is given but no specific method fits
+##   and if `obj` is a `GapObj`
+##   and if `recursive == true` holds then we want to convert recursively;
+##   for that, we take `_default_type(obj, true)` instead,
+##   and accept this type if it is a subtype of `T`.
+##   (This happens for example inside recursions where `T == Any`,
+##   for example when one wants to convert a GAP list of lists recursively
+##   to a `Vector{Any}`.)
+
+"""
+    gap_to_julia([type, ]x, recursion_dict::JuliaCacheDict=nothing; recursive::Bool=true)
 
 Try to convert the object `x` to a Julia object of type `type`.
 If `x` is a `GapObj` then the conversion rules are defined in the
@@ -40,7 +352,7 @@ defined in Julia by `type`.
 The parameter `recursion_dict` is used to preserve the identity
 of converted subobjects and should never be given by the user.
 
-For GAP lists and records, it makes sense to convert also the subobjects
+For GAP lists and records, it makes sense to either convert also the subobjects
 recursively, or to keep the subobjects as they are;
 the behaviour is controlled by `recursive`, which can be `true` or `false`.
 
@@ -81,11 +393,11 @@ The following `gap_to_julia` conversions are supported by GAP.jl.
 
 | GAP filter    | default Julia type       | other Julia types     |
 |---------------|--------------------------|-----------------------|
-| `IsInt`       | `BigInt`                 | `T <: Integer         |
+| `IsInt`       | `BigInt`                 | `T <: Integer`        |
 | `IsFFE`       | `FFE`                    |                       |
 | `IsBool`      | `Bool`                   |                       |
-| `IsRat`       | `Rational{BigInt}`       | `Rational{T}          |
-| `IsFloat`     | `Float64`                | `T <: AbstractFloat   |
+| `IsRat`       | `Rational{BigInt}`       | `Rational{T}`         |
+| `IsFloat`     | `Float64`                | `T <: AbstractFloat`  |
 | `IsChar`      | `Cuchar`                 | `Char`                |
 | `IsStringRep` | `String`                 | `Symbol`, `Vector{T}` |
 | `IsRangeRep`  | `StepRange{Int64,Int64}` | `Vector{T}`           |
@@ -95,275 +407,62 @@ The following `gap_to_julia` conversions are supported by GAP.jl.
 | `IsMatrixObj` | `Matrix{Any}`            | `Matrix{T}`           |
 | `IsRecord`    | `Dict{Symbol, Any}`      | `Dict{Symbol, T}`     |
 """
-function gap_to_julia(t::T, x::Any; recursive::Bool = true) where {T<:Type}
-    ## Default for conversion:
-    ## Base case for conversion (least specialized method): Allow converting any
-    ## Julia object x to type T, provided that the type of x is a subtype of T;
-    ## otherwise, explicitly reject the conversion.
-    ## As an example why this is useful, suppose you have a GAP list x (i.e., an
-    ## object of type GapObj) containing a bunch of Julia tuples. Then this method
-    ## enables conversion of that list to a Julia array of type Vector{Tuple},
-    ## like this:
-    ##    gap_to_julia(Vector{Tuple{Int64}},xx)
-    ## This works because first the gap_to_julia method with signature
-    ## (::Type{Vector{T}}, :: GapObj) is invoked, with T = Tuple{Int64}; this then
-    ## invokes gap_to_julia recursively with signature (::Tuple{Int64},::Any),
-    ## which ends up selecting the method below.
-    if !(typeof(x) <: t)
-        throw(ErrorException(
-            "Don't know how to convert value of type " *
-            string(typeof(x)) *
-            " to type " *
-            string(t),
-        ))
-    end
-    return x
-end
+function gap_to_julia end
 
-## If no method for the given arguments supports 'recursion_dict'
-## then assume that it is not needed.
-gap_to_julia(type_obj, obj, recursion_dict::Union{Nothing,RecDict}; recursive::Bool = true) =
-    gap_to_julia(type_obj, obj; recursive)
-
-## Default
-gap_to_julia(::Type{Any}, x::GapObj; recursive::Bool = true) =
-    gap_to_julia(x; recursive)
+gap_to_julia(x::Bool) = x
+gap_to_julia(x::Int) = x
+gap_to_julia(x::FFE) = x
+gap_to_julia(T::Type, x::Any; recursive::Bool = true) = gap_to_julia_internal(T, x, nothing, Val(recursive))
 gap_to_julia(::Type{Any}, x::Any; recursive::Bool = true) = x
 gap_to_julia(::T, x::Nothing; recursive::Bool = true) where {T<:Type} = nothing
 gap_to_julia(::Type{Any}, x::Nothing; recursive::Bool = true) = nothing
-
-## Handle "conversion" to GAP.Obj and GapObj (may occur in recursions).
-gap_to_julia(::Type{Obj}, x::Obj; recursive::Bool = true) = x
-gap_to_julia(::Type{GapObj}, x::GapObj; recursive::Bool = true) = x
-
-## Integers
-gap_to_julia(::Type{T}, x::GapInt; recursive::Bool = true) where {T<:Integer} = T(x)
-
-## Rationals
-gap_to_julia(::Type{Rational{T}}, x::GapInt; recursive::Bool = true) where {T<:Integer} = Rational{T}(x)
-
-## Floats
-gap_to_julia(::Type{T}, obj::GapObj; recursive::Bool = true) where {T<:AbstractFloat} = T(obj)
-
-## Chars
-gap_to_julia(::Type{Char}, obj::GapObj; recursive::Bool = true) = Char(obj)
-gap_to_julia(::Type{Cuchar}, obj::GapObj; recursive::Bool = true) = Cuchar(obj)
-
-## Strings
-gap_to_julia(::Type{String}, obj::GapObj; recursive::Bool = true) = String(obj)
-
-## Symbols
-gap_to_julia(::Type{Symbol}, obj::GapObj; recursive::Bool = true) = Symbol(obj)
-
-## Convert GAP string to Vector{UInt8}
-function gap_to_julia(::Type{Vector{UInt8}}, obj::GapObj; recursive::Bool = true)
-    Wrappers.IsStringRep(obj) && return CSTR_STRING_AS_ARRAY(obj)
-    Wrappers.IsList(obj) && return UInt8[gap_to_julia(UInt8, obj[i]) for i = 1:length(obj)]
-    throw(ConversionError(obj, Vector{UInt8}))
-end
-
-## BitVectors
-gap_to_julia(::Type{BitVector}, obj::GapObj; recursive::Bool = true) = BitVector(obj)
-
-## Vectors
-function gap_to_julia(
-    ::Type{Vector{T}},
-    obj::GapObj,
-    recursion_dict::RecDict = IdDict();
-    recursive::Bool = true,
-) where {T}
-    if Wrappers.IsList(obj)
-        islist = true
-    elseif Wrappers.IsVectorObj(obj)
-        islist = false
-        ELM_LIST = Wrappers.ELM_LIST
-    else
-        throw(ConversionError(obj, Vector{T}))
-    end
-
-    if !haskey(recursion_dict, obj)
-        len_list = length(obj)
-        new_array = Vector{T}(undef, len_list)
-        recursion_dict[obj] = new_array
-        for i = 1:len_list
-            if islist
-                current_obj = ElmList(obj, i)  # returns 'nothing' for holes in the list
-            else
-                # vector objects aren't lists,
-                # but the function for accessing entries is `ELM_LIST`
-                current_obj = ELM_LIST(obj, i)
-            end
-            if recursive && !isbitstype(typeof(current_obj))
-                new_array[i] = get!(recursion_dict, current_obj) do
-                    gap_to_julia(T, current_obj, recursion_dict; recursive = true)
-                end
-            else
-                new_array[i] = current_obj
-            end
-        end
-    end
-    return recursion_dict[obj]::Vector{T}
-end
-
-## Matrices or lists of lists
-function gap_to_julia(
-    type::Type{Matrix{T}},
-    obj::GapObj,
-    recursion_dict::RecDict = IdDict();
-    recursive::Bool = true,
-) where {T}
-    if haskey(recursion_dict, obj)
-        return recursion_dict[obj]::Matrix{T}
-    end
-    if Wrappers.IsMatrixObj(obj)
-        nrows = Wrappers.NumberRows(obj)::Int
-        ncols = Wrappers.NumberColumns(obj)::Int
-    elseif Wrappers.IsList(obj)
-        nrows = length(obj)
-        ncols = nrows == 0 ? 0 : length(obj[1])
-    else
-        throw(ConversionError(obj, type))
-    end
-
-    elm = Wrappers.ELM_MAT
-    new_array = type(undef, nrows, ncols)
-    if recursive
-        recursion_dict[obj] = new_array
-    end
-    for i = 1:nrows
-        for j = 1:ncols
-            current_obj = elm(obj, i, j)
-            if recursive
-                new_array[i, j] = get!(recursion_dict, current_obj) do
-                    gap_to_julia(T, current_obj, recursion_dict; recursive = true)
-                end
-            else
-                new_array[i, j] = current_obj
-            end
-        end
-    end
-    return new_array::Matrix{T}
-end
-
-## Sets
-## Assume that this function cannot be called inside recursions.
-## Note that Julia does not support `Set{Set{Int}}([[1], [1, 1]])`.
-## Without this assumption, we would have to construct the set
-## in the beginning, and then fill it up using `union!`.
-function gap_to_julia(::Type{Set{T}}, obj::GapObj; recursive::Bool = true) where {T}
-    if Wrappers.IsCollection(obj)
-        obj = Wrappers.AsSet(obj)
-    elseif Wrappers.IsList(obj)
-        # The list entries may be not comparable via `<`.
-        obj = Wrappers.DuplicateFreeList(obj)
-    else
-        throw(ConversionError(obj, Set{T}))
-    end
-    len_list = length(obj)
-    new_array = Vector{T}(undef, len_list)
-    if recursive
-        recursion_dict = IdDict()
-    end
-    for i = 1:len_list
-        current_obj = ElmList(obj, i)
-        if recursive
-            new_array[i] = get!(recursion_dict, current_obj) do
-                gap_to_julia(T, current_obj, recursion_dict; recursive = true)
-            end
-        else
-            new_array[i] = current_obj
-        end
-    end
-    return Set{T}(new_array)
-end
-
-## Tuples
-## Note that the tuple type prescribes the types of the entries,
-## thus we have to convert at least also the next layer,
-## even if `recursive == false` holds.
-function gap_to_julia(
-    ::Type{T},
-    obj::GapObj,
-    recursion_dict::RecDict = IdDict();
-    recursive::Bool = true,
-) where {T<:Tuple}
-    !Wrappers.IsList(obj) && throw(ConversionError(obj, T))
-    if !haskey(recursion_dict, obj)
-        parameters = T.parameters
-        len = length(parameters)
-        length(obj) == len ||
-            throw(ArgumentError("length of $obj does not match type $T"))
-        list = [
-            gap_to_julia(parameters[i], obj[i], recursion_dict; recursive)
-            for i = 1:len
-        ]
-        recursion_dict[obj] = T(list)
-    end
-    return recursion_dict[obj]::T
-end
-
-## Ranges
-gap_to_julia(::Type{T}, obj::GapObj; recursive::Bool = true) where {T<:UnitRange} = T(obj)
-gap_to_julia(::Type{T}, obj::GapObj; recursive::Bool = true) where {T<:StepRange} = T(obj)
-
-## Dictionaries
-function gap_to_julia(
-    ::Type{Dict{Symbol,T}},
-    obj::GapObj,
-    recursion_dict::RecDict = IdDict();
-    recursive::Bool = true,
-) where {T}
-    !Wrappers.IsRecord(obj) && throw(ConversionError(obj, Dict{Symbol,T}))
-    if !haskey(recursion_dict, obj)
-        names = Wrappers.RecNames(obj)
-        names_list = Vector{Symbol}(names)
-        dict = Dict{Symbol,T}()
-        recursion_dict[obj] = dict
-        for key in names_list
-            current_obj = getproperty(obj, key)
-            if recursive
-                dict[key] = get!(recursion_dict, current_obj) do
-                    gap_to_julia(T, current_obj, recursion_dict; recursive = true)
-                end
-            else
-                dict[key] = current_obj
-            end
-        end
-    end
-    return recursion_dict[obj]::Dict{Symbol,T}
-end
-
-## Generic conversions
 gap_to_julia(x::Any; recursive::Bool = true) = x
 
-function gap_to_julia(x::GapObj; recursive::Bool = true)
-    GAP_IS_INT(x) && return gap_to_julia(BigInt, x)
-    GAP_IS_RAT(x) && return gap_to_julia(Rational{BigInt}, x)
-    GAP_IS_MACFLOAT(x) && return gap_to_julia(Float64, x)
-    GAP_IS_CHAR(x) && return gap_to_julia(Cuchar, x)
-    # Do not choose this conversion for other lists in 'IsString'.
-    Wrappers.IsStringRep(x) && return gap_to_julia(String, x)
-    # Do not choose this conversion for other lists in 'IsRange'.
-    Wrappers.IsRangeRep(x) && return gap_to_julia(StepRange{Int64,Int64}, x)
-    # Do not choose this conversion for other lists in 'IsBlist'.
-    Wrappers.IsBlistRep(x) && return gap_to_julia(BitVector, x)
-    Wrappers.IsList(x) && return gap_to_julia(Vector{Any}, x; recursive)
-    Wrappers.IsMatrixObj(x) && return gap_to_julia(Matrix{Any}, x; recursive)
-    Wrappers.IsVectorObj(x) && return gap_to_julia(Vector{Any}, x; recursive)
-    Wrappers.IsRecord(x) && return gap_to_julia(Dict{Symbol,Any}, x; recursive)
-    Wrappers.IS_JULIA_FUNC(x) && return UnwrapJuliaFunc(x)
-    throw(ConversionError(x, "any known type"))
+function _default_type(x::GapObj, recursive::Bool)
+  GAP_IS_INT(x) && return BigInt, false
+  GAP_IS_RAT(x) && return Rational{BigInt}, false
+  GAP_IS_MACFLOAT(x) && return Float64, false
+  GAP_IS_CHAR(x) && return Cuchar, false
+  Wrappers.IsStringRep(x) && return String, false
+  Wrappers.IsRangeRep(x) && return StepRange{Int64,Int64}, false
+  Wrappers.IsBlistRep(x) && return BitVector, false
+  Wrappers.IsList(x) && return Vector{Any}, recursive
+  Wrappers.IsMatrixObj(x) && return Matrix{Any}, recursive
+  Wrappers.IsVectorObj(x) && return Vector{Any}, recursive
+  Wrappers.IsRecord(x) && return Dict{Symbol,Any}, recursive
+  Wrappers.IS_JULIA_FUNC(x) && return Function, false
+  return Any, false
 end
 
-## for the GAP function GAPToJulia:
-## turning arguments into keyword arguments is easier in Julia than in GAP
+function gap_to_julia(x::GapObj; recursive::Bool = true)
+  T, recursive = _default_type(x, recursive)
+  T == Any && throw(ConversionError(x, "any known type"))
+  return gap_to_julia_internal(T, x, nothing, Val(recursive))
+end
+
+
+#############################################################################
+##
+## the function `_gap_to_julia`
+
+"""
+    _gap_to_julia([::Type{T}, ]x::Obj[, recursive::Bool])
+
+This function implements the GAP function GAPToJulia.
+It just delegates to `gap_to_julia`.
+Its purpose is to turn the `recursive` argument into a keyword argument,
+which is easier in Julia than in GAP.
+"""
 _gap_to_julia(x::Obj) = gap_to_julia(x)
-
-_gap_to_julia(x::Bool, recursive::Bool) = x
-_gap_to_julia(x::Int, recursive::Bool) = x
-_gap_to_julia(x::FFE, recursive::Bool) = x
-_gap_to_julia(x::GapObj, recursive::Bool) = gap_to_julia(x; recursive)
-
 _gap_to_julia(::Type{T}, x::Obj) where {T} = gap_to_julia(T, x)
 _gap_to_julia(::Type{T}, x::Obj, recursive::Bool) where {T} =
     gap_to_julia(T, x; recursive)
+
+# for GapObj, gap_to_julia knows default types
+_gap_to_julia(x::GapObj, recursive::Bool) = gap_to_julia(x; recursive)
+
+# for GAP.Obj except GapObj, we can do better
+_gap_to_julia(x::Bool, recursive::Bool) = x
+_gap_to_julia(x::Int, recursive::Bool) = x
+_gap_to_julia(x::FFE, recursive::Bool) = x
+

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -79,9 +79,6 @@ function gap_to_julia_internal(
     ::Val{recursive},
 ) where {T, recursive}
 
-    recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
-    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
-
     if Wrappers.IsList(obj)
         islist = true
     elseif Wrappers.IsVectorObj(obj)
@@ -89,6 +86,9 @@ function gap_to_julia_internal(
     else
         throw(ConversionError(obj, TT))
     end
+
+    recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
+    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
 
     len_list = length(obj)
     new_array = TT(undef, len_list)
@@ -120,9 +120,6 @@ function gap_to_julia_internal(
     ::Val{recursive},
 ) where {T, recursive}
 
-    recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
-    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
-
     if Wrappers.IsMatrixObj(obj)
         nrows = Wrappers.NumberRows(obj)::Int
         ncols = Wrappers.NumberColumns(obj)::Int
@@ -132,6 +129,9 @@ function gap_to_julia_internal(
     else
         throw(ConversionError(obj, TT))
     end
+
+    recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
+    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
 
     elm = Wrappers.ELM_MAT
     new_array = TT(undef, nrows, ncols)
@@ -161,9 +161,6 @@ function gap_to_julia_internal(
     ::Val{recursive},
 ) where {T, recursive}
 
-    recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
-    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
-
     if Wrappers.IsCollection(obj)
         newobj = Wrappers.AsSet(obj)
     elseif Wrappers.IsList(obj)
@@ -172,6 +169,10 @@ function gap_to_julia_internal(
     else
         throw(ConversionError(obj, TT))
     end
+
+    recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
+    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
+
     len_list = length(newobj)
     new_array = Vector{T}(undef, len_list)
     for i = 1:len_list
@@ -199,10 +200,12 @@ function gap_to_julia_internal(
     ::Val{recursive},
 ) where {T<:Tuple, recursive}
 
+    !Wrappers.IsList(obj) && throw(ConversionError(obj, T))
+
     recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
     rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
 
-    !Wrappers.IsList(obj) && throw(ConversionError(obj, T))
+    # extract the Tuple parameters, i.e. from Tuple{T1, T2, ...}  the list T1,T2,...
     parameters = T.parameters
     len = length(parameters)
     length(obj) == len ||
@@ -225,10 +228,11 @@ function gap_to_julia_internal(
     ::Val{recursive},
 ) where {T, recursive}
 
+    !Wrappers.IsRecord(obj) && throw(ConversionError(obj, TT))
+
     recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
     rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
 
-    !Wrappers.IsRecord(obj) && throw(ConversionError(obj, TT))
     dict = TT()
     recursion_dict = handle_recursion((obj, TT), dict, recursive, rec_dict)
 

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -88,11 +88,13 @@ function gap_to_julia_internal(
     end
 
     recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
-    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
 
     len_list = length(obj)
     new_array = TT(undef, len_list)
+
+    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
     recursion_dict = handle_recursion((obj, TT), new_array, recursive, rec_dict)
+
     for i = 1:len_list
         if islist
             current_obj = ElmList(obj, i)  # returns 'nothing' for holes in the list
@@ -131,10 +133,11 @@ function gap_to_julia_internal(
     end
 
     recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
-    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
 
     elm = Wrappers.ELM_MAT
     new_array = TT(undef, nrows, ncols)
+
+    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
     recursion_dict = handle_recursion((obj, TT), new_array, recursive, rec_dict)
 
     for i = 1:nrows, j = 1:ncols
@@ -231,9 +234,10 @@ function gap_to_julia_internal(
     !Wrappers.IsRecord(obj) && throw(ConversionError(obj, TT))
 
     recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
-    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
 
     dict = TT()
+
+    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
     recursion_dict = handle_recursion((obj, TT), dict, recursive, rec_dict)
 
     names = Wrappers.RecNames(obj)

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -93,7 +93,7 @@ function gap_to_julia_internal(
 
     len_list = length(obj)
     new_array = TT(undef, len_list)
-    recursion_dict = handle_recursion_g(obj, TT, new_array, recursive, rec_dict)
+    recursion_dict = handle_recursion((obj, TT), new_array, recursive, rec_dict)
     for i = 1:len_list
         if islist
             current_obj = ElmList(obj, i)  # returns 'nothing' for holes in the list
@@ -136,7 +136,7 @@ function gap_to_julia_internal(
 
     elm = Wrappers.ELM_MAT
     new_array = TT(undef, nrows, ncols)
-    recursion_dict = handle_recursion_g(obj, TT, new_array, recursive, rec_dict)
+    recursion_dict = handle_recursion((obj, TT), new_array, recursive, rec_dict)
 
     for i = 1:nrows, j = 1:ncols
         current_obj = elm(obj, i, j)
@@ -185,7 +185,7 @@ function gap_to_julia_internal(
         end
     end
     ret_val = TT(new_array)
-    handle_recursion_g(obj, TT, ret_val, recursive, rec_dict)
+    handle_recursion((obj, TT), ret_val, recursive, rec_dict)
     return ret_val
 end
 
@@ -214,7 +214,7 @@ function gap_to_julia_internal(
     ]
 
     ret_val = T(list)
-    recursion_dict = handle_recursion_g(obj, T, ret_val, recursive, rec_dict)
+    recursion_dict = handle_recursion((obj, TT), ret_val, recursive, rec_dict)
     return ret_val
 end
 
@@ -231,7 +231,7 @@ function gap_to_julia_internal(
 
     !Wrappers.IsRecord(obj) && throw(ConversionError(obj, TT))
     dict = TT()
-    recursion_dict = handle_recursion_g(obj, TT, dict, recursive, rec_dict)
+    recursion_dict = handle_recursion((obj, TT), dict, recursive, rec_dict)
 
     names = Wrappers.RecNames(obj)
     names_list = Vector{Symbol}(names)

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -153,10 +153,6 @@ function gap_to_julia_internal(
 end
 
 ## Sets
-## Assume that the argument `obj` of this function is not self-referential,
-## for example we cannot really sort a self-referential GAP list.
-## Then we need not worry about creating the result in the end,
-## and then adding it to the dictionary that is needed for the recursion.
 function gap_to_julia_internal(
     TT::Type{Set{T}},
     obj::GapObj,

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -86,7 +86,6 @@ function gap_to_julia_internal(
         islist = true
     elseif Wrappers.IsVectorObj(obj)
         islist = false
-        ELM_LIST = Wrappers.ELM_LIST
     else
         throw(ConversionError(obj, TT))
     end
@@ -100,7 +99,7 @@ function gap_to_julia_internal(
         else
             # vector objects aren't lists,
             # but the function for accessing entries is `ELM_LIST`
-            current_obj = ELM_LIST(obj, i)
+            current_obj = Wrappers.ELM_LIST(obj, i)
         end
         if recursive && !isbitstype(typeof(current_obj))
             new_array[i] =

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -453,6 +453,8 @@ It just delegates to `gap_to_julia`.
 Its purpose is to turn the `recursive` argument into a keyword argument,
 which is easier in Julia than in GAP.
 """
+function _gap_to_julia end
+
 _gap_to_julia(x::Obj) = gap_to_julia(x)
 _gap_to_julia(::Type{T}, x::Obj) where {T} = gap_to_julia(T, x)
 _gap_to_julia(::Type{T}, x::Obj, recursive::Bool) where {T} =
@@ -465,4 +467,3 @@ _gap_to_julia(x::GapObj, recursive::Bool) = gap_to_julia(x; recursive)
 _gap_to_julia(x::Bool, recursive::Bool) = x
 _gap_to_julia(x::Int, recursive::Bool) = x
 _gap_to_julia(x::FFE, recursive::Bool) = x
-

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -105,7 +105,7 @@ function gap_to_julia_internal(
         end
         if recursive && !isbitstype(typeof(current_obj))
             ret_val[i] =
-                gap_to_julia_internal(T, current_obj, recursion_dict, Val(recursive))
+                gap_to_julia_internal(T, current_obj, recursion_dict, BoolVal(recursive))
         else
             ret_val[i] = current_obj
         end
@@ -144,7 +144,7 @@ function gap_to_julia_internal(
         current_obj = elm(obj, i, j)
         if recursive && !isbitstype(typeof(current_obj))
             ret_val[i, j] =
-                gap_to_julia_internal(T, current_obj, recursion_dict, Val(recursive))
+                gap_to_julia_internal(T, current_obj, recursion_dict, BoolVal(recursive))
         else
             ret_val[i, j] = current_obj
         end
@@ -179,7 +179,7 @@ function gap_to_julia_internal(
     for i = 1:length(newobj)
         current_obj = ElmList(newobj, i)
         if recursive && !isbitstype(typeof(current_obj))
-            push!(ret_val, gap_to_julia_internal(T, current_obj, rec_dict, Val(recursive)))
+            push!(ret_val, gap_to_julia_internal(T, current_obj, rec_dict, BoolVal(recursive)))
         else
             push!(ret_val, current_obj)
         end
@@ -210,7 +210,7 @@ function gap_to_julia_internal(
     rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
 
     list = [
-        gap_to_julia_internal(parameters[i], obj[i], rec_dict, Val(recursive))
+        gap_to_julia_internal(parameters[i], obj[i], rec_dict, BoolVal(recursive))
         for i = 1:len
     ]
 
@@ -272,7 +272,7 @@ function gap_to_julia_internal(
     (obj isa T) && !recursive && return obj
     D, rec = _default_type(obj, recursive)
     (D === T || !(D <: T)) && throw(ConversionError(obj, T))
-    return gap_to_julia_internal(D, obj, recursion_dict, Val(rec))
+    return gap_to_julia_internal(D, obj, recursion_dict, BoolVal(rec))
   else
     (obj isa T) && return obj
     throw(ConversionError(obj, T))
@@ -371,7 +371,7 @@ function gap_to_julia end
 gap_to_julia(x::Bool) = x
 gap_to_julia(x::Int) = x
 gap_to_julia(x::FFE) = x
-gap_to_julia(T::Type, x::Any; recursive::Bool = true) = gap_to_julia_internal(T, x, nothing, Val(recursive))
+gap_to_julia(T::Type, x::Any; recursive::Bool = true) = gap_to_julia_internal(T, x, nothing, BoolVal(recursive))
 gap_to_julia(::Type{Any}, x::Any; recursive::Bool = true) = x
 gap_to_julia(::T, x::Nothing; recursive::Bool = true) where {T<:Type} = nothing
 gap_to_julia(::Type{Any}, x::Nothing; recursive::Bool = true) = nothing
@@ -396,7 +396,7 @@ end
 function gap_to_julia(x::GapObj; recursive::Bool = true)
   T, recursive = _default_type(x, recursive)
   T == Any && throw(ConversionError(x, "any known type"))
-  return gap_to_julia_internal(T, x, nothing, Val(recursive))
+  return gap_to_julia_internal(T, x, nothing, BoolVal(recursive))
 end
 
 

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -204,14 +204,15 @@ function gap_to_julia_internal(
 
     !Wrappers.IsList(obj) && throw(ConversionError(obj, T))
 
-    recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
-    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
-
     # extract the Tuple parameters, i.e. from Tuple{T1, T2, ...}  the list T1,T2,...
     parameters = T.parameters
     len = length(parameters)
     length(obj) == len ||
         throw(ArgumentError("length of $obj does not match type $T"))
+
+    recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
+    rec_dict = recursion_info_j(TT, obj, recursive, recursion_dict)
+
     list = [
         gap_to_julia_internal(parameters[i], obj[i], rec_dict, Val(recursive))
         for i = 1:len

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -172,8 +172,7 @@ function GapObj_internal(
     len = length(obj)
     ret_val = NewPlist(len)
 
-    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
-    recursion_dict = handle_recursion(obj, ret_val, rec, rec_dict)
+    recursion_dict = recursion_info_g(T, obj, ret_val, recursive, recursion_dict)
 
     # Set the subobjects.
     for i = 1:len
@@ -181,15 +180,7 @@ function GapObj_internal(
         if x === nothing
             continue
         end
-        if recursive
-            # Convert the subobjects.
-            # Do not care about findíng them in the dictionary
-            # or adding them to the dictionary,
-            # since their conversion method decides about that.
-            res = GAP.GapObj_internal(x, recursion_dict, Val(true))
-        else
-            res = x
-        end
+        res = recursive ? GapObj_internal(x, recursion_dict, Val(true)) : x
         ret_val[i] = res
     end
 
@@ -207,15 +198,10 @@ function GapObj_internal(
 
     ret_val = NewPlist(length(obj))
 
-    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
-    recursion_dict = handle_recursion(obj, ret_val, rec, rec_dict)
+    recursion_dict = recursion_info_g(T, obj, ret_val, recursive, recursion_dict)
 
     for x in obj
-        if recursive
-            res = GapObj_internal(x, recursion_dict, Val(true))
-        else
-            res = x
-        end
+        res = recursive ? GapObj_internal(x, recursion_dict, Val(true)) : x
         Wrappers.Add(ret_val, res)
     end
     Wrappers.Sort(ret_val)
@@ -236,8 +222,7 @@ function GapObj_internal(
     rows = size(obj, 1)
     ret_val = NewPlist(rows)
 
-    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
-    recursion_dict = handle_recursion(obj, ret_val, rec, rec_dict)
+    recursion_dict = recursion_info_g(T, obj, ret_val, recursive, recursion_dict)
 
     for i = 1:rows
         ret_val[i] = GapObj_internal(obj[i, :], recursion_dict, Val(recursive))
@@ -273,16 +258,11 @@ function GapObj_internal(
 
     ret_val = NewPrecord(0)
 
-    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
-    recursion_dict = handle_recursion(obj, ret_val, rec, rec_dict)
+    recursion_dict = recursion_info_g(T, obj, ret_val, recursive, recursion_dict)
 
     for (x, y) in obj
         x = Wrappers.RNamObj(MakeString(string(x)))
-        if recursive
-            res = GapObj_internal(y, recursion_dict, Val(true))
-        else
-            res = y
-        end
+        res = recursive ? GapObj_internal(y, recursion_dict, Val(true)) : y
         Wrappers.ASS_REC(ret_val, x, res)
     end
 

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -81,7 +81,7 @@ The following `GapObj` conversions are supported by GAP.jl.
 | `UnitRange{T}`, `StepRange{T, S}`    | `IsRange`    |
 | `Function`                           | `IsFunction` |
 """
-GapObj(x, cache::GapCacheDict = nothing; recursive::Bool = false) = GapObj_internal(x, cache, Val(recursive))
+GapObj(x, cache::GapCacheDict = nothing; recursive::Bool = false) = GapObj_internal(x, cache, BoolVal(recursive))
 
 # The calls to `GAP.@install` install methods for `GAP.GapObj_internal`
 # so we must make sure it is declared before
@@ -143,8 +143,8 @@ function GapObj_internal(x::Rational{T}, cache::GapCacheDict, ::Val{recursive}) 
             return -Globals.infinity
         end
     end
-    numer = GapObj_internal(numer_julia, cache, Val(recursive))
-    denom = GapObj_internal(denom_julia, cache, Val(recursive))
+    numer = GapObj_internal(numer_julia, cache, BoolVal(recursive))
+    denom = GapObj_internal(denom_julia, cache, BoolVal(recursive))
     return Wrappers.QUO(numer, denom)
 end
 
@@ -225,7 +225,7 @@ function GapObj_internal(
     recursion_dict = recursion_info_g(T, obj, ret_val, recursive, recursion_dict)
 
     for i = 1:rows
-        ret_val[i] = GapObj_internal(obj[i, :], recursion_dict, Val(recursive))
+        ret_val[i] = GapObj_internal(obj[i, :], recursion_dict, BoolVal(recursive))
     end
     return ret_val
 end
@@ -237,7 +237,7 @@ function GapObj_internal(
     ::Val{recursive},
 ) where recursive
     array = collect(Any, obj)
-    return GapObj_internal(array, recursion_dict, Val(recursive))
+    return GapObj_internal(array, recursion_dict, BoolVal(recursive))
 end
 
 ## Ranges
@@ -294,7 +294,7 @@ function GapObj_internal(
         recursion_dict[obj] = ret_val
         for i = 1:len
             x = obj[i]
-            ret_val[i] = GapObj_internal(x, recursion_dict::RecDict_g, Val(recursive))
+            ret_val[i] = GapObj_internal(x, recursion_dict::RecDict_g, BoolVal(recursive))
         end
     elseif Wrappers.IsRecord(obj)
         ret_val = NewPrecord(0)
@@ -306,7 +306,7 @@ function GapObj_internal(
         for xx in Wrappers.RecNames(obj)::GapObj
             x = Wrappers.RNamObj(xx)
             y = Wrappers.ELM_REC(obj, x)
-            res = GapObj_internal(y, recursion_dict::RecDict_g, Val(recursive))
+            res = GapObj_internal(y, recursion_dict::RecDict_g, BoolVal(recursive))
             Wrappers.ASS_REC(ret_val, x, res)
         end
     else

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -9,17 +9,6 @@
 ##  SPDX-License-Identifier: LGPL-3.0-or-later
 ##
 
-"""
-    RecDict_g = IdDict{Any,Any}
-
-An internal type of GAP.jl used for tracking conversion results in `julia_to_gap`.
-The value stored at the key `obj` is the result
-of the Julia to GAP conversion of `obj`.
-"""
-const RecDict_g = IdDict{Any,Any}
-
-const GapCacheDict = Union{Nothing,RecDict_g}
-
 
 ## Converters
 """
@@ -170,26 +159,6 @@ GAP.@install GapObj(x::Char) = CharWithValue(Cuchar(x))
 ## Strings and symbols
 GAP.@install GapObj(x::AbstractString) = MakeString(string(x))
 GAP.@install GapObj(x::Symbol) = MakeString(string(x))
-
-# helper functions for recursion (conversion from Julia to GAP)
-function recursion_info_g(::Type{T}, obj, recursive::Bool, recursion_dict::GapCacheDict) where {T}
-    rec = recursive && _needs_tracking_julia_to_gap(T)
-    if rec && recursion_dict === nothing
-        rec_dict = RecDict_g()
-    else
-        rec_dict = recursion_dict
-    end
-
-    return rec, rec_dict
-end
-
-function handle_recursion(obj, ret_val, rec::Bool, rec_dict::GapCacheDict)
-    if rec_dict !== nothing
-        # We assume that `obj` is not yet cached.
-        rec_dict[obj] = ret_val
-    end
-    return rec ? rec_dict : nothing
-end
 
 ## Arrays (including BitVector)
 function GapObj_internal(

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -10,9 +10,11 @@
 ##
 
 """
-    RecDict_g
+    RecDict_g = IdDict{Any,Any}
 
 An internal type of GAP.jl used for tracking conversion results in `julia_to_gap`.
+The value stored at the key `obj` is the result
+of the Julia to GAP conversion of `obj`.
 """
 const RecDict_g = IdDict{Any,Any}
 
@@ -170,7 +172,7 @@ GAP.@install GapObj(x::AbstractString) = MakeString(string(x))
 GAP.@install GapObj(x::Symbol) = MakeString(string(x))
 
 # helper functions for recursion (conversion from Julia to GAP)
-function recursion_info_j(::Type{T}, obj, recursive::Bool, recursion_dict::GapCacheDict) where {T}
+function recursion_info_g(::Type{T}, obj, recursive::Bool, recursion_dict::GapCacheDict) where {T}
     rec = recursive && _needs_tracking_julia_to_gap(T)
     if rec && recursion_dict === nothing
         rec_dict = RecDict_g()
@@ -183,6 +185,7 @@ end
 
 function handle_recursion(obj, ret_val, rec::Bool, rec_dict::GapCacheDict)
     if rec_dict !== nothing
+        # We assume that `obj` is not yet cached.
         rec_dict[obj] = ret_val
     end
     return rec ? rec_dict : nothing
@@ -196,7 +199,7 @@ function GapObj_internal(
 ) where {T, recursive}
 
     recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && return recursion_dict[obj]
-    rec, rec_dict = recursion_info_j(T, obj, recursive, recursion_dict)
+    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
 
     len = length(obj)
     ret_val = NewPlist(len)
@@ -232,7 +235,7 @@ function GapObj_internal(
 ) where {T, recursive}
 
     recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && return recursion_dict[obj]
-    rec, rec_dict = recursion_info_j(T, obj, recursive, recursion_dict)
+    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
 
     ret_val = NewPlist(length(obj))
 
@@ -260,7 +263,7 @@ function GapObj_internal(
 ) where {T, recursive}
 
     recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && return recursion_dict[obj]
-    rec, rec_dict = recursion_info_j(T, obj, recursive, recursion_dict)
+    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
 
     rows = size(obj, 1)
     ret_val = NewPlist(rows)
@@ -298,7 +301,7 @@ function GapObj_internal(
 ) where {T, S<:Union{Symbol,AbstractString}, recursive}
 
     recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && return recursion_dict[obj]
-    rec, rec_dict = recursion_info_j(T, obj, recursive, recursion_dict)
+    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
 
     ret_val = NewPrecord(0)
 

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -168,11 +168,11 @@ function GapObj_internal(
 ) where {T, recursive}
 
     recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && return recursion_dict[obj]
-    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
 
     len = length(obj)
     ret_val = NewPlist(len)
 
+    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
     recursion_dict = handle_recursion(obj, ret_val, rec, rec_dict)
 
     # Set the subobjects.
@@ -204,10 +204,10 @@ function GapObj_internal(
 ) where {T, recursive}
 
     recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && return recursion_dict[obj]
-    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
 
     ret_val = NewPlist(length(obj))
 
+    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
     recursion_dict = handle_recursion(obj, ret_val, rec, rec_dict)
 
     for x in obj
@@ -232,11 +232,11 @@ function GapObj_internal(
 ) where {T, recursive}
 
     recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && return recursion_dict[obj]
-    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
 
     rows = size(obj, 1)
     ret_val = NewPlist(rows)
 
+    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
     recursion_dict = handle_recursion(obj, ret_val, rec, rec_dict)
 
     for i = 1:rows
@@ -270,10 +270,10 @@ function GapObj_internal(
 ) where {T, S<:Union{Symbol,AbstractString}, recursive}
 
     recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && return recursion_dict[obj]
-    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
 
     ret_val = NewPrecord(0)
 
+    rec, rec_dict = recursion_info_g(T, obj, recursive, recursion_dict)
     recursion_dict = handle_recursion(obj, ret_val, rec, rec_dict)
 
     for (x, y) in obj

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -180,7 +180,7 @@
     y = Tuple{GAP.Obj,Any}(x; recursive = false)
     @test isa(y, Tuple)
     @test isa(y[1], GAP.Obj)
-    @test isa(y[2], Array)
+#   @test isa(y[2], Array)
     @test isa(y[2][2], GAP.Obj)
   end
 

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -12,6 +12,9 @@
 @testset "conversion from GAP" begin
 
   @testset "Defaults" begin
+    @test GAP.gap_to_julia(true) == true
+    @test GAP.gap_to_julia(1) == 1
+    @test GAP.gap_to_julia(Z(3)) == Z(3)
     @test GAP.gap_to_julia(Any, true) == true
     @test GAP.gap_to_julia(GAP.Obj, true) == true
     @test GAP.gap_to_julia(Any, "foo") == "foo"
@@ -196,6 +199,8 @@
     x = GAP.evalstr("[ Z(2), Z(3) ]")  # a non-collection
     y = [GAP.evalstr("Z(2)"), GAP.evalstr("Z(3)")]
     #@test GAP.gap_to_julia(Set{GAP.FFE}, x) == Set(y)
+    @test GAP.gap_to_julia(Set{Int}, GAP.evalstr("[ 1, true ]")) == Set([1, true])
+    @test_throws GAP.ConversionError GAP.gap_to_julia(Set{Int}, GAP.evalstr("rec( 1:= 1 )"))
   end
 
   @testset "Tuples" begin
@@ -257,9 +262,17 @@
     @test isa(y[:b], GAP.Obj)
   end
 
+  @testset "Julia Functions" begin
+    @test GAP.gap_to_julia(GAP.Globals.Julia.sqrt) === sqrt
+    @test_throws GAP.ConversionError GAP.gap_to_julia(Function, 1)
+  end
+
   @testset "Default" begin
     x = GAP.evalstr("(1,2,3)")
     @test_throws GAP.ConversionError GAP.gap_to_julia(x)
+    @test_throws GAP.ConversionError GAP.gap_to_julia(Int, (1, 2))
+    @test GAP.gap_to_julia(Nothing, nothing) == nothing
+    @test GAP.gap_to_julia(Any, nothing) == nothing
   end
 
   @testset "Conversions involving circular references" begin

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -155,6 +155,9 @@
     x = GAP.evalstr( "NewVector( IsPlistVectorRep, Integers, [ 0, 2, 5 ] )" )
     @test GAP.gap_to_julia(x) == Vector{Any}([0, 2, 5])
     @test GAP.gap_to_julia(Vector{Int}, x) == Vector{Int}([0, 2, 5])
+    x = GAP.evalstr( "[ [ 1, 2 ], ~[1] ]" )
+    y = GAP.gap_to_julia(Vector{Set{Int}}, x; recursive = true)
+    @test y[1] === y[2]
   end
 
   @testset "Matrices" begin
@@ -211,7 +214,7 @@
     y = GAP.gap_to_julia(Tuple{GAP.Obj,Any}, x; recursive = false)
     @test isa(y, Tuple)
     @test isa(y[1], GAP.Obj)
-    @test isa(y[2], Array)
+    @test isa(y[2], GapObj)
     @test isa(y[2][2], GAP.Obj)
   end
 
@@ -277,7 +280,7 @@
 
   @testset "Catch conversions to types that are not supported" begin
     xx = GapObj("a")
-    @test_throws ErrorException GAP.gap_to_julia(Dict{Int64,Int64}, xx)
+    @test_throws GAP.ConversionError GAP.gap_to_julia(Dict{Int64,Int64}, xx)
   end
 
   @testset "Test converting GAP lists with holes in them" begin

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -14,7 +14,7 @@
   @testset "Defaults" begin
     @test GAP.gap_to_julia(true) == true
     @test GAP.gap_to_julia(1) == 1
-    @test GAP.gap_to_julia(Z(3)) == Z(3)
+    @test GAP.gap_to_julia(GAP.Globals.Z(3)) == GAP.Globals.Z(3)
     @test GAP.gap_to_julia(Any, true) == true
     @test GAP.gap_to_julia(GAP.Obj, true) == true
     @test GAP.gap_to_julia(Any, "foo") == "foo"


### PR DESCRIPTION
- Introduce an internal function `gap_to_julia_internal` for which the (perhaps recursive) methods get installed that do the work.
- Delegate from `gap_to_julia` to `gap_to_julia_internal`.
- Introduce a new object type for caching objects and their Julia types, in order to keep the relation between identical objects. Create these objects only if they are needed.
- Rename some internal types, in order to distinguish between the two conversion directions. We need different objects for bookkeeping in recursive situations.

Due to the changes, there are no "back delegations" anymore. The behaviour changed slightly:

- One test has a different result now, I think the new result is better.
- The method for converting GAP objects to Julia `Set`s was wrong w.r.t. the identity objects in recursive situations; a new test shows the difference.

The changes are breaking in the sense that new methods for GAP to Julia conversion shall now get installed for `gap_to_julia_internal` not for `gap_to_julia`.

addresses #1089