### PR TITLE
CI: change use of FORCE_JULIAINTERFACE_COMPILATION

### DIFF
--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -5,24 +5,26 @@ set -x
 
 AnyFailures=No
 
+# Force recompilation of JuliaInterface with coverage instrumentation
+export CFLAGS="--coverage"
+export LDFLAGS="--coverage"
 mkdir -p coverage
 #
 cd pkg/JuliaInterface
 pwd
 # Force recompilation of JuliaInterface with coverage instrumentation.
 # Use a fixed build directory so that gcov can find .gcno/.gcda files.
-CFLAGS="--coverage" LDFLAGS="--coverage" FORCE_JULIAINTERFACE_COMPILATION=tmp ${GAP} --nointeract
-${GAP} makedoc.g
-${GAP} --cover ../../coverage/JuliaInterface.coverage -r tst/testall.g || AnyFailures=Yes
+export FORCE_JULIAINTERFACE_COMPILATION=tmp
+${GAP} --cover ../../coverage/JuliaInterface.coverage -r makedoc.g tst/testall.g || AnyFailures=Yes
 gcov -o tmp/gen/src/ src/*.c*
-rm -rf tmp # Delete the coverage instrumentation in JuliaInterface again
+#rm -rf tmp # Delete the coverage instrumentation in JuliaInterface again
 cd ../..
 
 #
+export FORCE_JULIAINTERFACE_COMPILATION=
 cd pkg/JuliaExperimental
 pwd
-${GAP} makedoc.g
-${GAP} --cover ../../coverage/JuliaExperimental.coverage -r tst/testall.g || AnyFailures=Yes
+${GAP} --cover ../../coverage/JuliaExperimental.coverage -r makedoc.g tst/testall.g || AnyFailures=Yes
 cd ../..
 
 if [ ${AnyFailures} = Yes ]


### PR DESCRIPTION
I might be mistaken on the following (and am running this in CI to test it). But:

So far we set FORCE_JULIAINTERFACE_COMPILATION in one invocation of gap.sh; but then omitted it for the next couple. But then those other runs will use the stock version from the JLL again, defeating the whole point of forcing recompilation with `--coverage` enabled.