### PR TITLE
unconditionally set a global `Download` timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes in GAP.jl
 
+## Version 0.16.7-DEV (released 2026-XX-XX)
+
+- Set a timeout of 30 seconds for GAP's `Download` function,
+  except if the user's `gap.ini` file defines already a finite timeout value.
+
 ## Version 0.16.6 (released 2026-04-30)
 
 - Declare compatibility with AbstractAlgebra 0.49

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -254,6 +254,13 @@ function __init__()
     # Start GAP.
     initialize(cmdline_options)
 
+    timeout = Globals.UserPreference(GapObj("utils"), GapObj("DownloadMaxTime"))
+    if timeout == 0
+      # The user did not set a non-default timeout.
+      # Prescribe a timeout of 30 seconds for `Download` calls.
+      Globals.SetUserPreference(GapObj("utils"), GapObj("DownloadMaxTime"), 30)
+    end
+
     if !isdefined(Main, :__GAP_ARGS__)
         # We had started GAP with the `-b` option.
         # Reset this option in order to leave it to GAP's `LoadPackage`


### PR DESCRIPTION
an alternative to and thus closes #1381, as proposed by @lgoettgens:

Always set a `Download` timeout of 30 seconds, except if the value in the user's `gap.ini` defines already a finite timeout value.