### PR TITLE
Bump hap to v1.74

### DIFF
--- a/.github/workflows/CI-distro.yml
+++ b/.github/workflows/CI-distro.yml
@@ -63,8 +63,6 @@ jobs:
           - gap-package: 'example'                    # no jll
           - gap-package: 'examplesforhomalg'          # `Error, found no GAP executable in PATH`
           - gap-package: 'groupoids'                  # `Segmentation fault (Invalid permissions for mapped object)` after passing all tests
-          - gap-package: 'hap'                        # `polymake command not found. Please set POLYMAKE_COMMAND by hand`
-          - gap-package: 'hapcryst'                   # `polymake command not found. Please set POLYMAKE_COMMAND by hand`
           - gap-package: 'help'                       # test failure in HeLP-4.0/tst/yes_4ti2.tst:39
           - gap-package: 'io'                         # segfaults, most likely due to child process handling
           - gap-package: 'itc'                        # dependency `xgap` has no jll

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -629,14 +629,14 @@ git-tree-sha1 = "1a54c9820d5b814418020102bfd7d17f3fe305a9"
     url = "https://files.gap-system.org/pkg/guava-3.20.tar.gz"
 
 [GAP_pkg_hap]
-git-tree-sha1 = "9707bc3019c190e7574c9fbcb8c19a7239d59569"
+git-tree-sha1 = "03fb28fa7c2374da1e0d72826f6df2b276a5b509"
 
     [[GAP_pkg_hap.download]]
-    sha256 = "0d9062ed95af35d8ed607bfafe424c00428629dfecaaf773df013b2ca8a5caaf"
-    url = "https://github.com/gap-packages/hap/releases/download/v1.72/hap-1.72.tar.gz"
+    sha256 = "47bf17458da4176bc68b10fcabbd15510213f9304ec2496eb0d5ae5528c38aa8"
+    url = "https://github.com/gap-packages/hap/releases/download/v1.73/hap-1.73.tar.gz"
     [[GAP_pkg_hap.download]]
-    sha256 = "0d9062ed95af35d8ed607bfafe424c00428629dfecaaf773df013b2ca8a5caaf"
-    url = "https://files.gap-system.org/pkg/hap-1.72.tar.gz"
+    sha256 = "47bf17458da4176bc68b10fcabbd15510213f9304ec2496eb0d5ae5528c38aa8"
+    url = "https://files.gap-system.org/pkg/hap-1.73.tar.gz"
 
 [GAP_pkg_hapcryst]
 git-tree-sha1 = "1c94fdb42a4b1584fc8abf8a4559054a1b73d88b"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -629,14 +629,14 @@ git-tree-sha1 = "1a54c9820d5b814418020102bfd7d17f3fe305a9"
     url = "https://files.gap-system.org/pkg/guava-3.20.tar.gz"
 
 [GAP_pkg_hap]
-git-tree-sha1 = "03fb28fa7c2374da1e0d72826f6df2b276a5b509"
+git-tree-sha1 = "672342988314d3f24bfe9192bf1c9352a2d66e40"
 
     [[GAP_pkg_hap.download]]
-    sha256 = "47bf17458da4176bc68b10fcabbd15510213f9304ec2496eb0d5ae5528c38aa8"
-    url = "https://github.com/gap-packages/hap/releases/download/v1.73/hap-1.73.tar.gz"
+    sha256 = "357f720914ce8e148afe3d0fdd6dde1b6bbb3f071d9f32d912d8179e1271374c"
+    url = "https://github.com/gap-packages/hap/releases/download/v1.74/hap-1.74.tar.gz"
     [[GAP_pkg_hap.download]]
-    sha256 = "47bf17458da4176bc68b10fcabbd15510213f9304ec2496eb0d5ae5528c38aa8"
-    url = "https://files.gap-system.org/pkg/hap-1.73.tar.gz"
+    sha256 = "357f720914ce8e148afe3d0fdd6dde1b6bbb3f071d9f32d912d8179e1271374c"
+    url = "https://files.gap-system.org/pkg/hap-1.74.tar.gz"
 
 [GAP_pkg_hapcryst]
 git-tree-sha1 = "1c94fdb42a4b1584fc8abf8a4559054a1b73d88b"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -629,14 +629,14 @@ git-tree-sha1 = "1a54c9820d5b814418020102bfd7d17f3fe305a9"
     url = "https://files.gap-system.org/pkg/guava-3.20.tar.gz"
 
 [GAP_pkg_hap]
