### PR TITLE
CI: enable coverage tracking in generated gap.sh

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           JULIA_DEBUG: "GAP"
         run: |
-          julia --project=. --depwarn=error -e 'import GAP; GAP.create_gap_sh("/tmp")'
+          julia --project=. --depwarn=error  --code-coverage -e 'import GAP; GAP.create_gap_sh("/tmp")'
           export GAP="/tmp/gap.sh -A --quitonbreak --norepl"
           etc/ci_test.sh
 

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -295,7 +295,7 @@ function create_gap_sh(dstdir::String, dstname::String="gap.sh"; use_active_proj
                 [deps]
                 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
                 """)
-        run(`$(Base.julia_cmd()) --startup-file=no --project=$(projectdir) -e "using Pkg; Pkg.develop(PackageSpec(path=\"$(gaproot_gapjl)\"))"`)
+        run(`$(Base.julia_cmd()) --code-coverage --startup-file=no --project=$(projectdir) -e "using Pkg; Pkg.develop(PackageSpec(path=\"$(gaproot_gapjl)\"))"`)
 
         @info "Generating gap.sh ..."
     end


### PR DESCRIPTION
... so that we also see code coverage for the Julia code in JuliaExperimental.

At least that's the theory. Let's see if it works out.