### PR TITLE
fix: `setup_override_dir.jl` no longer errors with `build_dir` cmd line arg

### DIFF
--- a/etc/setup_override_dir.jl
+++ b/etc/setup_override_dir.jl
@@ -127,7 +127,7 @@ run(`make -j$(Sys.CPU_THREADS) build/gap-nocomp $(verbose ? "V=1" : [])`)
 # which involves launching GAP, which requires libgmp from GMP_jll, which requires
 # fiddling with DYLD_FALLBACK_LIBRARY_PATH / LD_LIBRARY_PATH ....
 for f in ["c_oper1.c", "c_type1.c"]
-    cp(joinpath(gap_prefix, "build", f), joinpath("build", f))
+    cp(joinpath(gap_prefix, "build", f), joinpath("build", f); force=true)
 end
 
 # complete the build


### PR DESCRIPTION
Avoids
```julia
ERROR: LoadError: ArgumentError: 'build/c_oper1.c' exists. `force=true` is required to remove 'build/c_oper1.c' before copying.
Stacktrace:
 [1] checkfor_mv_cp_cptree(src::String, dst::String, txt::String; force::Bool)
   @ Base.Filesystem ./file.jl:360
 [2] checkfor_mv_cp_cptree
   @ ./file.jl:344 [inlined]
 [3] cp(src::String, dst::String; force::Bool, follow_symlinks::Bool)
   @ Base.Filesystem ./file.jl:406
 [4] cp(src::String, dst::String)
   @ Base.Filesystem ./file.jl:404
 [5] top-level scope
   @ ~/code/julia/GAP.jl/etc/setup_override_dir.jl:130
 [6] include(mod::Module, _path::String)
   @ Base ./Base.jl:306
 [7] exec_options(opts::Base.JLOptions)
   @ Base ./client.jl:317
 [8] _start()
   @ Base ./client.jl:550
in expression starting at /home/lgoe/code/julia/GAP.jl/etc/setup_override_dir.jl:129
```