### PR TITLE
handle `resume` option in the Julia based `Download` method

### DIFF
--- a/src/packages.jl
+++ b/src/packages.jl
@@ -52,6 +52,11 @@ function init_packagemanager()
          :name => "via Julia's Downloads.download",
          :isAvailable => Globals.ReturnTrue,
          :download => function(url, opt)
+            if hasproperty(opt, :resume)
+              return GapObj(Dict{Symbol, Any}(:success => false,
+                                              :error => GapObj("no support for resuming")),
+                            recursive=true)
+            end
             try
               timeout = hasproperty(opt, :maxTime) ? Real(opt.maxTime) : Inf
               if hasproperty(opt, :target)

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -52,7 +52,8 @@ function init_packagemanager()
          :name => "via Julia's Downloads.download",
          :isAvailable => Globals.ReturnTrue,
          :download => function(url, opt)
-            if hasproperty(opt, :resume)
+            if hasproperty(opt, :resume) && opt.resume == true &&
+               hasproperty(opt, :target) && Wrappers.IsString(opt.target)
               return GapObj(Dict{Symbol, Any}(:success => false,
                                               :error => GapObj("no support for resuming")),
                             recursive=true)


### PR DESCRIPTION
Once gap-packages/utils#105 becomes available, the `GAP.Globals.Download` method that is based on the Julia package Downloads.jl must decline requests where `resume:= true` is set.

(Downloads.jl  is based on libcurl, which supports resuming, but the function `Downloads.download` apparently does not support this.)