### PR TITLE
Conversions for `fpMatrix`/`FpMatrix`

### DIFF
--- a/ext/NemoExt/nemo_to_gap.jl
+++ b/ext/NemoExt/nemo_to_gap.jl
@@ -78,3 +78,9 @@ function GAP.GapObj_internal(obj::Union{ZZMatrix,QQMatrix}, ::GapCacheDict, ::Va
     end
     return ret_val
 end
+
+## matrix of elements of a finite field (of prime order)
+GAP.@install function GapObj(obj::Union{fpMatrix, FpMatrix})
+    e = GAP.Globals.Z(GapObj(characteristic(base_ring(obj))))
+    return GapObj(lift(obj)) * e
+end

--- a/test/NemoExt/nemo_to_gap.jl
+++ b/test/NemoExt/nemo_to_gap.jl
@@ -135,3 +135,15 @@ import AbstractAlgebra
     @test GAP.Obj(x) == val
   end
 end
+
+@testset "fpMatrix" begin
+    F = Native.GF(5)
+    m = matrix(F, 4, 4, 1:16)
+    @test GAP.Obj(m) == GAP.evalstr("[ [ Z(5), Z(5)^2, Z(5)^0, Z(5)^3 ], [ 0*Z(5), Z(5), Z(5)^2, Z(5)^0 ], [ Z(5)^3, 0*Z(5), Z(5), Z(5)^2 ], [ Z(5)^0, Z(5)^3, 0*Z(5), Z(5) ] ]")
+end
+
+@testset "FpMatrix" begin
+    F = Native.GF(ZZ(5))
+    m = matrix(F, 4, 4, 1:16)
+    @test GAP.Obj(m) == GAP.evalstr("[ [ Z(5), Z(5)^2, Z(5)^0, Z(5)^3 ], [ 0*Z(5), Z(5), Z(5)^2, Z(5)^0 ], [ Z(5)^3, 0*Z(5), Z(5), Z(5)^2 ], [ Z(5)^0, Z(5)^3, 0*Z(5), Z(5) ] ]")
+end


### PR DESCRIPTION
Basic (preliminary) conversion methods for matrices over finite fields; here we cover `fpMatrix` and `FpMatrix`.

Originally https://github.com/oscar-system/Oscar.jl/pull/5945