### PR TITLE
fix `GAP.Packages.versioninfo`

### DIFF
--- a/src/packages.jl
+++ b/src/packages.jl
@@ -560,15 +560,20 @@ function versioninfo(io::IO = stdout; GAP::Bool = false, jll::Bool = false, full
     name = String(key)
     push!(names, name)
     vals = dict[key]
-    path = replace(realpath(vals[1]), default_artifacts_path => "ARTIFACTS")
-    if startswith(path, "ARTIFACTS")
-      pos = findall("/", path)
-      if length(pos) > 1 && pos[2][1]-pos[1][1] > 10
-        path = path[1:(pos[1][1]+7)] * "..." * path[pos[2][1]:end]
+    if ispath(vals[1])
+      path = replace(realpath(vals[1]), default_artifacts_path => "ARTIFACTS")
+      if startswith(path, "ARTIFACTS")
+        pos = findall("/", path)
+        if length(pos) > 1 && pos[2][1]-pos[1][1] > 10
+          path = path[1:(pos[1][1]+7)] * "..." * path[pos[2][1]:end]
+        end
       end
+      push!(paths, path)
+      push!(versions, vals[2])
+    else
+      push!(paths, "($(vals[1])) -- loaded but not existing")
+      push!(versions, "")
     end
-    push!(paths, path)
-    push!(versions, vals[2])
   end
   namewidth = maximum(length.(names)) + 2
   verswidth = maximum(length.(versions)) + 2

--- a/test/packages.jl
+++ b/test/packages.jl
@@ -26,6 +26,7 @@
     @test GAP.Packages.install("https://github.com/gap-packages/RegisterPackageTNUMDemo/releases/download/v0.4/RegisterPackageTNUMDemo-0.4.tar.gz", interactive = false)
     @test GAP.Packages.load("RegisterPackageTNUMDemo")
     @test GAP.Packages.remove("RegisterPackageTNUMDemo", interactive = false)
+    GAP.Packages.versioninfo(IOBuffer(); full = true)
 
 #    pkgdir = mktempdir()
 #    @test GAP.Packages.install("fga", interactive = false, pkgdir = pkgdir)

--- a/test/packages.jl
+++ b/test/packages.jl
@@ -26,7 +26,7 @@
     @test GAP.Packages.install("https://github.com/gap-packages/RegisterPackageTNUMDemo/releases/download/v0.4/RegisterPackageTNUMDemo-0.4.tar.gz", interactive = false)
     @test GAP.Packages.load("RegisterPackageTNUMDemo")
     @test GAP.Packages.remove("RegisterPackageTNUMDemo", interactive = false)
-    GAP.Packages.versioninfo(IOBuffer(); full = true)
+    GAP.Packages.versioninfo(IOBuffer(); full = true) # test that this does not error, see #1246
 
 #    pkgdir = mktempdir()
 #    @test GAP.Packages.install("fga", interactive = false, pkgdir = pkgdir)


### PR DESCRIPTION
It may happen that a GAP package is loaded but its directory does not exist.

For example, our test that installs/loads/removes a package creates such a GAP session.
Calling `GAP.Packages.versioninfo` afterwards ran into an error up to now.