### PR TITLE
Version 0.15.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes in GAP.jl
 
-## Version 0.15.0-DEV (released 2025-XX-XX)
+## Version 0.15.0 (released 2025-08-26)
 
 - Drop support for Julia 1.6 to 1.9; require Julia 1.10 or later.
 - **Breaking:** Remove `julia_to_gap` (code which called it, say as

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GAP"
 uuid = "c863536a-3901-11e9-33e7-d5cd0df7b904"
 authors = ["Thomas Breuer <sam@math.rwth-aachen.de>", "Sebastian Gutsche <gutsche@mathematik.uni-siegen.de>", "Max Horn <horn@mathematik.uni-kl.de>"]
-version = "0.15.0-DEV"
+version = "0.15.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/gap/systemfile.g
+++ b/gap/systemfile.g
@@ -33,7 +33,7 @@ end);
     # early enough for being required by other GAP packages,
     # and such that it is available when user files get read
     # via the GAP command line.
-    deps := [ [ "JuliaInterface", ">=0.15.0-DEV" ] ];
+    deps := [ [ "JuliaInterface", ">=0.15.0" ] ];
     if not IsBound(GAPInfo.KernelInfo.ENVIRONMENT.GAP_BARE_DEPS) then
         APPEND_LIST_INTR( deps, GAPInfo.Dependencies.NeededOtherPackages );
     fi;

--- a/pkg/JuliaExperimental/PackageInfo.g
+++ b/pkg/JuliaExperimental/PackageInfo.g
@@ -17,8 +17,8 @@ SetPackageInfo( rec(
 
 PackageName := "JuliaExperimental",
 Subtitle := "Experimental code for the GAP Julia integration",
-Version := "0.15.0-DEV",
-Date := "14/07/2025", # dd/mm/yyyy format
+Version := "0.15.0",
+Date := "26/08/2025", # dd/mm/yyyy format
 License := "LGPL-3.0-or-later",
 
 Persons := [

--- a/pkg/JuliaInterface/PackageInfo.g
+++ b/pkg/JuliaInterface/PackageInfo.g
@@ -18,8 +18,8 @@ SetPackageInfo( rec(
 
 PackageName := "JuliaInterface",
 Subtitle := "Interface to Julia",
-Version := "0.15.0-DEV",
-Date := "14/07/2025", # dd/mm/yyyy format
+Version := "0.15.0",
+Date := "26/08/2025", # dd/mm/yyyy format
 License := "LGPL-3.0-or-later",
 
 Persons := [


### PR DESCRIPTION
This is a draft for now, until the matching downstream tests in https://github.com/oscar-system/GAP.jl/pull/1231 succeed (https://github.com/oscar-system/GAP.jl/actions/runs/17205185302/job/48804190317?pr=1231). Once that is done, I'll go ahead with the release, making a Hecke compat PR, ...