-git-tree-sha1 = "0a91782e221bed2ccaabedfbf77981077075a316"
+git-tree-sha1 = "9707bc3019c190e7574c9fbcb8c19a7239d59569"
 
     [[GAP_pkg_hap.download]]
-    sha256 = "300e776141be73f807a2fbdfc0ce45d871c8d4a765dc2ca3b49ba38db9d51861"
-    url = "https://github.com/gap-packages/hap/releases/download/v1.70/hap-1.70.tar.gz"
+    sha256 = "0d9062ed95af35d8ed607bfafe424c00428629dfecaaf773df013b2ca8a5caaf"
+    url = "https://github.com/gap-packages/hap/releases/download/v1.72/hap-1.72.tar.gz"
     [[GAP_pkg_hap.download]]
-    sha256 = "300e776141be73f807a2fbdfc0ce45d871c8d4a765dc2ca3b49ba38db9d51861"
-    url = "https://files.gap-system.org/pkg/hap-1.70.tar.gz"
+    sha256 = "0d9062ed95af35d8ed607bfafe424c00428629dfecaaf773df013b2ca8a5caaf"
+    url = "https://files.gap-system.org/pkg/hap-1.72.tar.gz"
 
 [GAP_pkg_hapcryst]
 git-tree-sha1 = "1c94fdb42a4b1584fc8abf8a4559054a1b73d88b"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
   to specify the name of the created script (defaulting to `gap.sh`).
 - Update the `CrystCat` GAP package from 1.1.10 to 1.1.11
 - Update the `Wedderga` GAP package from 4.11.1 to 4.11.2
-- Update the `hap` GAP package from 1.70 to 1.72
+- Update the `hap` GAP package from 1.70 to 1.73
 - Add dependency on `polymake_jll` to provide a `polymake` executable
   for use by the `polymaking`, `hap`, and `hapcryst` GAP packages
 - Fix `GAP.versioninfo` to correctly report all precompiled binaries

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,11 @@
 
 - `create_gap_sh` now accepts an optional second argument
   to specify the name of the created script (defaulting to `gap.sh`).
-- Update the "CrystCat" GAP package from 1.1.10 to 1.1.11
-- Update the "Wedderga" GAP package from 4.11.1 to 4.11.2
+- Update the `CrystCat` GAP package from 1.1.10 to 1.1.11
+- Update the `Wedderga` GAP package from 4.11.1 to 4.11.2
+- Update the `hap` GAP package from 1.70 to 1.72
 - Add dependency on `polymake_jll` to provide a `polymake` executable
-  for use by the `polymaking` GAP package
+  for use by the `polymaking`, `hap`, and `hapcryst` GAP packages
 - Fix `GAP.versioninfo` to correctly report all precompiled binaries
   of GAP packages that are available
 
@@ -140,8 +141,8 @@
 
 ## Version 0.13.1 (released 2025-02-07)
 
-- Add precompiled binaries for the "semigroups" GAP package
-- Update the "PackageManager" GAP package from 1.6.0 to 1.6.1
+- Add precompiled binaries for the `semigroups` GAP package
+- Update the `PackageManager` GAP package from 1.6.0 to 1.6.1
 - Fix compatibility issues with upcoming Julia 1.12
 - Add initial support for Julia 1.13
 - Introduce a global variable `GAP_jl` on the GAP side, which points to the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
   to specify the name of the created script (defaulting to `gap.sh`).
 - Update the `CrystCat` GAP package from 1.1.10 to 1.1.11
 - Update the `Wedderga` GAP package from 4.11.1 to 4.11.2
-- Update the `hap` GAP package from 1.70 to 1.73
+- Update the `hap` GAP package from 1.70 to 1.74
 - Add dependency on `polymake_jll` to provide a `polymake` executable
   for use by the `polymaking`, `hap`, and `hapcryst` GAP packages
 - Fix `GAP.versioninfo` to correctly report all precompiled binaries


### PR DESCRIPTION
Alternative to and thus closes https://github.com/oscar-system/GAP.jl/pull/1304.