### PR TITLE
Always test the "treehash mismatch check"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -135,8 +135,10 @@ jobs:
         env:
           CFLAGS: "--coverage"
           LDFLAGS: "--coverage"
-          FORCE_JULIAINTERFACE_COMPILATION: "${{ github.workspace }}/pkg/JuliaInterface/tmp"
+          JULIAINTERFACE_BUILD_DIR: "${{ github.workspace }}/pkg/JuliaInterface/tmp"
         run: |
+          mkdir -p pkg/JuliaInterface/src/force-treehash-mismatch
+          touch pkg/JuliaInterface/src/force-treehash-mismatch/nonempty
           julia --project=. --color=yes -e 'import GAP; write("juliainterface.path", GAP.JuliaInterface_path)'
           JuliaInterfaceSo=$(cat juliainterface.path)
           test -f "${JuliaInterfaceSo}"

--- a/etc/ci_test.sh
+++ b/etc/ci_test.sh
@@ -25,7 +25,8 @@ build_JuliaInterface_for_coverage() {
 
     # Force recompilation of JuliaInterface with coverage instrumentation.
     # Use a fixed build directory so that gcov can find .gcno/.gcda files.
-    export FORCE_JULIAINTERFACE_COMPILATION="${JuliaInterfaceBuildDir}"
+    export FORCE_JULIAINTERFACE_COMPILATION=
+    export JULIAINTERFACE_BUILD_DIR="${JuliaInterfaceBuildDir}"
 
     # Run GAP through Julia to get it to create JuliaInterface.so, and then
     # write the path to it into a file for use later on.
@@ -37,6 +38,7 @@ build_JuliaInterface_for_coverage() {
     test -f "${JuliaInterfaceSo}"
     export GAP_JL_JULIAINTERFACE_SO="${JuliaInterfaceSo}"
     unset FORCE_JULIAINTERFACE_COMPILATION
+    unset JULIAINTERFACE_BUILD_DIR
     RemoveJuliaInterfaceBuildDir=Yes
 }
 
@@ -65,6 +67,7 @@ then
     if [ -d "${JuliaInterfaceBuildDir}/gen/src" ] && ls "${JuliaInterfaceBuildDir}"/gen/src/*.gcno >/dev/null 2>&1
     then
         unset FORCE_JULIAINTERFACE_COMPILATION
+        unset JULIAINTERFACE_BUILD_DIR
         RemoveJuliaInterfaceBuildDir=No
     else
         unset GAP_JL_JULIAINTERFACE_SO

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -215,6 +215,22 @@ function build_JuliaInterface(builddir::String)
     return normpath(joinpath(builddir, "bin", GAP.sysinfo["GAParch"]))
 end
 
+function juliainterface_builddir()
+    # If JULIAINTERFACE_BUILD_DIR is set,
+    # its value is assumed to be a path in which we perform an "out-of-tree" build
+    # of JuliaInterface. That is, its build system reads files from its source dir,
+    # but writes .o files etc. into the builddir or subdirectories (that is, it
+    # writes .o files into the `gen/src` subdir, and the kernel extension ends up
+    # as `bin/ARCH/JuliaInterface.so`.
+    if haskey(ENV, "JULIAINTERFACE_BUILD_DIR")
+        builddir = abspath(ENV["JULIAINTERFACE_BUILD_DIR"])
+        mkpath(builddir)
+        return builddir
+    end
+
+    return mktempdir()
+end
+
 function locate_JuliaInterface_so()
     if haskey(ENV, "GAP_JL_JULIAINTERFACE_SO")
         path = abspath(ENV["GAP_JL_JULIAINTERFACE_SO"])
@@ -230,36 +246,18 @@ function locate_JuliaInterface_so()
     bundled = joinpath(@__DIR__, "..", "pkg", "JuliaInterface")
     bundled_hash = TreeHash.tree_hash(joinpath(bundled, "src"))
 
-    # If FORCE_JULIAINTERFACE_COMPILATION then we always compile JuliaInterface.
-    # This is useful for debugging or for code coverage tracking. If the variable
-    # is set but empty, or set to "true", then we compile into a tempdir. Otherwise,
-    # its value is assumed to be a path in which we perform an "out-of-tree" build
-    # of JuliaInterface. That is, its build system reads files from its source dir,
-    # but writes .o files etc. into the builddir or subdirectories (that is, it
-    # writes .o files into the `gen/src` subdir, and the kernel extension ends up
-    # as `bin/ARCH/JuliaInterface.so`.
-    if haskey(ENV, "FORCE_JULIAINTERFACE_COMPILATION")
-        # requested re-compilation via ENV -> re-compile
-        forcedir = ENV["FORCE_JULIAINTERFACE_COMPILATION"]
-        if isempty(forcedir) || forcedir == "true"
-            builddir = mktempdir()
-        else
-            builddir = abspath(forcedir)
-            mkpath(builddir)
-        end
-        @debug "FORCE_JULIAINTERFACE_COMPILATION is set -> compile in $(builddir)"
-        # take a pidlock to protect users who call FORCE_JULIAINTERFACE_COMPILATION with
-        # the same fixed path from multiple concurrent processes
-        path = Pidfile.mkpidlock(joinpath(builddir, "JuliaInterface.lock"); stale_age=300) do
-            build_JuliaInterface(builddir)
-        end
-    elseif jll_hash == bundled_hash
+    if jll_hash == bundled_hash && !haskey(ENV, "FORCE_JULIAINTERFACE_COMPILATION")
         # tree hashes of bundled C sources and GAP_pkg_juliainterface_jll match -> use JuliaInterface.so from the JLL
         @debug "Use JuliaInterface.so from GAP_pkg_juliainterface_jll"
         path = joinpath(jll, "lib", "gap")
     else
-        # fall-back case -> re-compile
-        path = build_JuliaInterface(mktempdir())
+        builddir = juliainterface_builddir()
+        @debug "Compile JuliaInterface in $(builddir)"
+        # take a pidlock to protect users who use the same fixed build directory
+        # from multiple concurrent processes
+        path = Pidfile.mkpidlock(joinpath(builddir, "JuliaInterface.lock"); stale_age=300) do
+            build_JuliaInterface(builddir)
+        end
     end
     @debug "Use JuliaInterface.so from $(path)"
     return joinpath(path, "JuliaInterface.so")


### PR DESCRIPTION
To do so, we add checks for a new environment variable `JULIAINTERFACE_BUILD_DIR`, which takes over parts of what `FORCE_JULIAINTERFACE_COMPILATION` did so far -- by separating the "force rebuild" mechanism from the "specify build dir" mechanism, we are more flexible.

In particular, we can now have a CI job modify the C source dir, to force a treehash mismatch, instead of using `FORCE_JULIAINTERFACE_COMPILATION`. That should avoid some of the coverage fluctuations seen in PR #1398.

Co-authored-by: Codex <codex@openai.com>