### PR TITLE
Version 0.17.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes in GAP.jl
 
-## Version 0.17.0-DEV (released YYYY-MM-DD)
+## Version 0.17.0 (released 2026-06-18)
 
 - **Breaking:** Update to GAP 4.16.0
 - Update the GAP package distribution to 4.16.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GAP"
 uuid = "c863536a-3901-11e9-33e7-d5cd0df7b904"
-version = "0.17.0-DEV"
+version = "0.17.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/gap/systemfile.g
+++ b/gap/systemfile.g
@@ -39,7 +39,7 @@ end);
     # early enough for being required by other GAP packages,
     # and such that it is available when user files get read
     # via the GAP command line.
-    deps := [ [ "JuliaInterface", ">=0.17.0-DEV" ] ];
+    deps := [ [ "JuliaInterface", ">=0.17.0" ] ];
     if not IsBound(GAPInfo.KernelInfo.ENVIRONMENT.GAP_BARE_DEPS) then
         APPEND_LIST_INTR( deps, GAPInfo.Dependencies.NeededOtherPackages );
     fi;

--- a/pkg/JuliaExperimental/PackageInfo.g
+++ b/pkg/JuliaExperimental/PackageInfo.g
@@ -17,8 +17,8 @@ SetPackageInfo( rec(
 
 PackageName := "JuliaExperimental",
 Subtitle := "Experimental code for the GAP Julia integration",
-Version := "0.17.0-DEV",
-Date := "04/05/2026", # dd/mm/yyyy format
+Version := "0.17.0",
+Date := "18/06/2026", # dd/mm/yyyy format
 License := "LGPL-3.0-or-later",
 
 Persons := [

--- a/pkg/JuliaInterface/PackageInfo.g
+++ b/pkg/JuliaInterface/PackageInfo.g
@@ -18,8 +18,8 @@ SetPackageInfo( rec(
 
 PackageName := "JuliaInterface",
 Subtitle := "Interface to Julia",
-Version := "0.17.0-DEV",
-Date := "04/05/2026", # dd/mm/yyyy format
+Version := "0.17.0",
+Date := "18/06/2026", # dd/mm/yyyy format
 License := "LGPL-3.0-or-later",
 
 Persons := [


### PR DESCRIPTION
I think all the PRs that we wanted to wait for are now merged. I do not really have an opinion if we merge https://github.com/oscar-system/GAP.jl/pull/1398 and do the jll rebuild cycle before or after this release.

Downstream tests in https://github.com/oscar-system/GAP.jl/pull/1392 were happy yesterday. I just updated the branch there to latest master to really make sure that we don't break OSCAR. Once they are green again (and I *only* care there about downstream CI, in particular not about any julia nightly stuff), this PR is good to go from my POV.

Closes https://github.com/oscar-system/GAP.jl/pull/1392.