### PR TITLE
Remove JuliaInterface BannerFunction

### DIFF
--- a/pkg/JuliaInterface/PackageInfo.g
+++ b/pkg/JuliaInterface/PackageInfo.g
@@ -114,26 +114,6 @@ Dependencies := rec(
 
 AvailabilityTest := ReturnTrue,
 
-# Show the julia version number in the banner string.
-# (We assume that this function gets called *after* the package has been
-# loaded, in particular after Julia has been started.)
-BannerFunction := function( info )
-  local str, version;
-
-  str:= DefaultPackageBannerString( info );
-  if not IsBoundGlobal( "JuliaEvalString" ) then
-    return str;
-  fi;
-  version:= ValueGlobal( "JuliaEvalString" )( "string( VERSION )" );
-  if not IsBoundGlobal( "JuliaToGAP" ) then
-    return str;
-  fi;
-  version:= ValueGlobal( "JuliaToGAP" )( IsString, version );
-
-  return ReplacedString( str, "Homepage",
-             Concatenation( "(julia version is ", version, ")\nHomepage" ) );
-end,
-
 TestFile := "tst/testall.g",
 
 Keywords := [ "GAP-Julia integration", "Julia", "Interface" ],


### PR DESCRIPTION
It is not useful in practice (it was back when one could
load Julia from GAP, but those days are long gone).
