### PR TITLE
Wrap treehash code into module

### DIFF
--- a/src/setup.jl
+++ b/src/setup.jl
@@ -219,10 +219,10 @@ function locate_JuliaInterface_so()
     # compare the C sources used to build GAP_pkg_juliainterface_jll with bundled copies
     # by comparing tree hashes
     jll = GAP_pkg_juliainterface_jll.find_artifact_dir()
-    jll_hash = tree_hash(joinpath(jll, "src"))
+    jll_hash = TreeHash.tree_hash(joinpath(jll, "src"))
     bundled = joinpath(@__DIR__, "..", "pkg", "JuliaInterface")
     path = Pidfile.mkpidlock("$bundled.lock"; stale_age=300) do
-        bundled_hash = tree_hash(joinpath(bundled, "src"))
+        bundled_hash = TreeHash.tree_hash(joinpath(bundled, "src"))
 
         # requested re-compilation via ENV -> re-compile
         if get(ENV, "FORCE_JULIAINTERFACE_COMPILATION", "false") == "true"

--- a/src/treehash.jl
+++ b/src/treehash.jl
@@ -27,7 +27,9 @@
 # > SOFTWARE.
 # >
 
-import SHA
+module TreeHash
+
+using SHA: SHA, SHA1_CTX, update!
 
 # This code gratefully adapted from https://github.com/simonbyrne/GitX.jl
 @enum GitMode mode_dir = 0o040000 mode_normal = 0o100644 mode_executable = 0o100755 mode_symlink = 0o120000 mode_submodule = 0o160000
@@ -173,3 +175,5 @@ function tree_hash(::Type{HashType}, root::AbstractString; debug_out::Union{IO, 
     return SHA.digest!(ctx)
 end
 tree_hash(root::AbstractString; debug_out::Union{IO, Nothing} = nothing) = tree_hash(SHA.SHA1_CTX, root; debug_out)
+
+end # module


### PR DESCRIPTION
I also re-instantiated the exact code from the reference to make future updates easier.
Wrapping this code into a module allows us to do proper imports and exports for this piece of code. In particular, this fixes the issue that the `SHA1_CTX` in line 101 is not qualified. (Found using JET)