### PR TITLE
Improve CI coverage tracking for JuliaInterface

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           JULIA_DEBUG: "GAP"
         run: |
-          julia --project=. --depwarn=error -e 'import GAP; GAP.create_gap_sh("/tmp"; code_coverage=true)'
+          julia --project=. --depwarn=error -e 'import GAP; GAP.create_gap_sh("/tmp"; code_coverage="user")'
           export GAP="/tmp/gap.sh -A --quitonbreak --norepl"
           etc/ci_test.sh
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           JULIA_DEBUG: "GAP"
         run: |
-          julia --project=. --depwarn=error -e 'import GAP; GAP.create_gap_sh("/tmp")'
+          julia --project=. --depwarn=error -e 'import GAP; GAP.create_gap_sh("/tmp"; code_coverage=true)'
           export GAP="/tmp/gap.sh -A --quitonbreak --norepl"
           etc/ci_test.sh
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,8 +63,19 @@ jobs:
         uses: julia-actions/julia-buildpkg@v1
       - name: "Run tests"
         uses: julia-actions/julia-runtest@v1
+        env:
+          CFLAGS: "--coverage"
+          LDFLAGS: "--coverage"
+          FORCE_JULIAINTERFACE_COMPILATION: "${{ github.workspace }}/pkg/JuliaInterface/tmp"
         with:
           depwarn: error
