### PR TITLE
Fix conversion calls in Oscar

### DIFF
--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -271,7 +271,6 @@ function gap_to_julia_internal(
   if obj isa GapObj
     (obj isa T) && !recursive && return obj
     D, rec = _default_type(obj, recursive)
-    (D === T || !(D <: T)) && throw(ConversionError(obj, T))
     return gap_to_julia_internal(D, obj, recursion_dict, BoolVal(rec))
   else
     (obj isa T) && return obj


### PR DESCRIPTION
The concrete line that failed was https://github.com/oscar-system/Oscar.jl/blob/39afcf98cfb029e580a161de7f9eb9d119b758b9/test/Groups/pcgroup.jl#L141 which then called https://github.com/oscar-system/Oscar.jl/blob/70e2bf86ccf6abf1262f647dc4adb835008e27f7/src/Groups/pcgroup.jl#L893, which finally failed in the line that is removed here, due to `Any` not being a subtype of `Union{Nothing, GapObj}`. I don't understand enough of the surrounding code to suggest a proper fix, but just removing this line seems to work fine. In cases where conversion is indeed not possible, there will be another exception thrown at a later point when trying to convert the elements themselves.

I tested all of Oscar's `test/GAP/` and `test/Groups/` with this, and with this PR here, it succeeds.