### PR TITLE
Remove remnants from gap pkg `toricvarieties`

### DIFF
--- a/.github/workflows/CI-distro.yml
+++ b/.github/workflows/CI-distro.yml
@@ -76,7 +76,6 @@ jobs:
           - gap-package: 'profiling'                  # segfaults during testing
           - gap-package: 'ringsforhomalg'             # `Error, found no GAP executable in PATH`
           - gap-package: 'smallclassnr'               # tests pass, but the job fails. Needs to be investigated further
-          - gap-package: 'toricvarieties'             # random segfaults during testing
           - gap-package: 'xgap'                       # no jll
 
     steps:


### PR DESCRIPTION
Since it has been removed from the gap distro, see https://github.com/gap-system/gap/blob/09dc1f04f62c00062b2d8bf59d6de89d82783ad1/CHANGES.md?plain=1#L101