### PR TITLE
Ensure polymake is available to GAP packages

### DIFF
--- a/.github/workflows/CI-distro.yml
+++ b/.github/workflows/CI-distro.yml
@@ -70,7 +70,6 @@ jobs:
           - gap-package: 'itc'                        # dependency `xgap` has no jll
           - gap-package: 'localizeringforhomalg'      # `Error, found no GAP executable in PATH`
           - gap-package: 'packagemanager'             # many "#I  No sysinfo.gap found" warnings
-          - gap-package: 'polymaking'                 # `polymake command not found. Please set POLYMAKE_COMMAND by hand`
           - gap-package: 'profiling'                  # segfaults during testing
           - gap-package: 'ringsforhomalg'             # `Error, found no GAP executable in PATH`
           - gap-package: 'semigroups'                 # `Segmentation fault (Invalid permissions for mapped object)` after passing all tests

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,13 @@
 # Changes in GAP.jl
 
-## Version 0.16.3 (released 2025-XX-XX)
+## Version 0.16.3-DEV (released 2025-MM-DD)
 
 - `create_gap_sh` now accepts an optional second argument
   to specify the name of the created script (defaulting to `gap.sh`).
 - Update the "CrystCat" GAP package from 1.1.10 to 1.1.11
 - Update the "Wedderga" GAP package from 4.11.1 to 4.11.2
+- Add dependency on `polymake_jll` to provide a `polymake` executable
+  for use by the `polymaking` GAP package
 
 ## Version 0.16.2 (released 2025-12-02)
 

--- a/Project.toml
+++ b/Project.toml
@@ -50,6 +50,7 @@ Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 Singular_jll = "43d676ae-4934-50ba-8046-7a96366d613b"
 lib4ti2_jll = "1493ae25-0f90-5c0e-a06c-8c5077d6d66f"
 nauty_jll = "55c6dc9b-343a-50ca-8ff2-b71adb3733d5"
+polymake_jll = "7c209550-9012-526c-9264-55ba7a78ba2c"
 
 [weakdeps]
 Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
@@ -108,6 +109,7 @@ Singular_jll = "404.1.700"
 julia = "1.10"
 lib4ti2_jll = "1.6.10"
 nauty_jll = "2.6.13"
+polymake_jll = "400.1500.1"
 
 [extras]
 Ncurses_jll = "68e3532b-a499-55ff-9963-d1c0c0748b3a"


### PR DESCRIPTION
Some progress towards #1122.


The changes in `Project.toml` are due to letting `Pkg.jl` add the new jll, and it insisted on re-sorting entries; it seemed plausible to me to just accept that.