### PR TITLE
CI: pass --coverage to C/LDFLAGS when building JuliaInterface in treehash job

### DIFF
--- a/.github/workflows/treehash.yml
+++ b/.github/workflows/treehash.yml
@@ -48,7 +48,19 @@ jobs:
         with:
           depwarn: error
         env:
-          FORCE_JULIAINTERFACE_COMPILATION: "true"
+          FORCE_JULIAINTERFACE_COMPILATION: "force_compile_dir"
+          CFLAGS: "--coverage"
+          LDFLAGS: "--coverage"
+      - name: "Run gcov"
+        run: |
+          for d in $(find . -name force_compile_dir) ; do
+            echo "=== scanning $d"
+            pushd $d
+            ls -R
+            gcov -o gen/src/ src/*.c*
+            popd
+          od
+
       - name: "Process code coverage"
         uses: julia-actions/julia-processcoverage@v1
       - name: "Upload coverage data to Codecov"

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -207,8 +207,8 @@ function build_JuliaInterface(builddir::String)
     cd(builddir) do
         withenv("CFLAGS" => JULIA_CFLAGS,
                 "LDFLAGS" => JULIA_LDFLAGS * " " * JULIA_LIBS) do
-            run(pipeline(`$(joinpath(jipath, "configure")) $(gaproot)`, stdout="build.log"))
-            run(pipeline(`make V=1 -j$(Sys.CPU_THREADS)`, stdout="build.log", append=true))
+            run(pipeline(`$(joinpath(jipath, "configure")) $(gaproot)`))
+            run(pipeline(`make V=1 -j$(Sys.CPU_THREADS)`))
         end
     end
 


### PR DESCRIPTION
There is a bunch of C code in JuliaInterface that we *definitely* are exercising, but which Codecov does not report as covered. I am trying to figure out why. One guess is that we only enable the CFLAG `--cover` when running the `gap` tests (in `etc/ci_test.sh`), so this PR tries to enable them also when running the JuliaInterface tests, at least in one case (the "treehash" CI check, as it already enables `FORCE_JULIAINTERFACE_COMPILATION=true` anyway).

UPDATE: alas, it doesn't work and I am not really sure why