### PR TITLE
Split the treehash CI job into two

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -125,7 +125,7 @@ jobs:
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v3
         with:
-          version: ${{ matrix.julia-version }}
+          version: 1
         id: setup-julia
       - name: "Cache artifacts"
         uses: julia-actions/cache@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+
   docs:
     name: "Documentation"
     runs-on: ubuntu-latest
@@ -106,6 +107,58 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+
+
+  test-with-juliainterface-rebuild:
+    name: "Test with JuliaInterface rebuild"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # For Codecov, we must also fetch the parent of the HEAD commit to
+          # be able to properly deal with PRs / merges
+          fetch-depth: 2
+      - name: "Install extra dependencies"
+        if: runner.os == 'Linux'
+        run: sudo apt-get install expect
+      - name: "Set up Julia"
+        uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.julia-version }}
+        id: setup-julia
+      - name: "Cache artifacts"
+        uses: julia-actions/cache@v3
+      - name: "Build package"
+        uses: julia-actions/julia-buildpkg@v1
+      - name: "Build JuliaInterface for C coverage"
+        env:
+          CFLAGS: "--coverage"
+          LDFLAGS: "--coverage"
+          FORCE_JULIAINTERFACE_COMPILATION: "${{ github.workspace }}/pkg/JuliaInterface/tmp"
+        run: |
+          julia --project=. --color=yes -e 'import GAP; write("juliainterface.path", GAP.JuliaInterface_path)'
+          JuliaInterfaceSo=$(cat juliainterface.path)
+          test -f "${JuliaInterfaceSo}"
+          echo "GAP_JL_JULIAINTERFACE_SO=${JuliaInterfaceSo}" >> "${GITHUB_ENV}"
+      - name: "Run tests"
+        uses: julia-actions/julia-runtest@v1
+        with:
+          depwarn: error
+      - name: "Process JuliaInterface C coverage"
+        run: |
+          JuliaInterfaceSo=$(cat juliainterface.path)
+          test -f "${JuliaInterfaceSo}"
+          cd pkg/JuliaInterface
+          gcov -o ./tmp/gen/src/ src/*.c*
+      - name: "Process code coverage"
+        uses: julia-actions/julia-processcoverage@v1
+      - name: "Upload coverage data to Codecov"
+        continue-on-error: true
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   slack-notification:
     name: Send Slack notification on status change

--- a/.github/workflows/treehash.yml
+++ b/.github/workflows/treehash.yml
@@ -40,33 +40,3 @@ jobs:
             bundled_hash = GitTools.tree_hash(joinpath(bundled, "src"))
             jll_hash == bundled_hash || error("tree hash is $bundled_hash, but JLL uses $jll_hash")
             '
-      # next verify that GAP.jl still runs when forced to rebuild juliainterface;
-      # as a side effect this also reduce code coverage fluctuation when
-      # updating GAP_pkg_juliainterface_jll
-      - name: "Build JuliaInterface for C coverage"
-        env:
-          CFLAGS: "--coverage"
-          LDFLAGS: "--coverage"
-          FORCE_JULIAINTERFACE_COMPILATION: "${{ github.workspace }}/pkg/JuliaInterface/tmp"
-        run: |
-          julia --project=. --color=yes -e 'import GAP; write("juliainterface.path", GAP.JuliaInterface_path)'
-          JuliaInterfaceSo=$(cat juliainterface.path)
-          test -f "${JuliaInterfaceSo}"
-          echo "GAP_JL_JULIAINTERFACE_SO=${JuliaInterfaceSo}" >> "${GITHUB_ENV}"
-      - name: "Run tests"
-        uses: julia-actions/julia-runtest@v1
-        with:
-          depwarn: error
-      - name: "Process JuliaInterface C coverage"
-        run: |
-          JuliaInterfaceSo=$(cat juliainterface.path)
-          test -f "${JuliaInterfaceSo}"
-          cd pkg/JuliaInterface
-          gcov -o ./tmp/gen/src/ src/*.c*
-      - name: "Process code coverage"
-        uses: julia-actions/julia-processcoverage@v1
-      - name: "Upload coverage data to Codecov"
-        continue-on-error: true
-        uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
As suggested in https://github.com/oscar-system/GAP.jl/pull/1393#issuecomment-4727337149

The new "Test with JuliaInterface rebuild" job should also be marked as "required" in the github UI.