### PR TITLE
Fix handling of `GapExitCode` in `GAP.Packages.test`

### DIFF
--- a/.github/workflows/CI-distro.yml
+++ b/.github/workflows/CI-distro.yml
@@ -75,7 +75,6 @@ jobs:
           - gap-package: 'polymaking'                 # `polymake command not found. Please set POLYMAKE_COMMAND by hand`
           - gap-package: 'profiling'                  # segfaults during testing
           - gap-package: 'ringsforhomalg'             # `Error, found no GAP executable in PATH`
-          - gap-package: 'smallclassnr'               # tests pass, but the job fails. Needs to be investigated further
           - gap-package: 'toricvarieties'             # random segfaults during testing
           - gap-package: 'xgap'                       # no jll
 

--- a/.github/workflows/CI-distro.yml
+++ b/.github/workflows/CI-distro.yml
@@ -80,8 +80,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - name: "Install PARI/GP"   # for alnuth, and thus guarana, polenta, radiroot
-        if: matrix.gap-package == 'alnuth' || matrix.gap-package == 'guarana' || matrix.gap-package == 'polenta' || matrix.gap-package == 'radiroot'
+      - name: "Install PARI/GP"   # for alnuth, and thus guarana, polenta, radiroot, twistedconjugacy
+        if: matrix.gap-package == 'alnuth' || matrix.gap-package == 'guarana' || matrix.gap-package == 'polenta' || matrix.gap-package == 'radiroot' || matrix.gap-package == 'twistedconjugacy'
         run: |
           sudo apt-get update
           sudo apt-get install pari-gp

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
   `GAP.GapObj_internal` and does not involve cals to `GapObj`.
   We had always stated in the documentation that users should not enter
   this argument because it gets created automatically in recursive conversions.
+- Fix `GAP.Packages.test` to work correctly when the package to be tested
+  quits GAP with a boolean exit code.
 
 ## Version 0.15.3 (released 2025-09-24)
 

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -501,7 +501,7 @@ function test(name::String)
   function fake_QuitGap(code)
     called_QuitGap && return # only do something on the first call
     called_QuitGap = true
-    if code != 0
+    if (code isa Bool && !code) || (code isa Int && code % 256 != 0)
       error_occurred = true
     end
     return


### PR DESCRIPTION
This now matches the description of `GapExitCode` at https://docs.gap-system.org/doc/ref/chap6_mj.html#X838B50A9790DE55B.

This fixed the `smallclassnr` test job, but unveiled an issue with `twistedconjugacy` (which is also fixed in this PR).