### PR TITLE
Run the slack notification even on failure

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -109,7 +109,7 @@ jobs:
     needs:
       - test
       - docs
-    if: github.ref_name == github.event.repository.default_branch
+    if: "!cancelled() && github.ref_name == github.event.repository.default_branch"
     runs-on: ubuntu-latest
     steps:
       - name: Determine whether CI status changed


### PR DESCRIPTION
I noticed that slack notification only fires on success, never on failure. Turns out `needs:` in github workflow yaml means "if the needed job is completed successfully".

For `!cancelled()`, quotes are needed "so that !cancelled() is not interpreted as a YAML tag", according to stackoverflow ( https://stackoverflow.com/a/58859404 )