### PR TITLE
Add Hecke to OscarCI

### DIFF
--- a/OscarCI.toml
+++ b/OscarCI.toml
@@ -9,8 +9,12 @@ title = "metadata for oscar CI run"
   [pkgs.Oscar]
   test = true
 
-#[include]
-#  [include.julia]
-#  Oscar = "master"
-#  julia-version = "nightly"
-#  os = "ubuntu-latest"
+  [pkgs.Hecke]
+  test = false
+
+[include]
+  [include.justoscarmaster]
+  Oscar = "master"
+  Hecke = "release"
+  julia-version = "1.10"
+  os = "ubuntu-latest"


### PR DESCRIPTION
In https://github.com/oscar-system/GAP.jl/pull/1276, the OscarCI test does not run due to a resolving problem with Hecke. This PR here is needed to also allow a matching branch in Hecke.