### PR TITLE
Version 0.15.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes in GAP.jl
 
-## Version 0.15.4 (released 2025-XX-XX)
+## Version 0.15.4 (released 2025-10-15)
 
 - Improve compatibility with latest Julia nightly builds.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GAP"
 uuid = "c863536a-3901-11e9-33e7-d5cd0df7b904"
 authors = ["Thomas Breuer <sam@math.rwth-aachen.de>", "Sebastian Gutsche <gutsche@mathematik.uni-siegen.de>", "Max Horn <horn@mathematik.uni-kl.de>"]
-version = "0.15.3"
+version = "0.15.4"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/gap/systemfile.g
+++ b/gap/systemfile.g
@@ -33,7 +33,7 @@ end);
     # early enough for being required by other GAP packages,
     # and such that it is available when user files get read
     # via the GAP command line.
-    deps := [ [ "JuliaInterface", ">=0.15.3" ] ];
+    deps := [ [ "JuliaInterface", ">=0.15.4" ] ];
     if not IsBound(GAPInfo.KernelInfo.ENVIRONMENT.GAP_BARE_DEPS) then
         APPEND_LIST_INTR( deps, GAPInfo.Dependencies.NeededOtherPackages );
     fi;

--- a/pkg/JuliaExperimental/PackageInfo.g
+++ b/pkg/JuliaExperimental/PackageInfo.g
@@ -17,8 +17,8 @@ SetPackageInfo( rec(
 
 PackageName := "JuliaExperimental",
 Subtitle := "Experimental code for the GAP Julia integration",
-Version := "0.15.3",
-Date := "24/09/2025", # dd/mm/yyyy format
+Version := "0.15.4",
+Date := "15/10/2025", # dd/mm/yyyy format
 License := "LGPL-3.0-or-later",
 
 Persons := [

--- a/pkg/JuliaInterface/PackageInfo.g
+++ b/pkg/JuliaInterface/PackageInfo.g
@@ -18,8 +18,8 @@ SetPackageInfo( rec(
 
 PackageName := "JuliaInterface",
 Subtitle := "Interface to Julia",
-Version := "0.15.3",
-Date := "24/09/2025", # dd/mm/yyyy format
+Version := "0.15.4",
+Date := "15/10/2025", # dd/mm/yyyy format
 License := "LGPL-3.0-or-later",
 
 Persons := [


### PR DESCRIPTION
I backported #1267 to the release-0.15 branch to let the latest GAP.jl release pass nanosoldier again, so that the julia devs at least have a chance to see that they break our code.
This PR just bumps the version number on top of this.