+      - name: "Process JuliaInterface C coverage from Julia tests"
+        run: |
+          JuliaInterfaceSo=$(find "${{ github.workspace }}/pkg/JuliaInterface/tmp/bin" -name JuliaInterface.so -type f | head -n 1)
+          test -n "${JuliaInterfaceSo}"
+          echo "GAP_JL_JULIAINTERFACE_SO=${JuliaInterfaceSo}" >> "${GITHUB_ENV}"
+          cd pkg/JuliaInterface
+          gcov -o "${{ github.workspace }}/pkg/JuliaInterface/tmp/gen/src/" src/*.c*
       - name: "Test REPL integration"
         if: matrix.julia-version != '1.10'
         run: etc/expect.sh --project=@. --code-coverage

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,19 +63,8 @@ jobs:
         uses: julia-actions/julia-buildpkg@v1
       - name: "Run tests"
         uses: julia-actions/julia-runtest@v1
-        env:
-          CFLAGS: "--coverage"
-          LDFLAGS: "--coverage"
-          FORCE_JULIAINTERFACE_COMPILATION: "${{ github.workspace }}/pkg/JuliaInterface/tmp"
         with:
           depwarn: error
-      - name: "Process JuliaInterface C coverage from Julia tests"
-        run: |
-          JuliaInterfaceSo=$(find "${{ github.workspace }}/pkg/JuliaInterface/tmp/bin" -name JuliaInterface.so -type f | head -n 1)
-          test -n "${JuliaInterfaceSo}"
-          echo "GAP_JL_JULIAINTERFACE_SO=${JuliaInterfaceSo}" >> "${GITHUB_ENV}"
-          cd pkg/JuliaInterface
-          gcov -o "${{ github.workspace }}/pkg/JuliaInterface/tmp/gen/src/" src/*.c*
       - name: "Test REPL integration"
         if: matrix.julia-version != '1.10'
         run: etc/expect.sh --project=@. --code-coverage

--- a/.github/workflows/treehash.yml
+++ b/.github/workflows/treehash.yml
@@ -48,7 +48,15 @@ jobs:
         with:
           depwarn: error
         env:
-          FORCE_JULIAINTERFACE_COMPILATION: "true"
+          CFLAGS: "--coverage"
+          LDFLAGS: "--coverage"
+          FORCE_JULIAINTERFACE_COMPILATION: "${{ github.workspace }}/pkg/JuliaInterface/tmp"
+      - name: "Process JuliaInterface C coverage"
+        run: |
+          JuliaInterfaceSo=$(find "${{ github.workspace }}/pkg/JuliaInterface/tmp/bin" -name JuliaInterface.so -type f | head -n 1)
+          test -n "${JuliaInterfaceSo}"
+          cd pkg/JuliaInterface
+          gcov -o "${{ github.workspace }}/pkg/JuliaInterface/tmp/gen/src/" src/*.c*
       - name: "Process code coverage"
         uses: julia-actions/julia-processcoverage@v1
       - name: "Upload coverage data to Codecov"

--- a/.github/workflows/treehash.yml
+++ b/.github/workflows/treehash.yml
@@ -61,9 +61,8 @@ jobs:
         run: |
           JuliaInterfaceSo=$(cat juliainterface.path)
           test -f "${JuliaInterfaceSo}"
-          JuliaInterfaceBuildDir=$(cd "$(dirname "${JuliaInterfaceSo}")/../.." && pwd)
           cd pkg/JuliaInterface
-          gcov -o "${JuliaInterfaceBuildDir}/gen/src/" src/*.c*
+          gcov -o ./tmp/gen/src/ src/*.c*
       - name: "Process code coverage"
         uses: julia-actions/julia-processcoverage@v1
       - name: "Upload coverage data to Codecov"

--- a/.github/workflows/treehash.yml
+++ b/.github/workflows/treehash.yml
@@ -43,14 +43,20 @@ jobs:
       # next verify that GAP.jl still runs when forced to rebuild juliainterface;
       # as a side effect this also reduce code coverage fluctuation when
       # updating GAP_pkg_juliainterface_jll
-      - name: "Run tests"
-        uses: julia-actions/julia-runtest@v1
-        with:
-          depwarn: error
+      - name: "Build JuliaInterface for C coverage"
         env:
           CFLAGS: "--coverage"
           LDFLAGS: "--coverage"
           FORCE_JULIAINTERFACE_COMPILATION: "${{ github.workspace }}/pkg/JuliaInterface/tmp"
+        run: |
+          julia --project=. --color=yes -e 'import GAP; write("juliainterface.path", GAP.JuliaInterface_path)'
+          JuliaInterfaceSo=$(cat juliainterface.path)
+          test -f "${JuliaInterfaceSo}"
+          echo "GAP_JL_JULIAINTERFACE_SO=${JuliaInterfaceSo}" >> "${GITHUB_ENV}"
+      - name: "Run tests"
+        uses: julia-actions/julia-runtest@v1
+        with:
+          depwarn: error
       - name: "Process JuliaInterface C coverage"
         run: |
           JuliaInterfaceSo=$(find "${{ github.workspace }}/pkg/JuliaInterface/tmp/bin" -name JuliaInterface.so -type f | head -n 1)

--- a/.github/workflows/treehash.yml
+++ b/.github/workflows/treehash.yml
@@ -59,10 +59,11 @@ jobs:
           depwarn: error
       - name: "Process JuliaInterface C coverage"
         run: |
-          JuliaInterfaceSo=$(find "${{ github.workspace }}/pkg/JuliaInterface/tmp/bin" -name JuliaInterface.so -type f | head -n 1)
-          test -n "${JuliaInterfaceSo}"
+          JuliaInterfaceSo=$(cat juliainterface.path)
+          test -f "${JuliaInterfaceSo}"
+          JuliaInterfaceBuildDir=$(cd "$(dirname "${JuliaInterfaceSo}")/../.." && pwd)
           cd pkg/JuliaInterface
-          gcov -o "${{ github.workspace }}/pkg/JuliaInterface/tmp/gen/src/" src/*.c*
+          gcov -o "${JuliaInterfaceBuildDir}/gen/src/" src/*.c*
       - name: "Process code coverage"
         uses: julia-actions/julia-processcoverage@v1
       - name: "Upload coverage data to Codecov"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Update the GAP package distribution to 4.16.0
 - Update the `utils` GAP package to 0.96
 - Add conversion from Nemo type `AbsSimpleNumFieldElem` to GAP objects
+- Add keyword argument `code_coverage` to `create_gap_sh`
 
 ## Version 0.16.7 (released 2026-06-09)
 

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -5,17 +5,26 @@ set -x
 
 AnyFailures=No
 
+JuliaInterfaceBuildDir="${PWD}/pkg/JuliaInterface/tmp"
+
+export CFLAGS="${CFLAGS:+${CFLAGS} }--coverage"
+export LDFLAGS="${LDFLAGS:+${LDFLAGS} }--coverage"
+export FORCE_JULIAINTERFACE_COMPILATION="${JuliaInterfaceBuildDir}"
+
 mkdir -p coverage
 #
 cd pkg/JuliaInterface
 pwd
 # Force recompilation of JuliaInterface with coverage instrumentation.
 # Use a fixed build directory so that gcov can find .gcno/.gcda files.
-CFLAGS="--coverage" LDFLAGS="--coverage" FORCE_JULIAINTERFACE_COMPILATION=tmp ${GAP} --nointeract
+${GAP} --nointeract
+JuliaInterfaceSo=$(find "${JuliaInterfaceBuildDir}/bin" -name JuliaInterface.so -type f | head -n 1)
+test -n "${JuliaInterfaceSo}"
+export GAP_JL_JULIAINTERFACE_SO="${JuliaInterfaceSo}"
+unset FORCE_JULIAINTERFACE_COMPILATION
+
 ${GAP} makedoc.g
 ${GAP} --cover ../../coverage/JuliaInterface.coverage -r tst/testall.g || AnyFailures=Yes
-gcov -o tmp/gen/src/ src/*.c*
-rm -rf tmp # Delete the coverage instrumentation in JuliaInterface again
 cd ../..
 
 #
@@ -23,6 +32,11 @@ cd pkg/JuliaExperimental
 pwd
 ${GAP} makedoc.g
 ${GAP} --cover ../../coverage/JuliaExperimental.coverage -r tst/testall.g || AnyFailures=Yes
+cd ../..
+
+cd pkg/JuliaInterface
+gcov -o "${JuliaInterfaceBuildDir}/gen/src/" src/*.c*
+rm -rf "${JuliaInterfaceBuildDir}" # Delete the coverage instrumentation in JuliaInterface again
 cd ../..
 
 if [ ${AnyFailures} = Yes ]

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -20,8 +20,18 @@ then
     JuliaInterfaceSo="${GAP_JL_JULIAINTERFACE_SO}"
     test -f "${JuliaInterfaceSo}"
     JuliaInterfaceBuildDir=$(cd "$(dirname "${JuliaInterfaceSo}")/../.." && pwd)
-    unset FORCE_JULIAINTERFACE_COMPILATION
-else
+    if [ -d "${JuliaInterfaceBuildDir}/gen/src" ] && ls "${JuliaInterfaceBuildDir}"/gen/src/*.gcno >/dev/null 2>&1
+    then
+        unset FORCE_JULIAINTERFACE_COMPILATION
+    else
+        unset GAP_JL_JULIAINTERFACE_SO
+    fi
+fi
+if [ -z "${GAP_JL_JULIAINTERFACE_SO:-}" ]
+then
+    JuliaInterfaceBuildDir="${JULIAINTERFACE_COVERAGE_BUILD_DIR:-${PWD}/../../pkg/JuliaInterface/tmp}"
+    mkdir -p "${JuliaInterfaceBuildDir}"
+    JuliaInterfaceBuildDir=$(cd "${JuliaInterfaceBuildDir}" && pwd)
     # Force recompilation of JuliaInterface with coverage instrumentation.
     # Use a fixed build directory so that gcov can find .gcno/.gcda files.
     export FORCE_JULIAINTERFACE_COMPILATION="${JuliaInterfaceBuildDir}"
@@ -31,6 +41,8 @@ else
     export GAP_JL_JULIAINTERFACE_SO="${JuliaInterfaceSo}"
     unset FORCE_JULIAINTERFACE_COMPILATION
     RemoveJuliaInterfaceBuildDir=Yes
+else
+    RemoveJuliaInterfaceBuildDir=No
 fi
 test -d "${JuliaInterfaceBuildDir}/gen/src"
 

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -9,6 +9,21 @@ DefaultJuliaInterfaceBuildDir="${PWD}/pkg/JuliaInterface/tmp"
 JuliaInterfaceBuildDir="${DefaultJuliaInterfaceBuildDir}"
 RemoveJuliaInterfaceBuildDir=No
 
+build_JuliaInterface_for_coverage() {
+    JuliaInterfaceBuildDir="${DefaultJuliaInterfaceBuildDir}"
+    mkdir -p "${JuliaInterfaceBuildDir}"
+    JuliaInterfaceBuildDir=$(cd "${JuliaInterfaceBuildDir}" && pwd)
+    # Force recompilation of JuliaInterface with coverage instrumentation.
+    # Use a fixed build directory so that gcov can find .gcno/.gcda files.
+    export FORCE_JULIAINTERFACE_COMPILATION="${JuliaInterfaceBuildDir}"
+    ${GAP} --nointeract
+    JuliaInterfaceSo=$(find "${JuliaInterfaceBuildDir}/bin" -name JuliaInterface.so -type f | head -n 1)
+    test -n "${JuliaInterfaceSo}"
+    export GAP_JL_JULIAINTERFACE_SO="${JuliaInterfaceSo}"
+    unset FORCE_JULIAINTERFACE_COMPILATION
+    RemoveJuliaInterfaceBuildDir=Yes
+}
+
 export CFLAGS="${CFLAGS:+${CFLAGS} }--coverage"
 export LDFLAGS="${LDFLAGS:+${LDFLAGS} }--coverage"
 
@@ -24,26 +39,13 @@ then
     if [ -d "${JuliaInterfaceBuildDir}/gen/src" ] && ls "${JuliaInterfaceBuildDir}"/gen/src/*.gcno >/dev/null 2>&1
     then
         unset FORCE_JULIAINTERFACE_COMPILATION
+        RemoveJuliaInterfaceBuildDir=No
     else
         unset GAP_JL_JULIAINTERFACE_SO
+        build_JuliaInterface_for_coverage
     fi
-fi
-if [ -z "${GAP_JL_JULIAINTERFACE_SO:-}" ]
-then
-    JuliaInterfaceBuildDir="${DefaultJuliaInterfaceBuildDir}"
-    mkdir -p "${JuliaInterfaceBuildDir}"
-    JuliaInterfaceBuildDir=$(cd "${JuliaInterfaceBuildDir}" && pwd)
-    # Force recompilation of JuliaInterface with coverage instrumentation.
-    # Use a fixed build directory so that gcov can find .gcno/.gcda files.
-    export FORCE_JULIAINTERFACE_COMPILATION="${JuliaInterfaceBuildDir}"
-    ${GAP} --nointeract
-    JuliaInterfaceSo=$(find "${JuliaInterfaceBuildDir}/bin" -name JuliaInterface.so -type f | head -n 1)
-    test -n "${JuliaInterfaceSo}"
-    export GAP_JL_JULIAINTERFACE_SO="${JuliaInterfaceSo}"
-    unset FORCE_JULIAINTERFACE_COMPILATION
-    RemoveJuliaInterfaceBuildDir=Yes
 else
-    RemoveJuliaInterfaceBuildDir=No
+    build_JuliaInterface_for_coverage
 fi
 test -d "${JuliaInterfaceBuildDir}/gen/src"
 

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -5,7 +5,8 @@ set -x
 
 AnyFailures=No
 
-JuliaInterfaceBuildDir="${JULIAINTERFACE_COVERAGE_BUILD_DIR:-${PWD}/pkg/JuliaInterface/tmp}"
+DefaultJuliaInterfaceBuildDir="${PWD}/pkg/JuliaInterface/tmp"
+JuliaInterfaceBuildDir="${DefaultJuliaInterfaceBuildDir}"
 RemoveJuliaInterfaceBuildDir=No
 
 export CFLAGS="${CFLAGS:+${CFLAGS} }--coverage"
@@ -29,7 +30,7 @@ then
 fi
 if [ -z "${GAP_JL_JULIAINTERFACE_SO:-}" ]
 then
-    JuliaInterfaceBuildDir="${JULIAINTERFACE_COVERAGE_BUILD_DIR:-${PWD}/../../pkg/JuliaInterface/tmp}"
+    JuliaInterfaceBuildDir="${DefaultJuliaInterfaceBuildDir}"
     mkdir -p "${JuliaInterfaceBuildDir}"
     JuliaInterfaceBuildDir=$(cd "${JuliaInterfaceBuildDir}" && pwd)
     # Force recompilation of JuliaInterface with coverage instrumentation.

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -45,7 +45,7 @@ mkdir -p coverage
 # Enter the JuliaInterface GAP package directory. makedoc.g, tst/testall.g,
 # and the later gcov invocation are all relative to this directory.
 cd pkg/JuliaInterface
-pwd
+pwd  # for debugging
 
 # Some callers, notably the treehash workflow, prebuild an instrumented
 # JuliaInterface.so and pass it in GAP_JL_JULIAINTERFACE_SO. Reuse it only if

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -5,18 +5,31 @@ set -x
 
 AnyFailures=No
 
+# If this script has to build JuliaInterface itself, use a predictable
+# out-of-tree build directory below the checkout. gcov needs the matching
+# .gcno files from that build directory after the tests have run.
 DefaultJuliaInterfaceBuildDir="${PWD}/pkg/JuliaInterface/tmp"
+
+# This may be replaced below when a caller provides GAP_JL_JULIAINTERFACE_SO.
+# In that case it points at the build directory containing the provided .so.
 JuliaInterfaceBuildDir="${DefaultJuliaInterfaceBuildDir}"
+
+# Only delete the build directory when this script created it. Callers that
+# prebuild and pass GAP_JL_JULIAINTERFACE_SO own their build directory.
 RemoveJuliaInterfaceBuildDir=No
 
 build_JuliaInterface_for_coverage() {
     JuliaInterfaceBuildDir="${DefaultJuliaInterfaceBuildDir}"
     mkdir -p "${JuliaInterfaceBuildDir}"
     JuliaInterfaceBuildDir=$(cd "${JuliaInterfaceBuildDir}" && pwd)
+
     # Force recompilation of JuliaInterface with coverage instrumentation.
     # Use a fixed build directory so that gcov can find .gcno/.gcda files.
     export FORCE_JULIAINTERFACE_COMPILATION="${JuliaInterfaceBuildDir}"
     ${GAP} --nointeract
+
+    # Tell subsequent GAP.jl sessions to load this instrumented library instead
+    # of rebuilding or using the JLL-provided JuliaInterface.so.
     JuliaInterfaceSo=$(find "${JuliaInterfaceBuildDir}/bin" -name JuliaInterface.so -type f | head -n 1)
     test -n "${JuliaInterfaceSo}"
     export GAP_JL_JULIAINTERFACE_SO="${JuliaInterfaceSo}"
@@ -28,14 +41,24 @@ export CFLAGS="${CFLAGS:+${CFLAGS} }--coverage"
 export LDFLAGS="${LDFLAGS:+${LDFLAGS} }--coverage"
 
 mkdir -p coverage
-#
+
+# Enter the JuliaInterface GAP package directory. makedoc.g, tst/testall.g,
+# and the later gcov invocation are all relative to this directory.
 cd pkg/JuliaInterface
 pwd
+
+# Some callers, notably the treehash workflow, prebuild an instrumented
+# JuliaInterface.so and pass it in GAP_JL_JULIAINTERFACE_SO. Reuse it only if
+# it comes from a gcov build: the .so path alone is not enough, because other
+# workflows may also force a local build without coverage instrumentation.
 if [ -n "${GAP_JL_JULIAINTERFACE_SO:-}" ]
 then
     JuliaInterfaceSo="${GAP_JL_JULIAINTERFACE_SO}"
     test -f "${JuliaInterfaceSo}"
     JuliaInterfaceBuildDir=$(cd "$(dirname "${JuliaInterfaceSo}")/../.." && pwd)
+
+    # gcov requires .gcno files emitted at compile time. If they are missing,
+    # ignore the provided library and build a coverage-instrumented one here.
     if [ -d "${JuliaInterfaceBuildDir}/gen/src" ] && ls "${JuliaInterfaceBuildDir}"/gen/src/*.gcno >/dev/null 2>&1
     then
         unset FORCE_JULIAINTERFACE_COMPILATION
@@ -49,19 +72,28 @@ else
 fi
 test -d "${JuliaInterfaceBuildDir}/gen/src"
 
+# Build the JuliaInterface manual. This also checks the manual examples.
 ${GAP} makedoc.g
+
+# Run the JuliaInterface GAP test suite while collecting GAP-level coverage.
 ${GAP} --cover ../../coverage/JuliaInterface.coverage -r tst/testall.g || AnyFailures=Yes
 cd ../..
 
-#
+# Build docs and run the JuliaExperimental GAP tests as part of the bundled
+# GAP package checks. These reuse the same instrumented JuliaInterface.so.
 cd pkg/JuliaExperimental
 pwd
 ${GAP} makedoc.g
 ${GAP} --cover ../../coverage/JuliaExperimental.coverage -r tst/testall.g || AnyFailures=Yes
 cd ../..
 
+# Convert the C coverage counters from the instrumented JuliaInterface build
+# into .gcov files for Codecov. This must happen before deleting the build dir.
 cd pkg/JuliaInterface
 gcov -o "${JuliaInterfaceBuildDir}/gen/src/" src/*.c*
+
+# Avoid leaving this script's temporary coverage build behind. When the build
+# was supplied by the caller, keep it available for later workflow steps.
 if [ "${RemoveJuliaInterfaceBuildDir}" = Yes ]
 then
     rm -rf "${JuliaInterfaceBuildDir}" # Delete the coverage instrumentation in JuliaInterface again

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -5,23 +5,34 @@ set -x
 
 AnyFailures=No
 
-JuliaInterfaceBuildDir="${PWD}/pkg/JuliaInterface/tmp"
+JuliaInterfaceBuildDir="${JULIAINTERFACE_COVERAGE_BUILD_DIR:-${PWD}/pkg/JuliaInterface/tmp}"
+RemoveJuliaInterfaceBuildDir=No
 
 export CFLAGS="${CFLAGS:+${CFLAGS} }--coverage"
 export LDFLAGS="${LDFLAGS:+${LDFLAGS} }--coverage"
-export FORCE_JULIAINTERFACE_COMPILATION="${JuliaInterfaceBuildDir}"
 
 mkdir -p coverage
 #
 cd pkg/JuliaInterface
 pwd
-# Force recompilation of JuliaInterface with coverage instrumentation.
-# Use a fixed build directory so that gcov can find .gcno/.gcda files.
-${GAP} --nointeract
-JuliaInterfaceSo=$(find "${JuliaInterfaceBuildDir}/bin" -name JuliaInterface.so -type f | head -n 1)
-test -n "${JuliaInterfaceSo}"
-export GAP_JL_JULIAINTERFACE_SO="${JuliaInterfaceSo}"
-unset FORCE_JULIAINTERFACE_COMPILATION
+if [ -n "${GAP_JL_JULIAINTERFACE_SO:-}" ]
+then
+    JuliaInterfaceSo="${GAP_JL_JULIAINTERFACE_SO}"
+    test -f "${JuliaInterfaceSo}"
+    JuliaInterfaceBuildDir=$(cd "$(dirname "${JuliaInterfaceSo}")/../.." && pwd)
+    unset FORCE_JULIAINTERFACE_COMPILATION
+else
+    # Force recompilation of JuliaInterface with coverage instrumentation.
+    # Use a fixed build directory so that gcov can find .gcno/.gcda files.
+    export FORCE_JULIAINTERFACE_COMPILATION="${JuliaInterfaceBuildDir}"
+    ${GAP} --nointeract
+    JuliaInterfaceSo=$(find "${JuliaInterfaceBuildDir}/bin" -name JuliaInterface.so -type f | head -n 1)
+    test -n "${JuliaInterfaceSo}"
+    export GAP_JL_JULIAINTERFACE_SO="${JuliaInterfaceSo}"
+    unset FORCE_JULIAINTERFACE_COMPILATION
+    RemoveJuliaInterfaceBuildDir=Yes
+fi
+test -d "${JuliaInterfaceBuildDir}/gen/src"
 
 ${GAP} makedoc.g
 ${GAP} --cover ../../coverage/JuliaInterface.coverage -r tst/testall.g || AnyFailures=Yes
@@ -36,7 +47,10 @@ cd ../..
 
 cd pkg/JuliaInterface
 gcov -o "${JuliaInterfaceBuildDir}/gen/src/" src/*.c*
-rm -rf "${JuliaInterfaceBuildDir}" # Delete the coverage instrumentation in JuliaInterface again
+if [ "${RemoveJuliaInterfaceBuildDir}" = Yes ]
+then
+    rm -rf "${JuliaInterfaceBuildDir}" # Delete the coverage instrumentation in JuliaInterface again
+fi
 cd ../..
 
 if [ ${AnyFailures} = Yes ]

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -26,12 +26,15 @@ build_JuliaInterface_for_coverage() {
     # Force recompilation of JuliaInterface with coverage instrumentation.
     # Use a fixed build directory so that gcov can find .gcno/.gcda files.
     export FORCE_JULIAINTERFACE_COMPILATION="${JuliaInterfaceBuildDir}"
-    ${GAP} --nointeract
+
+    # Run GAP through Julia to get it to create JuliaInterface.so, and then
+    # write the path to it into a file for use later on.
+    ${GAP} --nointeract -c 'FileString("juliainterface.path", JuliaToGAP(IsString, GAP_jl.JuliaInterface_path)); QUIT;'
 
     # Tell subsequent GAP.jl sessions to load this instrumented library instead
     # of rebuilding or using the JLL-provided JuliaInterface.so.
-    JuliaInterfaceSo=$(find "${JuliaInterfaceBuildDir}/bin" -name JuliaInterface.so -type f | head -n 1)
-    test -n "${JuliaInterfaceSo}"
+    JuliaInterfaceSo=$(cat juliainterface.path)
+    test -f "${JuliaInterfaceSo}"
     export GAP_JL_JULIAINTERFACE_SO="${JuliaInterfaceSo}"
     unset FORCE_JULIAINTERFACE_COMPILATION
     RemoveJuliaInterfaceBuildDir=Yes

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -216,6 +216,13 @@ function build_JuliaInterface(builddir::String)
 end
 
 function locate_JuliaInterface_so()
+    if haskey(ENV, "GAP_JL_JULIAINTERFACE_SO")
+        path = abspath(ENV["GAP_JL_JULIAINTERFACE_SO"])
+        isfile(path) || error("GAP_JL_JULIAINTERFACE_SO does not point to a file: $(path)")
+        @debug "Use JuliaInterface.so from GAP_JL_JULIAINTERFACE_SO=$(path)"
+        return path
+    end
+
     # compare the C sources used to build GAP_pkg_juliainterface_jll with bundled copies
     # by comparing tree hashes
     jll = GAP_pkg_juliainterface_jll.find_artifact_dir()
@@ -259,7 +266,8 @@ function locate_JuliaInterface_so()
 end
 
 """
-    create_gap_sh(dstdir::String, dstname::String="gap.sh")
+    create_gap_sh(dstdir::String, dstname::String="gap.sh";
+                  code_coverage::Bool=Base.JLOptions().code_coverage != 0)
 
 Given a directory path, create three files in that directory:
 - a shell script named `dstname` which acts like the `gap.sh` shipped with a
@@ -270,8 +278,13 @@ Given a directory path, create three files in that directory:
 - two TOML files, `Manifest.toml` and `Project.toml`, which are required by
   the script to function (they record the precise versions of GAP.jl and other
   Julia packages involved)
+
+If `code_coverage` is `true`, the generated script starts Julia with
+`--code-coverage`. By default this follows the current Julia process.
 """
-function create_gap_sh(dstdir::String, dstname::String="gap.sh"; use_active_project::Bool=false)
+function create_gap_sh(dstdir::String, dstname::String="gap.sh";
+                       use_active_project::Bool=false,
+                       code_coverage::Bool=Base.JLOptions().code_coverage != 0)
     dstname == basename(dstname) || error("`dstname` must be a file name, not a path")
 
     dstdir = expanduser(dstdir)
@@ -300,6 +313,10 @@ function create_gap_sh(dstdir::String, dstname::String="gap.sh"; use_active_proj
         @info "Generating gap.sh ..."
     end
 
+    julia_cmd = filter(arg -> !startswith(arg, "--code-coverage"), String.(Base.julia_cmd().exec))
+    if code_coverage
+        push!(julia_cmd, "--code-coverage")
+    end
 
     gap_sh_path = joinpath(dstdir, dstname)
     write(gap_sh_path,
@@ -317,7 +334,7 @@ function create_gap_sh(dstdir::String, dstname::String="gap.sh"; use_active_proj
         else
             READ_STARTUP_FILE="no"
         fi
-        exec $(join(Base.julia_cmd().exec, " ")) --startup-file=\$READ_STARTUP_FILE --project=\$(dirname \"\$0\") -i -- \"\$0\" "\$@"
+        exec $(join(julia_cmd, " ")) --startup-file=\$READ_STARTUP_FILE --project=\$(dirname \"\$0\") -i -- \"\$0\" "\$@"
         =#
 
         # pass command line arguments to GAP.jl via a small hack

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -267,7 +267,7 @@ end
 
 """
     create_gap_sh(dstdir::String, dstname::String="gap.sh";
-                  code_coverage::Bool=Base.JLOptions().code_coverage != 0)
+                  code_coverage::Union{Nothing,String}=nothing)
 
 Given a directory path, create three files in that directory:
 - a shell script named `dstname` which acts like the `gap.sh` shipped with a
@@ -279,12 +279,13 @@ Given a directory path, create three files in that directory:
   the script to function (they record the precise versions of GAP.jl and other
   Julia packages involved)
 
-If `code_coverage` is `true`, the generated script starts Julia with
-`--code-coverage`. By default this follows the current Julia process.
+If `code_coverage` is a string, the generated script appends
+`--code-coverage=\$(code_coverage)` when starting Julia. By default, it
+inherits the flags of the current Julia process.
 """
 function create_gap_sh(dstdir::String, dstname::String="gap.sh";
                        use_active_project::Bool=false,
-                       code_coverage::Bool=Base.JLOptions().code_coverage != 0)
+                       code_coverage::Union{Nothing,String}=nothing)
     dstname == basename(dstname) || error("`dstname` must be a file name, not a path")
 
     dstdir = expanduser(dstdir)
@@ -313,9 +314,9 @@ function create_gap_sh(dstdir::String, dstname::String="gap.sh";
         @info "Generating gap.sh ..."
     end
 
-    julia_cmd = filter(arg -> !startswith(arg, "--code-coverage"), String.(Base.julia_cmd().exec))
-    if code_coverage
-        push!(julia_cmd, "--code-coverage")
+    julia_cmd = String.(Base.julia_cmd().exec)
+    if code_coverage !== nothing
+        push!(julia_cmd, "--code-coverage=$(code_coverage)")
     end
 
     gap_sh_path = joinpath(dstdir, dstname)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -158,6 +158,13 @@ end
     @test GapObj([1, 2, 3, 4, 5, 6, 7]) == f(1, 2, 3, 4, 5, 6, 7)
 end
 
+@testset "gapcalls border cases" begin
+    # check argument validation of internal helprs
+    @test_throws MethodError GAP.slow_call_gap_func_nokw(1,1)
+    @test_throws ErrorException GAP.slow_call_gap_func_nokw(GAP.Globals.SymmetricGroup,1)
+    @test GAP.slow_call_gap_func_nokw(GAP.Globals.SymmetricGroup,(1,)) isa Ptr
+end
+
 @testset "bugfixes" begin
     # from issue #324:
     l = GAP.evalstr("[1,~,3]")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ include("constructors.jl")
 include("macros.jl")
 include("packages.jl")
 include("help.jl")
+include("setup.jl")
 include("rand.jl")
 
 if !(VERSION.major == 1 && VERSION.minor == 10) || Base.JLOptions().code_coverage == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,9 +54,6 @@ end
     GAP.create_gap_sh(tmpdir)
     cmd = Cmd(`$(joinpath("etc", "ci_test.sh"))`; dir=dirname(dirname(pathof(GAP))))
     cmd = addenv(cmd, "GAP" => "$(joinpath(tmpdir, "gap.sh")) -A --quitonbreak --norepl")
-    if haskey(ENV, "FORCE_JULIAINTERFACE_COMPILATION")
-      cmd = addenv(cmd, "GAP_JL_JULIAINTERFACE_SO" => GAP.JuliaInterface_path)
-    end
     @test success(pipeline(cmd; stdout, stderr))
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,9 @@ end
     GAP.create_gap_sh(tmpdir)
     cmd = Cmd(`$(joinpath("etc", "ci_test.sh"))`; dir=dirname(dirname(pathof(GAP))))
     cmd = addenv(cmd, "GAP" => "$(joinpath(tmpdir, "gap.sh")) -A --quitonbreak --norepl")
+    if haskey(ENV, "FORCE_JULIAINTERFACE_COMPILATION")
+      cmd = addenv(cmd, "GAP_JL_JULIAINTERFACE_SO" => GAP.JuliaInterface_path)
+    end
     @test success(pipeline(cmd; stdout, stderr))
   end
 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -22,24 +22,15 @@
   end
 
   mktempdir() do tmpdir
-    generated = true
-    try
-      GAP.create_gap_sh(tmpdir; use_active_project=true, code_coverage=true)
-    catch err
-      generated = false
-    end
-    @test generated
-
-    if generated
-      gap_sh = read(joinpath(tmpdir, "gap.sh"), String)
-      @test occursin("--code-coverage", gap_sh)
-    end
+    GAP.create_gap_sh(tmpdir; use_active_project=true, code_coverage="user")
+    gap_sh = read(joinpath(tmpdir, "gap.sh"), String)
+    @test occursin("--code-coverage=user", gap_sh)
   end
 
   mktempdir() do tmpdir
-    GAP.create_gap_sh(tmpdir; use_active_project=true, code_coverage=false)
+    GAP.create_gap_sh(tmpdir; use_active_project=true, code_coverage="none")
     gap_sh = read(joinpath(tmpdir, "gap.sh"), String)
-    @test !occursin("--code-coverage", gap_sh)
+    @test occursin("--code-coverage=none", gap_sh)
   end
 end
 

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -1,0 +1,54 @@
+#############################################################################
+##
+##  This file is part of GAP.jl, a bidirectional interface between Julia and
+##  the GAP computer algebra system.
+##
+##  Copyright of GAP.jl and its parts belongs to its developers.
+##  Please refer to its README.md file for details.
+##
+##  SPDX-License-Identifier: LGPL-3.0-or-later
+##
+
+@testset "create_gap_sh" begin
+  mktempdir() do tmpdir
+    GAP.create_gap_sh(tmpdir; use_active_project=true)
+    gap_sh = read(joinpath(tmpdir, "gap.sh"), String)
+
+    if Base.JLOptions().code_coverage != 0
+      @test occursin("--code-coverage", gap_sh)
+    else
+      @test !occursin("--code-coverage", gap_sh)
+    end
+  end
+
+  mktempdir() do tmpdir
+    generated = true
+    try
+      GAP.create_gap_sh(tmpdir; use_active_project=true, code_coverage=true)
+    catch err
+      generated = false
+    end
+    @test generated
+
+    if generated
+      gap_sh = read(joinpath(tmpdir, "gap.sh"), String)
+      @test occursin("--code-coverage", gap_sh)
+    end
+  end
+
+  mktempdir() do tmpdir
+    GAP.create_gap_sh(tmpdir; use_active_project=true, code_coverage=false)
+    gap_sh = read(joinpath(tmpdir, "gap.sh"), String)
+    @test !occursin("--code-coverage", gap_sh)
+  end
+end
+
+@testset "locate_JuliaInterface_so" begin
+  mktempdir() do tmpdir
+    override = joinpath(tmpdir, "JuliaInterface.so")
+    write(override, "")
+    withenv("GAP_JL_JULIAINTERFACE_SO" => override) do
+      @test GAP.Setup.locate_JuliaInterface_so() == override
+    end
+  end
+end


### PR DESCRIPTION
Generate gap.sh with coverage when requested.

Let CI reuse one instrumented JuliaInterface build explicitly.

Co-authored-by: Codex <codex@openai.com>

---

I've asked Codex to combine my earlier PRs trying to improve coverage, and make it work. Let's see...

WARNING: I have not yet reviewed this closely myself, though it did already undergo some revisions. Still, AI slop my await you, so don't waste your time reviewing this at this point unless you really want to :-). My goal is to first see if get a coverage increase; only then is it worth to invest more time.

Closes #1339. Closes #1343. Closes #1344.