### PR TITLE
NewJuliaObj: turn check into assert

### DIFF
--- a/pkg/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/JuliaInterface/src/JuliaInterface.c
@@ -117,8 +117,7 @@ static Obj JuliaObjectTypeFunc(Obj o)
 
 Obj NewJuliaObj(jl_value_t * v)
 {
-    if (is_gapobj(v))
-        return (Obj)v;
+    GAP_ASSERT(!is_gapobj(v));
     JL_GC_PUSH1(&v);
     Obj o = NewBag(T_JULIA_OBJ, 1 * sizeof(Obj));
     ADDR_OBJ(o)[0] = (Obj)v;


### PR DESCRIPTION
Calling this with a GAPObj would just be invalid, and our current
code cannot do this, ever. We also don't guard against e.g. null
pointers or other invalid pointer.

As a side effect, this also increases code coverage.
