### PR TITLE
CI: test against julia 1.13-nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,8 @@ jobs:
         julia-version:
           - '1.10'
           - '1.11'
-          - '1.12-nightly'
+          - '1.12'
+          - '1.13-nightly'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -33,7 +33,7 @@ jobs:
           - 'stable-4.15'
         julia-version:
           - '1'         # latest stable release
-          - '1.12-nightly'
+          - '1.13-nightly'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
The new 1.12 job should be added to the list of "required" CI jobs.