### PR TITLE
Add `GAP.@include` macro

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
   `GAP.GapObj_internal` and does not involve cals to `GapObj`.
   We had always stated in the documentation that users should not enter
   this argument because it gets created automatically in recursive conversions.
+- Add `GAP.@include(filepath)` as a counterpart to julia's `include(filepath)`,
+  for reading GAP files into the GAP session.
 - Fix `GAP.Packages.test` to work correctly when the package to be tested
   quits GAP with a boolean exit code.
 

--- a/docs/src/other.md
+++ b/docs/src/other.md
@@ -10,6 +10,7 @@ DocTestSetup = :(using GAP)
 ```@docs
 @gap
 @g_str
+GAP.@include
 @gapwrap
 @gapattribute
 @wrap

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -53,6 +53,18 @@ const GAP_VERSION = VersionNumber(sysinfo["GAP_VERSION"])
 
 include("types.jl")
 
+"""
+    GAP.@include(path)
+
+Read and execute the GAP code in the file at `path`,
+which is interpreted as a relative path relative to the file where this macro is used.
+This is similar to julia's built-in `include` function,
+but for GAP code instead of Julia code.
+"""
+macro include(path)
+    return :(Wrappers.Read(GapObj(normpath(@__DIR__, $path))))
+end
+
 const last_error = Ref{String}("")
 
 const disable_error_handler = Ref{Bool}(false)
@@ -202,7 +214,7 @@ function initialize(argv::Vector{String})
     end
 
     # Redirect error messages, in order not to print them to the screen.
-    GAP.Globals.Read(GapObj(joinpath(@__DIR__, "..", "gap", "err.g")))
+    GAP.@include("../gap/err.g")
     @debug "finished reading gap/err.g"
 
     return nothing


### PR DESCRIPTION
Resolves https://github.com/oscar-system/GAP.jl/issues/940.