### PR TITLE
Fix `GAP.versioninfo` to indeed show all GAP_pkg_*_jlls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 - Update the "Wedderga" GAP package from 4.11.1 to 4.11.2
 - Add dependency on `polymake_jll` to provide a `polymake` executable
   for use by the `polymaking` GAP package
+- Fix `GAP.versioninfo` to correctly report all precompiled binaries
+  of GAP packages that are available
 
 ## Version 0.16.2 (released 2025-12-02)
 

--- a/src/GAP_pkg.jl
+++ b/src/GAP_pkg.jl
@@ -74,6 +74,7 @@ function setup_overrides()
     for pkg in gap_pkg_jll_names
         jll = getproperty(GAP, Symbol(pkg))
         @assert jll isa Module
+        push!(gap_pkg_jlls, jll)
         pkg = pkg[9:end-4]
 
         # Crude heuristic: if the JLL has a `bin` directory then we assume it


### PR DESCRIPTION
This got lost in https://github.com/oscar-system/GAP.jl/pull/1214.