### PR TITLE
Prepare juliainterface for GAP 4.15

### DIFF
--- a/pkg/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/JuliaInterface/src/JuliaInterface.c
@@ -16,7 +16,11 @@
 #include "convert.h"
 #include "sync.h"
 
+// With gap 4.15, the header julia_gc.h is available through gap_all.h.
+// To still support GAP 4.14, we include it conditionally.
+#ifndef GAP_JULIA_GC_H
 #include <julia_gc.h>    // GAP header
+#endif
 
 #include <julia_gcext.h>    // Julia header
 


### PR DESCRIPTION
Alternative to most parts of https://github.com/oscar-system/GAP.jl/pull/1239 (as discussed today with @fingolfin).

We should merge this PR asap, as the juliainterface code is now compatible with both gap 4.14 and 4.15. Therefore, the circular dependency mentioned in https://github.com/oscar-system/GAP.jl/pull/1244#issue-3395007341 (point 6) should no longer be there.

I would suggest that we merge this, and then I will try to do all the rebuilds with this against the gap beta3 (which hopefully contains https://github.com/gap-system/gap/pull/6124)