### PR TITLE
Optimize conversion of MatElem to GapObj

### DIFF
--- a/ext/NemoExt/NemoExt.jl
+++ b/ext/NemoExt/NemoExt.jl
@@ -14,7 +14,11 @@ module NemoExt
 using GAP
 using Nemo
 
-import GAP: GapInt, GapObj, Wrappers
+import GAP:
+    GapCacheDict,
+    GapInt,
+    GapObj,
+    Wrappers
 
 import Nemo:
   QQMatrix,

--- a/ext/NemoExt/nemo_to_gap.jl
+++ b/ext/NemoExt/nemo_to_gap.jl
@@ -14,8 +14,8 @@
 ## where low level Julia objects are treated)
 
 ## `ZZRingElem` to GAP integer
-GAP.@install function GapObj(obj::ZZRingElem)
-  Nemo._fmpz_is_small(obj) && return GapObj(Int(obj))
+GAP.@install function GapObj(obj::Nemo.ZZRingElemOrPtr)
+  Nemo._fmpz_is_small(obj) && return GapObj(data(obj))
   GC.@preserve obj begin
     x = Nemo._as_bigint(obj)
     return ccall((:MakeObjInt, GAP.libgap), GapObj, (Ptr{UInt64}, Cint), x.d, x.size)
@@ -25,16 +25,56 @@ end
 GapInt(obj::ZZRingElem) = GapObj(obj)
 
 ## `QQFieldElem` to GAP rational
-GAP.@install GapObj(obj::QQFieldElem) = Wrappers.QUO(GapObj(numerator(obj)), GapObj(denominator(obj)))
+GAP.@install function GapObj(obj::Nemo.QQFieldElemOrPtr)
+  GC.@preserve obj begin
+    n = GapObj(Nemo._num_ptr(obj))
+    d = GapObj(Nemo._den_ptr(obj))
+    return Wrappers.QUO(n, d)
+  end
+end
 
 ## `PosInf` and `NegInf` to GAP infinity
 GAP.@install GapObj(obj::PosInf) = GAP.Globals.infinity
 GAP.@install GapObj(obj::NegInf) = -GAP.Globals.infinity
 
-## `ZZMatrix` to matrix of GAP integers
-## TODO/FIXME: rewrite to not first convert to `Matrix`
-GAP.@install GapObj(obj::ZZMatrix) = GapObj(Matrix(obj); recursive = true)
+## Convert matrix
+function GAP.GapObj_internal(
+    obj::MatElem{T},
+    recursion_dict::GapCacheDict,
+    ::Val{recursive},
+) where {T, recursive}
 
-## `QQMatrix` to matrix of GAP rationals or integers
-## TODO/FIXME: rewrite to not first convert to `Matrix`
-GAP.@install GapObj(obj::QQMatrix) = GapObj(Matrix(obj); recursive = true)
+    recursive && recursion_dict !== nothing && haskey(recursion_dict, obj) && return recursion_dict[obj]
+
+    rows = nrows(obj)
+    cols = ncols(obj)
+    ret_val = GAP.NewPlist(rows)
+
+    recursion_dict = GAP.recursion_info_g(T, obj, ret_val, GAP.BoolVal(recursive), recursion_dict)
+
+    for i = 1:rows
+        r = ret_val[i] = GAP.NewPlist(cols)
+        for j = 1:cols
+            x = obj[i, j]
+            y = GAP.GapObj_internal(x, recursion_dict, GAP.BoolVal(recursive))
+            r[j] = y
+        end
+    end
+    return ret_val
+end
+
+function GAP.GapObj_internal(obj::Union{ZZMatrix,QQMatrix}, ::GapCacheDict, ::Val)
+    rows = nrows(obj)
+    cols = ncols(obj)
+    ret_val = GAP.NewPlist(rows)
+
+    for i = 1:rows
+        r = ret_val[i] = GAP.NewPlist(cols)
+        for j = 1:cols
+            ptr = Nemo.mat_entry_ptr(obj, i, j)
+            y = GapObj(ptr)
+            r[j] = y
+        end
+    end
+    return ret_val
+end

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -80,7 +80,7 @@ const RecDict_g = IdDict{Any,Any}
 const GapCacheDict = Union{Nothing,RecDict_g}
 
 # helper functions for recursion (conversion from Julia to GAP)
