### PR TITLE
Isolate JuliaInterface C coverage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,9 +110,28 @@ jobs:
 
 
   test-with-juliainterface-rebuild:
-    name: "Test with JuliaInterface rebuild"
-    runs-on: ubuntu-latest
+    name: JuliaInterface rebuild - Julia ${{ matrix.julia-version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Collect C coverage with Julia LTS on Linux. Restricting C coverage
+          # to GCC on Linux avoids merging incompatible executable-line maps.
+          - julia-version: lts
+            os: ubuntu-latest
+
+          # Also test the rebuild with the latest stable Julia on Linux.
+          - julia-version: '1'
+            os: ubuntu-latest
+
+          # Cover platform-specific Julia setup code on macOS as well. Do not
+          # collect C coverage here: Clang on macOS and GCC on Linux disagree
+          # about which C source lines are executable, and merging their reports
+          # makes Codecov mark covered continuation lines as uncovered.
+          - julia-version: '1'
+            os: macOS-latest
     steps:
       - uses: actions/checkout@v7
         with:
@@ -125,40 +144,48 @@ jobs:
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v3
         with:
-          version: 1
+          version: ${{ matrix.julia-version }}
         id: setup-julia
       - name: "Cache artifacts"
         uses: julia-actions/cache@v3
       - name: "Build package"
         uses: julia-actions/julia-buildpkg@v1
-      - name: "Build JuliaInterface for C coverage"
+      - name: "Build JuliaInterface with coverage"
         env:
-          CFLAGS: "--coverage"
-          LDFLAGS: "--coverage"
+          CFLAGS: ${{ runner.os == 'Linux' && matrix.julia-version == 'lts' && '--coverage' || '' }}
+          LDFLAGS: ${{ runner.os == 'Linux' && matrix.julia-version == 'lts' && '--coverage' || '' }}
           JULIAINTERFACE_BUILD_DIR: "${{ github.workspace }}/pkg/JuliaInterface/tmp"
         run: |
           mkdir -p pkg/JuliaInterface/src/force-treehash-mismatch
           touch pkg/JuliaInterface/src/force-treehash-mismatch/nonempty
-          julia --project=. --color=yes -e 'import GAP; write("juliainterface.path", GAP.JuliaInterface_path)'
+          julia --project=. --color=yes --code-coverage=user -e 'import GAP; write("juliainterface.path", GAP.JuliaInterface_path)'
           JuliaInterfaceSo=$(cat juliainterface.path)
           test -f "${JuliaInterfaceSo}"
           echo "GAP_JL_JULIAINTERFACE_SO=${JuliaInterfaceSo}" >> "${GITHUB_ENV}"
       - name: "Run tests"
         uses: julia-actions/julia-runtest@v1
+        env:
+          # Emit C reports only for the Julia LTS job using GCC on Linux.
+          JULIAINTERFACE_COVERAGE: ${{ runner.os == 'Linux' && matrix.julia-version == 'lts' && 'Yes' || 'No' }}
         with:
           depwarn: error
       - name: "Process JuliaInterface C coverage"
+        if: runner.os == 'Linux' && matrix.julia-version == 'lts'
         run: |
           JuliaInterfaceSo=$(cat juliainterface.path)
           test -f "${JuliaInterfaceSo}"
           cd pkg/JuliaInterface
           gcov -o ./tmp/gen/src/ src/*.c*
-      - name: "Process code coverage"
+      - name: "Process Julia code coverage"
         uses: julia-actions/julia-processcoverage@v1
       - name: "Upload coverage data to Codecov"
         continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
+          # We run gcov ourselves after the tests so its reports contain all
+          # accumulated counters. Disable the plugin to prevent Codecov from
+          # running gcov again and creating duplicate reports.
+          plugins: noop
           token: ${{ secrets.CODECOV_TOKEN }}
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -121,10 +121,12 @@ jobs:
           # to GCC on Linux avoids merging incompatible executable-line maps.
           - julia-version: lts
             os: ubuntu-latest
+            c-coverage: true
 
           # Also test the rebuild with the latest stable Julia on Linux.
           - julia-version: '1'
             os: ubuntu-latest
+            c-coverage: false
 
           # Cover platform-specific Julia setup code on macOS as well. Do not
           # collect C coverage here: Clang on macOS and GCC on Linux disagree
@@ -132,6 +134,7 @@ jobs:
           # makes Codecov mark covered continuation lines as uncovered.
           - julia-version: '1'
             os: macOS-latest
+            c-coverage: false
     steps:
       - uses: actions/checkout@v7
         with:
@@ -152,12 +155,15 @@ jobs:
         uses: julia-actions/julia-buildpkg@v1
       - name: "Build JuliaInterface with coverage"
         env:
-          CFLAGS: ${{ runner.os == 'Linux' && matrix.julia-version == 'lts' && '--coverage' || '' }}
-          LDFLAGS: ${{ runner.os == 'Linux' && matrix.julia-version == 'lts' && '--coverage' || '' }}
+          CFLAGS: ${{ matrix.c-coverage && '--coverage' || '' }}
+          LDFLAGS: ${{ matrix.c-coverage && '--coverage' || '' }}
           JULIAINTERFACE_BUILD_DIR: "${{ github.workspace }}/pkg/JuliaInterface/tmp"
         run: |
+          # Exercise the automatic rebuild when the bundled sources differ from the JLL.
           mkdir -p pkg/JuliaInterface/src/force-treehash-mismatch
           touch pkg/JuliaInterface/src/force-treehash-mismatch/nonempty
+          # Collect Julia coverage in every rebuild job, including macOS-specific
+          # setup code. The c-coverage matrix field controls C instrumentation only.
           julia --project=. --color=yes --code-coverage=user -e 'import GAP; write("juliainterface.path", GAP.JuliaInterface_path)'
           JuliaInterfaceSo=$(cat juliainterface.path)
           test -f "${JuliaInterfaceSo}"
@@ -165,16 +171,17 @@ jobs:
       - name: "Run tests"
         uses: julia-actions/julia-runtest@v1
         env:
-          # Emit C reports only for the Julia LTS job using GCC on Linux.
-          JULIAINTERFACE_COVERAGE: ${{ runner.os == 'Linux' && matrix.julia-version == 'lts' && 'Yes' || 'No' }}
+          JULIAINTERFACE_COVERAGE: ${{ matrix.c-coverage && 'Yes' || 'No' }}
         with:
           depwarn: error
       - name: "Process JuliaInterface C coverage"
-        if: runner.os == 'Linux' && matrix.julia-version == 'lts'
+        if: matrix.c-coverage
         run: |
           JuliaInterfaceSo=$(cat juliainterface.path)
           test -f "${JuliaInterfaceSo}"
           cd pkg/JuliaInterface
+          # Refresh the reports after the Julia test process exits and flushes
+          # its C counters; ci_test.sh runs while that process is still alive.
           gcov -o ./tmp/gen/src/ src/*.c*
       - name: "Process Julia code coverage"
         uses: julia-actions/julia-processcoverage@v1

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -5,78 +5,88 @@ set -x
 
 AnyFailures=No
 
-# If this script has to build JuliaInterface itself, use a predictable
-# out-of-tree build directory below the checkout. gcov needs the matching
-# .gcno files from that build directory after the tests have run.
-DefaultJuliaInterfaceBuildDir="${PWD}/pkg/JuliaInterface/tmp"
+# C coverage is deliberately opt-in. Clang on macOS and GCC on Linux disagree
+# about which source lines are executable, so merging their reports can mark
+# covered continuation lines and case labels as uncovered. Only the Julia LTS
+# rebuild job using GCC on Linux sets JULIAINTERFACE_COVERAGE=Yes.
+if [ "${JULIAINTERFACE_COVERAGE:-No}" = Yes ]
+then
+    # If this script has to build JuliaInterface itself, use a predictable
+    # out-of-tree build directory below the checkout. gcov needs the matching
+    # .gcno files from that build directory after the tests have run.
+    DefaultJuliaInterfaceBuildDir="${PWD}/pkg/JuliaInterface/tmp"
 
-# This may be replaced below when a caller provides GAP_JL_JULIAINTERFACE_SO.
-# In that case it points at the build directory containing the provided .so.
-JuliaInterfaceBuildDir="${DefaultJuliaInterfaceBuildDir}"
-
-# Only delete the build directory when this script created it. Callers that
-# prebuild and pass GAP_JL_JULIAINTERFACE_SO own their build directory.
-RemoveJuliaInterfaceBuildDir=No
-
-build_JuliaInterface_for_coverage() {
+    # Start with the default directory. If the caller provides an instrumented
+    # .so below, derive and use the directory in which that library was built.
     JuliaInterfaceBuildDir="${DefaultJuliaInterfaceBuildDir}"
-    mkdir -p "${JuliaInterfaceBuildDir}"
-    JuliaInterfaceBuildDir=$(cd "${JuliaInterfaceBuildDir}" && pwd)
 
-    # Force recompilation of JuliaInterface with coverage instrumentation.
-    # Use a fixed build directory so that gcov can find .gcno/.gcda files.
-    export FORCE_JULIAINTERFACE_COMPILATION=
-    export JULIAINTERFACE_BUILD_DIR="${JuliaInterfaceBuildDir}"
+    # Only delete the build directory when this script created it. Callers that
+    # prebuild and pass GAP_JL_JULIAINTERFACE_SO own their build directory.
+    RemoveJuliaInterfaceBuildDir=No
 
-    # Run GAP through Julia to get it to create JuliaInterface.so, and then
-    # write the path to it into a file for use later on.
-    ${GAP} --nointeract -c 'FileString("juliainterface.path", JuliaToGAP(IsString, GAP_jl.JuliaInterface_path)); QUIT;'
+    build_JuliaInterface_for_coverage() {
+        JuliaInterfaceBuildDir="${DefaultJuliaInterfaceBuildDir}"
+        mkdir -p "${JuliaInterfaceBuildDir}"
+        JuliaInterfaceBuildDir=$(cd "${JuliaInterfaceBuildDir}" && pwd)
 
-    # Tell subsequent GAP.jl sessions to load this instrumented library instead
-    # of rebuilding or using the JLL-provided JuliaInterface.so.
-    JuliaInterfaceSo=$(cat juliainterface.path)
-    test -f "${JuliaInterfaceSo}"
-    export GAP_JL_JULIAINTERFACE_SO="${JuliaInterfaceSo}"
-    unset FORCE_JULIAINTERFACE_COMPILATION
-    unset JULIAINTERFACE_BUILD_DIR
-    RemoveJuliaInterfaceBuildDir=Yes
-}
+        # The presence of FORCE_JULIAINTERFACE_COMPILATION bypasses the matching
+        # JLL, while JULIAINTERFACE_BUILD_DIR keeps the gcov files in a known
+        # location.
+        export FORCE_JULIAINTERFACE_COMPILATION=
+        export JULIAINTERFACE_BUILD_DIR="${JuliaInterfaceBuildDir}"
 
-export CFLAGS="${CFLAGS:+${CFLAGS} }--coverage"
-export LDFLAGS="${LDFLAGS:+${LDFLAGS} }--coverage"
+        # Trigger a GAP.jl load to compile JuliaInterface.so, then record its
+        # path for the subsequent test processes.
+        ${GAP} --nointeract -c 'FileString("juliainterface.path", JuliaToGAP(IsString, GAP_jl.JuliaInterface_path)); QUIT;'
+
+        # Load this instrumented library instead of rebuilding or using the
+        # JLL-provided JuliaInterface.so.
+        JuliaInterfaceSo=$(cat juliainterface.path)
+        test -f "${JuliaInterfaceSo}"
+        export GAP_JL_JULIAINTERFACE_SO="${JuliaInterfaceSo}"
+        unset FORCE_JULIAINTERFACE_COMPILATION
+        unset JULIAINTERFACE_BUILD_DIR
+        RemoveJuliaInterfaceBuildDir=Yes
+    }
+
+    export CFLAGS="${CFLAGS:+${CFLAGS} }--coverage"
+    export LDFLAGS="${LDFLAGS:+${LDFLAGS} }--coverage"
+fi
 
 mkdir -p coverage
 
 # Enter the JuliaInterface GAP package directory. makedoc.g, tst/testall.g,
-# and the later gcov invocation are all relative to this directory.
+# and the optional gcov invocation are all relative to this directory.
 cd pkg/JuliaInterface
 pwd  # for debugging
 
-# Some callers, notably the treehash workflow, prebuild an instrumented
-# JuliaInterface.so and pass it in GAP_JL_JULIAINTERFACE_SO. Reuse it only if
-# it comes from a gcov build: the .so path alone is not enough, because other
-# workflows may also force a local build without coverage instrumentation.
-if [ -n "${GAP_JL_JULIAINTERFACE_SO:-}" ]
+if [ "${JULIAINTERFACE_COVERAGE:-No}" = Yes ]
 then
-    JuliaInterfaceSo="${GAP_JL_JULIAINTERFACE_SO}"
-    test -f "${JuliaInterfaceSo}"
-    JuliaInterfaceBuildDir=$(cd "$(dirname "${JuliaInterfaceSo}")/../.." && pwd)
-
-    # gcov requires .gcno files emitted at compile time. If they are missing,
-    # ignore the provided library and build a coverage-instrumented one here.
-    if [ -d "${JuliaInterfaceBuildDir}/gen/src" ] && ls "${JuliaInterfaceBuildDir}"/gen/src/*.gcno >/dev/null 2>&1
+    # The Linux LTS rebuild job passes its instrumented JuliaInterface.so in
+    # GAP_JL_JULIAINTERFACE_SO. Reuse it only if it comes from a gcov build:
+    # the .so path alone does not prove that it was instrumented.
+    if [ -n "${GAP_JL_JULIAINTERFACE_SO:-}" ]
     then
-        unset FORCE_JULIAINTERFACE_COMPILATION
-        unset JULIAINTERFACE_BUILD_DIR
-        RemoveJuliaInterfaceBuildDir=No
+        JuliaInterfaceSo="${GAP_JL_JULIAINTERFACE_SO}"
+        test -f "${JuliaInterfaceSo}"
+        JuliaInterfaceBuildDir=$(cd "$(dirname "${JuliaInterfaceSo}")/../.." && pwd)
+
+        # gcov requires .gcno files emitted at compile time. If they are missing,
+        # ignore the provided library and build a coverage-instrumented one here.
+        if [ -d "${JuliaInterfaceBuildDir}/gen/src" ] && ls "${JuliaInterfaceBuildDir}"/gen/src/*.gcno >/dev/null 2>&1
+        then
+            unset FORCE_JULIAINTERFACE_COMPILATION
+            unset JULIAINTERFACE_BUILD_DIR
+            RemoveJuliaInterfaceBuildDir=No
+        else
+            unset GAP_JL_JULIAINTERFACE_SO
+            build_JuliaInterface_for_coverage
+        fi
     else
-        unset GAP_JL_JULIAINTERFACE_SO
         build_JuliaInterface_for_coverage
     fi
-else
-    build_JuliaInterface_for_coverage
+    test -d "${JuliaInterfaceBuildDir}/gen/src"
 fi
-test -d "${JuliaInterfaceBuildDir}/gen/src"
 
 # Build the JuliaInterface manual. This also checks the manual examples.
 ${GAP} makedoc.g
@@ -86,25 +96,29 @@ ${GAP} --cover ../../coverage/JuliaInterface.coverage -r tst/testall.g || AnyFai
 cd ../..
 
 # Build docs and run the JuliaExperimental GAP tests as part of the bundled
-# GAP package checks. These reuse the same instrumented JuliaInterface.so.
+# GAP package checks. The coverage job reuses its instrumented library here.
 cd pkg/JuliaExperimental
 pwd
 ${GAP} makedoc.g
 ${GAP} --cover ../../coverage/JuliaExperimental.coverage -r tst/testall.g || AnyFailures=Yes
 cd ../..
 
-# Convert the C coverage counters from the instrumented JuliaInterface build
-# into .gcov files for Codecov. This must happen before deleting the build dir.
-cd pkg/JuliaInterface
-gcov -o "${JuliaInterfaceBuildDir}/gen/src/" src/*.c*
-
-# Avoid leaving this script's temporary coverage build behind. When the build
-# was supplied by the caller, keep it available for later workflow steps.
-if [ "${RemoveJuliaInterfaceBuildDir}" = Yes ]
+# Only the Linux LTS rebuild job emits JuliaInterface C coverage. Convert its
+# counters before deleting a build created here; caller-owned builds remain
+# available for later workflow steps.
+if [ "${JULIAINTERFACE_COVERAGE:-No}" = Yes ]
 then
-    rm -rf "${JuliaInterfaceBuildDir}" # Delete the coverage instrumentation in JuliaInterface again
+    cd pkg/JuliaInterface
+    gcov -o "${JuliaInterfaceBuildDir}/gen/src/" src/*.c*
+
+    # Avoid leaving this script's temporary coverage build behind. When the build
+    # was supplied by the caller, keep it available for later workflow steps.
+    if [ "${RemoveJuliaInterfaceBuildDir}" = Yes ]
+    then
+        rm -rf "${JuliaInterfaceBuildDir}" # Delete the coverage instrumentation in JuliaInterface again
+    fi
+    cd ../..
 fi
-cd ../..
 
 if [ ${AnyFailures} = Yes ]
 then

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -5,10 +5,9 @@ set -x
 
 AnyFailures=No
 
-# C coverage is deliberately opt-in. Clang on macOS and GCC on Linux disagree
-# about which source lines are executable, so merging their reports can mark
-# covered continuation lines and case labels as uncovered. Only the Julia LTS
-# rebuild job using GCC on Linux sets JULIAINTERFACE_COVERAGE=Yes.
+# Set JULIAINTERFACE_COVERAGE=Yes to build or reuse an instrumented library
+# and generate C coverage reports. Otherwise, run the tests with the library
+# GAP.jl would normally load. The caller decides when to collect C coverage.
 if [ "${JULIAINTERFACE_COVERAGE:-No}" = Yes ]
 then
     # If this script has to build JuliaInterface itself, use a predictable
@@ -62,9 +61,9 @@ pwd  # for debugging
 
 if [ "${JULIAINTERFACE_COVERAGE:-No}" = Yes ]
 then
-    # The Linux LTS rebuild job passes its instrumented JuliaInterface.so in
-    # GAP_JL_JULIAINTERFACE_SO. Reuse it only if it comes from a gcov build:
-    # the .so path alone does not prove that it was instrumented.
+    # A caller may pass a prebuilt JuliaInterface.so in GAP_JL_JULIAINTERFACE_SO.
+    # Check for gcov metadata before reusing it; the .so path alone does not
+    # prove that it was instrumented.
     if [ -n "${GAP_JL_JULIAINTERFACE_SO:-}" ]
     then
         JuliaInterfaceSo="${GAP_JL_JULIAINTERFACE_SO}"
@@ -96,16 +95,17 @@ ${GAP} --cover ../../coverage/JuliaInterface.coverage -r tst/testall.g || AnyFai
 cd ../..
 
 # Build docs and run the JuliaExperimental GAP tests as part of the bundled
-# GAP package checks. The coverage job reuses its instrumented library here.
+# GAP package checks. With C coverage enabled, both suites reuse the same
+# instrumented library.
 cd pkg/JuliaExperimental
 pwd
 ${GAP} makedoc.g
 ${GAP} --cover ../../coverage/JuliaExperimental.coverage -r tst/testall.g || AnyFailures=Yes
 cd ../..
 
-# Only the Linux LTS rebuild job emits JuliaInterface C coverage. Convert its
-# counters before deleting a build created here; caller-owned builds remain
-# available for later workflow steps.
+# When C coverage is enabled, convert the counters before deleting a build
+# created here. Keep caller-owned builds so the caller can collect counters
+# from any processes that are still running.
 if [ "${JULIAINTERFACE_COVERAGE:-No}" = Yes ]
 then
     cd pkg/JuliaInterface


### PR DESCRIPTION
Only track JuliaInterface C coverage on Linux. This avoids merging compiler-dependent executable-line mappings, which lead to surprising and misleading "uncovered code" reports.

Co-authored-by: Codex <codex@openai.com>
