### PR TITLE
Remove GAP.Display and StringDisplayObj

### DIFF
--- a/pkg/JuliaInterface/gap/utils.gi
+++ b/pkg/JuliaInterface/gap/utils.gi
@@ -30,17 +30,6 @@ BindGlobal( "SetBangPosition",
     obj![ pos ]:= val;
   end );
 
-BindGlobal( "StringDisplayObj",
-function(obj)
-  local str, out;
-  str := "";
-  out := OutputTextString(str, false);
-  SetPrintFormattingStatus(out, false);
-  CALL_WITH_STREAM(out, Display, [obj]);
-  CloseStream(out);
-  return str;
-end );
-
 BindGlobal( "StringViewObj",
 function(obj)
   local str, out;

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -130,10 +130,6 @@ create_type(T::Type, paras::Vector) = T{paras...}
 
 ## convenience function
 
-function Display(x::GapObj)
-    print(String(Wrappers.StringDisplayObj(x)))
-end
-
 function Base.functionloc(f::GapObj)
     GAP.Globals.IsFunction(f) || throw(ArgumentError("`f` must be GAP function"))
     file = GAP.Globals.FilenameFunc(f)::GapObj

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -89,7 +89,6 @@ import GAP: @wrap
 @wrap ShallowCopy(x::Any)::Any
 @wrap Sort(x::GapObj)::Nothing
 @wrap String(x::Any)::Any
-@wrap StringDisplayObj(x::Any)::GapObj
 @wrap StringViewObj(x::Any)::GapObj
 @wrap StructuralCopy(x::Any)::Any
 @wrap SUM(x::Any, y::Any)::Any

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -160,7 +160,6 @@ end
     l = GAP.evalstr("[1,~,3]")
     @test l[2] === l
     @test String(GAP.Globals.StringViewObj(l)) == "[ 1, ~, 3 ]"
-    @test String(GAP.Globals.StringDisplayObj(l)) == "[ 1, ~, 3 ]\n"
 
     # from issue #1058:
     c = IOCapture.capture() do


### PR DESCRIPTION
Nothing is calling them and they are undocumented.

Right now `GAP.Display` also doesn't allow specifying custom `io::IO`. So it is not clear what we gain over just calling `GAP.Globals.Display` ?

Alternatively we could keep them but make them discoverable, e.g. by adding documentation, or replacing `GAP.Display` with a method for a standard function(perhaps `show` with a special mimetype, or as a method to Julia's `display`, or by some other means).

@ThomasBreuer any thoughts on this one?