### PR TITLE
in `create_gap_sh(dstdir)`, call `expanduser(dstdir)`

### DIFF
--- a/src/setup.jl
+++ b/src/setup.jl
@@ -245,6 +245,7 @@ Given a directory path, create three files in that directory:
 """
 function create_gap_sh(dstdir::String; use_active_project::Bool=false)
 
+    dstdir = expanduser(dstdir)
     mkpath(dstdir)
 
     if use_active_project


### PR DESCRIPTION
For convenience, support paths relative to the home directory.