### PR TITLE
Add script for running JET with options

### DIFF
--- a/etc/jet.jl
+++ b/etc/jet.jl
@@ -1,0 +1,23 @@
+using Revise
+using JET
+
+struct AnyFrameMethod <: ReportMatcher
+    m::Union{Function,Method,Symbol}
+end
+
+function JET.match_report(matcher::AnyFrameMethod, @nospecialize(report::JET.InferenceErrorReport))
+    # check all VirtualFrames in the VirtualStackTrace for a match to the specified method
+    m = matcher.m
+    if m isa Symbol
+        return any(vf -> vf.linfo.def.name === m, report.vst)
+    elseif m isa Method
+        return any(vf -> vf.linfo.def === m, report.vst)
+    else # if m isa Function
+        return any(vf -> vf.linfo.def in methods(m), report.vst)
+    end
+end
+
+using GAP; report_package(GAP; ignored_modules=[
+        AnyFrameMethod(:is_loaded_directly),
+        AnyFrameMethod(:ca_roots_path),
+        ])


### PR DESCRIPTION
Specifically, don't report anythin related to our unholy
is_loaded_directly hack. We know it's evil, no need to see
JET get twisted up about it.

Similar scripts could / should be add to our other packages,
with possible more things to ignore added for each, as needed.

The `AnyFrameMethod` could also perhaps be submitted to JET,
dunno if there'd be interest.