### PR TITLE
Enable some packages in distro CI that have random failures

### DIFF
--- a/.github/workflows/CI-distro.yml
+++ b/.github/workflows/CI-distro.yml
@@ -62,7 +62,6 @@ jobs:
           - gap-package: 'ctbllib'                    # random gc-related segfaults during testing
           - gap-package: 'example'                    # no jll
           - gap-package: 'examplesforhomalg'          # `Error, found no GAP executable in PATH`
-          - gap-package: 'groupoids'                  # `Segmentation fault (Invalid permissions for mapped object)` after passing all tests
           - gap-package: 'help'                       # test failure in HeLP-4.0/tst/yes_4ti2.tst:39
           - gap-package: 'io'                         # segfaults, most likely due to child process handling
           - gap-package: 'itc'                        # dependency `xgap` has no jll
@@ -70,9 +69,7 @@ jobs:
           - gap-package: 'packagemanager'             # many "#I  No sysinfo.gap found" warnings
           - gap-package: 'profiling'                  # segfaults during testing
           - gap-package: 'ringsforhomalg'             # `Error, found no GAP executable in PATH`
-          - gap-package: 'semigroups'                 # `Segmentation fault (Invalid permissions for mapped object)` after passing all tests
           - gap-package: 'xgap'                       # no jll
-          - gap-package: 'xmod'                       # `Segmentation fault (Invalid permissions for mapped object)` after passing all tests
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
We have more of these failures in non-disabled packages (e.g. hapcryst, sgpviz, xmodalg), and they usually are fine after one restart. Thus, I would propose to handle all of them in the same way.