### PR TITLE
Make override setup work with `[sources]` in `Project.toml`

### DIFF
--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -81,8 +81,8 @@ jobs:
           make -j`nproc`
       - name: "Override bundled GAP"
         run: |
-          julia --proj=override etc/setup_override_dir.jl /tmp/GAPROOT /tmp/gap_jll_override --enable-Werror
+          julia --project etc/setup_override_dir.jl /tmp/GAPROOT /tmp/gap_jll_override --enable-Werror
       - name: "Run tests"
         run: |
-           julia --proj=override etc/run_with_override.jl /tmp/gap_jll_override --depwarn=error -e "using Pkg; Pkg.test(\"GAP\")"
+           julia --project etc/run_with_override.jl /tmp/gap_jll_override --depwarn=error -e "using Pkg; Pkg.test(\"GAP\")"
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -580,4 +580,3 @@ Other changes:
 
 
 ## Version 0.3.5 (released 2020-03-22)
-

--- a/README.maintainer.md
+++ b/README.maintainer.md
@@ -43,20 +43,18 @@ For this to work, follow these instructions:
 
 3. Build GAP with the Julia version of your choice by executing the `etc/setup_override_dir.jl`
    script. It takes as first argument the GAPROOT, and as second argument the places where
-   the result shall be installed. I recommend to execute this in a separate
-   environment, as it may need to install a few things.
+   the result shall be installed.
 
    To give a concrete example you could invoke
 
-        julia --proj=override etc/setup_override_dir.jl $GAPROOT /tmp/gap_jll_override
+        julia --project etc/setup_override_dir.jl $GAPROOT /tmp/gap_jll_override
 
-4. Use the `etc/run_with_override.jl` script with the exact same Julia executable
-   and the override environment we just prepared.
+4. Use the `etc/run_with_override.jl` script with the exact same Julia executable.
 
-        julia --proj=override etc/run_with_override.jl /tmp/gap_jll_override
+        julia --project etc/run_with_override.jl /tmp/gap_jll_override
 
-5. This opens a Julia session with the override in effect. You can now e.g. load GAP.jl
-   via `using GAP`, or install other packages (such as Oscar) and test with them.
+5. This configures the override in-process; pass code via `-e` or a script file.
+   For example, `-e "using GAP"` loads GAP.jl with the override in effect.
 
 
 ## Directions for updating GAP.jl

--- a/etc/run_with_override.jl
+++ b/etc/run_with_override.jl
@@ -10,12 +10,9 @@ gapoverride = abspath(gapoverride)
 #
 #
 #
-@info "Install needed packages"
+@info "Using existing package environment at $(Base.active_project())"
 using Pkg
-Pkg.develop(path=dirname(@__DIR__))
-Pkg.add(["GAP_jll", "GAP_lib_jll"])
 Pkg.instantiate()
-
 import GAP_lib_jll
 
 #
@@ -50,6 +47,8 @@ run(`ln -sf $(abspath(GAP_lib_jll.find_artifact_dir(), "share", "gap", "doc")) $
 # prepend our temporary depot to the depot list...
 withenv("JULIA_DEPOT_PATH"=>tmpdepot*":", "FORCE_JULIAINTERFACE_COMPILATION" => "true") do
 
+    # ... make sure all dependencies are installed ...
+    run(`$(Base.julia_cmd()) --project=$(Base.active_project()) -e "using Pkg; Pkg.instantiate()"`)
     # ... and start Julia, by default with the same project environment
     run(`$(Base.julia_cmd()) --project=$(Base.active_project()) $(ARGS)`)
 end

--- a/etc/setup_override_dir.jl
+++ b/etc/setup_override_dir.jl
@@ -66,6 +66,9 @@ build_dir = abspath(build_dir)
 @info "Install needed packages"
 using Pkg
 using Artifacts
+
+tmpenv = mktempdir(; cleanup=true)
+Pkg.activate(tmpenv)
 Pkg.add(["JLLPrefixes"])
 Pkg.instantiate()
 


### PR DESCRIPTION
by re-using the package environment instead of adding one on top. This changes the way the override setup needs to be called, see the changes in `README.maintainer.md` for details.