### PR TITLE
Optimize conversion Symbol -> GapObj

### DIFF
--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -213,7 +213,8 @@ function setbangindex!(x::GapObj, v::Any, i::Int64)
 end
 
 # records
-RNamObj(f::Union{Symbol,Int64,AbstractString}) = Wrappers.RNamObj(MakeString(string(f)))
+RNamObj(f::Union{Int64,AbstractString}) = RNamObj(string(f))
+RNamObj(f::Union{Symbol,String}) = Wrappers.RNamObj(MakeString(f))
 # note: we don't use Union{Symbol,Int64,AbstractString} below to avoid
 # ambiguity between these methods and method `getproperty(x, f::Symbol)`
 # from Julia's Base module

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -204,7 +204,12 @@ function AssignGlobalVariable(name::Union{AbstractString,Symbol}, value::Any)
     _AssignGlobalVariable(name, tmp)
 end
 
-MakeString(val::String) = GC.@preserve val @ccall libgap.GAP_MakeStringWithLen(val::Ptr{UInt8}, sizeof(val)::Culong)::GapObj
+function MakeString(val::Union{String,Symbol})
+    len = sizeof(val)
+    GC.@preserve val begin
+        @ccall libgap.GAP_MakeStringWithLen(val::Ptr{UInt8}, len::Culong)::GapObj
+    end
+end
 
 function UNSAFE_CSTR_STRING(val::GapObj)
     addr = ADDR_OBJ(val)

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -173,7 +173,7 @@ GAP.@install GapObj(x::Char) = CharWithValue(Cuchar(x))
 
 ## Strings and symbols
 GAP.@install GapObj(x::AbstractString) = MakeString(string(x))
-GAP.@install GapObj(x::Symbol) = MakeString(string(x))
+GAP.@install GapObj(x::Symbol) = MakeString(x)
 
 ## Arrays (including BitVector)
 function GapObj_internal(


### PR DESCRIPTION
Avoid intermediate conversion to String, and thus one allocation.

Before:

    julia> @b GAP.Globals.GAPInfo.Version
    151.180 ns (3 allocs: 80 bytes)

    julia> @b GapObj(:Version)
    56.061 ns (3 allocs: 80 bytes)

After:

    julia> @b GAP.Globals.GAPInfo.Version
    144.766 ns (2 allocs: 48 bytes)

    julia> @b GapObj(:Version)
    27.758 ns (2 allocs: 48 bytes)
