### PR TITLE
Honor GAP package artifact overrides

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## Version 0.17.2 (released 2026-06-21)
 
 - Update the `alnuth` GAP package to 4.0.2
+- Honor `Overrides.toml` UUID/name overrides for `GAP_pkg_*` artifacts
+  when locating GAP package directories
 
 ## Version 0.17.1 (released 2026-06-21)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,13 @@
 # Changes in GAP.jl
 
+## Version 0.17.3-DEV (released 2026-MM-DD)
+
+- Honor `Overrides.toml` UUID/name overrides for `GAP_pkg_*` artifacts
+  when locating GAP package directories
+
 ## Version 0.17.2 (released 2026-06-21)
 
 - Update the `alnuth` GAP package to 4.0.2
-- Honor `Overrides.toml` UUID/name overrides for `GAP_pkg_*` artifacts
-  when locating GAP package directories
 
 ## Version 0.17.1 (released 2026-06-21)
 

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -32,7 +32,7 @@ if Sys.iswindows()
 end
 
 import AbstractAlgebra # for should_show_banner()
-import Artifacts: find_artifacts_toml, load_artifacts_toml, artifact_path
+import Artifacts: find_artifacts_toml, load_artifacts_toml
 
 import GAP_jll: GAP_jll, libgap
 import GAP_lib_jll
@@ -217,10 +217,9 @@ function __init__()
     artifact_dict = load_artifacts_toml(artifacts_toml)
 
     pkgdirs = String[]
-    for (name, meta) in artifact_dict
+    for name in keys(artifact_dict)
         startswith(name, "GAP_pkg_") || continue
-        hash = Base.SHA1(meta["git-tree-sha1"]::String)
-        push!(pkgdirs, artifact_path(hash; honor_overrides=true))
+        push!(pkgdirs, gap_pkg_artifact_dir(name[9:end]))
     end
     push!(pkgdirs, abspath(@__DIR__, "..", "pkg", "JuliaInterface"))
     push!(pkgdirs, abspath(@__DIR__, "..", "pkg", "JuliaExperimental"))

--- a/src/GAP_pkg.jl
+++ b/src/GAP_pkg.jl
@@ -64,6 +64,8 @@ const pkg_bindirs = Dict{String, String}()
 
 function gap_pkg_artifact_dir(pkgname)
   d = @artifact_str("GAP_pkg_$(pkgname)")
+  # Artifact overrides may point directly at the GAP package root.
+  isfile(joinpath(d, "PackageInfo.g")) && return d
   return joinpath(d, only(readdir(d)))
 end
 
@@ -119,4 +121,3 @@ function find_override(installationpath::String)
     end
     return joinpath(installationpath, "bin", String(GAP.Globals.GAPInfo.Architecture))
 end
-

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -43,3 +43,51 @@ end
     end
   end
 end
+
+@testset "gap package artifact overrides" begin
+  mktempdir() do tmpdir
+    artifacts_toml = joinpath(tmpdir, "Artifacts.toml")
+    override_dir = joinpath(tmpdir, "override", "alnuth")
+    mkpath(override_dir)
+    write(joinpath(override_dir, "PackageInfo.g"), "")
+    write(
+      artifacts_toml,
+      """
+      [GAP_pkg_alnuth]
+      git-tree-sha1 = "809593e819b916279aa515bc8644a9c1e5ab2a96"
+      """,
+    )
+
+    depot = joinpath(tmpdir, "depot")
+    overrides_toml = joinpath(depot, "artifacts", "Overrides.toml")
+    mkpath(dirname(overrides_toml))
+    write(
+      overrides_toml,
+      """
+      [c863536a-3901-11e9-33e7-d5cd0df7b904]
+      GAP_pkg_alnuth = "$(override_dir)"
+      """,
+    )
+
+    old_depot_path = copy(DEPOT_PATH)
+    artifact_stdlib = Base.require(
+      Base.PkgId(
+        Base.UUID("56f22d72-fd6d-98f1-02f0-08ddc0907c33"),
+        "Artifacts",
+      ),
+    )
+    old_artifact_overrides = deepcopy(artifact_stdlib.ARTIFACT_OVERRIDES[])
+
+    try
+      empty!(DEPOT_PATH)
+      push!(DEPOT_PATH, depot)
+      artifact_stdlib.ARTIFACT_OVERRIDES[] = nothing
+
+      @test GAP.gap_pkg_artifact_dir("alnuth") == override_dir
+    finally
+      empty!(DEPOT_PATH)
+      append!(DEPOT_PATH, old_depot_path)
+      artifact_stdlib.ARTIFACT_OVERRIDES[] = old_artifact_overrides
+    end
+  end
+end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -46,17 +46,9 @@ end
 
 @testset "gap package artifact overrides" begin
   mktempdir() do tmpdir
-    artifacts_toml = joinpath(tmpdir, "Artifacts.toml")
     override_dir = joinpath(tmpdir, "override", "alnuth")
     mkpath(override_dir)
     write(joinpath(override_dir, "PackageInfo.g"), "")
-    write(
-      artifacts_toml,
-      """
-      [GAP_pkg_alnuth]
-      git-tree-sha1 = "809593e819b916279aa515bc8644a9c1e5ab2a96"
-      """,
-    )
 
     depot = joinpath(tmpdir, "depot")
     overrides_toml = joinpath(depot, "artifacts", "Overrides.toml")


### PR DESCRIPTION
Use gap_pkg_artifact_dir when building GAP package roots so
UUID/name artifact overrides are respected during startup.

Allow the helper to return an override directory directly when it
already contains PackageInfo.g, and cover that behavior with a
regression test.

Together, this allows usage of an Overrides.toml looking like this:

    [c863536a-3901-11e9-33e7-d5cd0df7b904]
    GAP_pkg_alnuth = "/some/alternate/path"

Co-authored-by: Codex <codex@openai.com>
