### PR TITLE
Update .gitignore to ignore coverage data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ Manifest.toml
 /tags
 *.log
 /coverage/
+*.cov
+*.gcda
+*.gcno
 *.gcov
 /override/
 /docs/src/assets/
+/pkg/JuliaInterface/juliainterface.path


### PR DESCRIPTION
When computing coverage locally, a bunch of files are left
in the file system. To make sure they are not accidentally
committed, add them to gitignore.
