### PR TITLE
set timeout for downloads in `GAP.Packages.test`

### DIFF
--- a/src/packages.jl
+++ b/src/packages.jl
@@ -510,6 +510,11 @@ function test(name::String)
     return
   end
 
+  # Set a timeout of 30 seconds for web downloads.
+  # This affects functions that use the AtlasRep package if it is available.
+  orig_timeout = Globals.UserPreference(GapObj("utils"), GapObj("DownloadMaxTime"))
+  Globals.SetUserPreference(GapObj("utils"), GapObj("DownloadMaxTime"), 30)
+
   disable_error_handler[] = true
   result = false
   try
@@ -534,6 +539,9 @@ function test(name::String)
     called_QuitGap || throw(ArgumentError("GAP's TestPackage failed"))
     result = true
   end
+
+  Globals.SetUserPreference(GapObj("utils"), GapObj("DownloadMaxTime"), orig_timeout)
+
   return !error_occurred && result
 end
 


### PR DESCRIPTION
We want to set a timeout for GAP's `Download` function (from the utils package) in CI tests.

The CI tests for GAP.jl itself and for JuliaInterface do not call GAP code that wants to download files, thus the relevant CI tests are the ones that call `GAP.Packages.test` and the ones that run the Oscar tests.

The function `GAP.Packages.test` now sets and resets a timeout.
The Oscar tests are run by calling `Pkg.test("Oscar")`, this will be handled by setting the timeouts in Oscar.
(I did not find a CI test that runs parts of the GAP test suite. Such a test would also need a timeout.)

addresses #1378