### PR TITLE
Remove unreleased 0.16.7 from changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,6 @@
 - **Breaking:** Update to GAP 4.16.0
 - Update the GAP package distribution to 4.16.0
 - Update the `utils` GAP package to 0.96
-
-## Version 0.16.7-DEV (released 2026-XX-XX)
-
 - Set a timeout of 30 seconds for GAP's `Download` function,
   except if the user's `gap.ini` file defines already a finite timeout value.
 - Make the manual of the `JuliaInterface` GAP package available for interactive


### PR DESCRIPTION
Alternatively, we could create a release-0.16 branch right before merging the GAP 4.16.0 bump and do the 0.16.7 release from there. But I don't think that we get that much from that, so I wouldn't do that.