-function recursion_info_g(::Type{T}, obj, ret_val, recursive::Bool, recursion_dict::GapCacheDict) where {T}
+function recursion_info_g(::Type{T}, obj, ret_val, ::Val{recursive}, recursion_dict::GapCacheDict) where {T, recursive}
     rec = recursive && _needs_tracking_julia_to_gap(T)
     if rec && recursion_dict === nothing
         rec_dict = RecDict_g()

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -188,7 +188,7 @@ function GapObj_internal(
     len = length(obj)
     ret_val = NewPlist(len)
 
-    recursion_dict = recursion_info_g(T, obj, ret_val, recursive, recursion_dict)
+    recursion_dict = recursion_info_g(T, obj, ret_val, GAP.BoolVal(recursive), recursion_dict)
 
     # Set the subobjects.
     for i = 1:len
@@ -214,7 +214,7 @@ function GapObj_internal(
 
     ret_val = NewPlist(length(obj))
 
-    recursion_dict = recursion_info_g(T, obj, ret_val, recursive, recursion_dict)
+    recursion_dict = recursion_info_g(T, obj, ret_val, GAP.BoolVal(recursive), recursion_dict)
 
     for x in obj
         res = recursive ? GapObj_internal(x, recursion_dict, Val(true)) : x
@@ -238,9 +238,10 @@ function GapObj_internal(
     rows = size(obj, 1)
     ret_val = NewPlist(rows)
 
-    recursion_dict = recursion_info_g(T, obj, ret_val, recursive, recursion_dict)
+    recursion_dict = recursion_info_g(T, obj, ret_val, GAP.BoolVal(recursive), recursion_dict)
 
     for i = 1:rows
+    # TODO: don't work rowwise?!?
         ret_val[i] = GapObj_internal(obj[i, :], recursion_dict, BoolVal(recursive))
     end
     return ret_val
@@ -274,7 +275,7 @@ function GapObj_internal(
 
     ret_val = NewPrecord(0)
 
-    recursion_dict = recursion_info_g(T, obj, ret_val, recursive, recursion_dict)
+    recursion_dict = recursion_info_g(T, obj, ret_val, GAP.BoolVal(recursive), recursion_dict)
 
     for (x, y) in obj
         x = Wrappers.RNamObj(MakeString(string(x)))


### PR DESCRIPTION
Also speed up conversion of ZZRingElem & QQFieldElem.

Before:

    julia> x = ZZ(7); @b GapObj($x)
    4.329 ns

    julia> x = QQ(7,3); @b GapObj($x)
    140.800 ns (4 allocs: 80 bytes)

    julia> x = QQ(7,3)^100; @b GapObj($x)
    552.077 ns (10 allocs: 288 bytes)

    julia> m = matrix(ZZ, [1 2; 3 4]); @b GapObj($m)
    489.774 ns (16 allocs: 528 bytes)

    julia> m = matrix(QQ, [1 2; 3 4]); @b GapObj($m)
    1.292 μs (24 allocs: 720 bytes)

After:

    julia> x = ZZ(7); @b GapObj($x)
    3.101 ns

    julia> x = QQ(7,3); @b GapObj($x)
    64.239 ns (2 allocs: 48 bytes)

    julia> x = QQ(7,3)^100; @b GapObj($x)
    463.619 ns (8 allocs: 256 bytes)

    julia> m = matrix(ZZ, [1 2; 3 4]); @b GapObj($m)
    192.678 ns (6 allocs: 192 bytes)

    julia> m = matrix(QQ, [1 2; 3 4]); @b GapObj($m)
    586.957 ns (6 allocs: 192 bytes)
