### PR TITLE
Add script to update GAP*_jll compat entries

### DIFF
--- a/README.maintainer.md
+++ b/README.maintainer.md
@@ -176,18 +176,20 @@ all of the JLL packages that depend on GAP.
    `GAP_pkg_*_jll` packages.
 
 7. In `GAP.jl`, create a PR with the following changes:
-   1. In the `Project.toml` update the compat bounds as follows:
-      - For `GAP_jll` to the `version` from step 1, with a `~` prefix.
-      - For `GAP_lib_jll` to the `version` from step 3, with a `~` prefix.
-      - For `GAP_pkg_juliainterface_jll` to the new version number, with a `=` prefix.
-        You can find the new version number in the registry PR from step 6.
-      - For each other `GAP_pkg_*_jll` package that was updated in step 6, update to the new version
-        with a `~` prefix. You can find the new version numbers in the registry PRs from step 6.
-   2. Run `julia --project=etc etc/update_artifacts.jl` with the new GAP version as argument to update the `Artifacts.toml` file.
+   1. Run `julia --project=etc etc/update_artifacts.jl` with the new GAP version as argument to update the `Artifacts.toml` file.
       See the top of that script for instructions.
-   3. If the GAP release is not ABI-compatible with the previous one, update the minor part of the version
+   2. Run `julia --project=etc etc/update_jll_versions.jl` with the new GAP version as argument to update the
+      `GAP*_jll` compat bounds in `Project.toml`. It pins every JLL to the newest registered build of the
+      package version shipped by this GAP release, so the registry must already have picked up all versions
+      from step 6; whatever is still missing is reported instead of written. The script prints its proposal
+      and only edits `Project.toml` when passed `--write`.
+      See the top of that script for instructions.
+   3. Update the compat bound for `GAP_pkg_juliainterface_jll` by hand, with a `=` prefix. You can find the
+      new version number in the registry PR from step 6. The script skips it as long as the `version` in
+      `Project.toml` still differs from the juliainterface `upstream_version` chosen in step 5.
+   4. If the GAP release is not ABI-compatible with the previous one, update the minor part of the version
       of `GAP.jl` in its `Project.toml`
-   4. If the GAP release was created from a new release branch (e.g. `stable-4.15` instead of `stable-4.14`),
+   5. If the GAP release was created from a new release branch (e.g. `stable-4.15` instead of `stable-4.14`),
       then update occurrences in `.github/workflows/gap.yml` accordingly. Furthermore, rename the subfolders
       of `.github/workflows/GAP_patches/` accordingly.
    Wait for the PR to pass CI (including the `treehash` job) and merge it.

--- a/etc/pkginfos.jl
+++ b/etc/pkginfos.jl
@@ -1,0 +1,24 @@
+#
+# Shared helper for locating GAP's `package-infos.json`, used by
+# `update_artifacts.jl` and `update_jll_versions.jl`.
+#
+
+using Downloads: download
+
+"""
+    resolve_pkginfos_path(desc::AbstractString)
+
+Turn `desc` into a local path to a `package-infos.json[.gz]`. `desc` may be a
+GAP version (`"4.16.1"`), an arbitrary URL, or an already local path; the first
+two are downloaded to a temporary file.
+"""
+function resolve_pkginfos_path(desc::AbstractString)
+    if startswith(desc, "4.")
+        desc = "https://github.com/gap-system/gap/releases/download/v$desc/package-infos.json.gz"
+    end
+
+    startswith(desc, "http") || return desc
+
+    println("Download package-infos from $(desc)")
+    return download(desc)
+end

--- a/etc/update_artifacts.jl
+++ b/etc/update_artifacts.jl
@@ -18,6 +18,7 @@
 #
 
 using Downloads: download
+include("pkginfos.jl")
 import Pkg
 using Pkg.Artifacts
 import Pkg.PlatformEngines
@@ -122,18 +123,7 @@ end
 # https://github.com/gap-system/gap/releases/download/v4.14.0/package-infos.json.gz.sha256
 
 if length(ARGS) > 0
-    desc = ARGS[1]
-    if startswith(desc, "http")
-        pkginfos_url = desc
-        println("Download package-infos from $(pkginfos_url)")
-        pkginfos_path = download(pkginfos_url)
-    elseif startswith(desc, "4.")
-        pkginfos_url = "https://github.com/gap-system/gap/releases/download/v$desc/package-infos.json.gz"
-        println("Download package-infos from $(pkginfos_url)")
-        pkginfos_path = download(pkginfos_url)
-    else
-        pkginfos_path = desc
-    end
+    pkginfos_path = resolve_pkginfos_path(ARGS[1])
 
     println("processing $(pkginfos_path)")
     add_artifacts_for_packages(; pkginfos_path)

--- a/etc/update_artifacts.jl
+++ b/etc/update_artifacts.jl
@@ -1,6 +1,12 @@
 #
 # This script is used to update Artifacts.toml
 #
+# Setup: the `etc` environment must be instantiated before first use. Its
+# Manifest.toml is gitignored, so an old one may be stale; deleting it is safe.
+#
+#     rm -f etc/Manifest.toml
+#     julia --project=etc -e 'using Pkg; Pkg.instantiate()'
+#
 # Usage variants:
 # 1. Specify `packages-infos.json` to update all packages. This removes all
 #    artifacts for packages not contained in that file.

--- a/etc/update_jll_versions.jl
+++ b/etc/update_jll_versions.jl
@@ -2,6 +2,12 @@
 # This script updates the `GAP*_jll` entries in the `[compat]` section of
 # Project.toml to match a given GAP release. Run it after `update_artifacts.jl`.
 #
+# Setup: the `etc` environment must be instantiated before first use. Its
+# Manifest.toml is gitignored, so an old one may be stale; deleting it is safe.
+#
+#     rm -f etc/Manifest.toml
+#     julia --project=etc -e 'using Pkg; Pkg.instantiate()'
+#
 # Usage:
 #
 #     julia --project=etc etc/update_jll_versions.jl 4.16.1

--- a/etc/update_jll_versions.jl
+++ b/etc/update_jll_versions.jl
@@ -1,0 +1,243 @@
+#
+# This script updates the `GAP*_jll` entries in the `[compat]` section of
+# Project.toml to match a given GAP release. Run it after `update_artifacts.jl`.
+#
+# Usage:
+#
+#     julia --project=etc etc/update_jll_versions.jl 4.16.1
+#     julia --project=etc etc/update_jll_versions.jl https://.../package-infos.json.gz
+#     julia --project=etc etc/update_jll_versions.jl local/path/package-infos.json --write
+#
+# Options:
+#
+#     --write             apply the changes (default is a dry run)
+#     --update-registry   refresh the package registries first
+#     --gap-version=X.Y.Z GAP version, if it cannot be derived from the argument
+#
+# A `GAP_pkg_X_jll` must be built from the *same* upstream version of package X
+# that Artifacts.toml ships, because `setup_overrides` in src/GAP_pkg.jl grafts
+# the JLL's binaries onto the artifact's source tree. So the target version is
+# taken from `package-infos.json`, and the registry merely decides which build
+# of it to pin.
+#
+
+include("pkginfos.jl")
+import Pkg
+using Pkg.Registry: reachable_registries, registry_info
+import GZip
+import JSON
+
+const PKG_PREFIX = "GAP_pkg_"
+const JLL_SUFFIX = "_jll"
+
+# JuliaInterface is not a package distributed with GAP: it lives in pkg/ of this
+# very repository, so its JLL version tracks GAP.jl's own version and is pinned
+# exactly (see .github/workflows/treehash.yml).
+const JULIAINTERFACE = "GAP_pkg_juliainterface_jll"
+
+#
+# Version encodings
+#
+# GAP itself (GAP_jll, GAP_lib_jll) uses `X.Y.Z -> X00.Y00.Z00`, see
+# Yggdrasil/G/GAP/build_tarballs.jl.
+#
+# GAP packages use `offset_version` from Yggdrasil/G/GAP_pkg/common.jl, which
+# combines the upstream version `a.b.c` with a recipe-local rebuild `offset`:
+#
+#     major = 100a + offset.major
+#     minor = 10000b + 100c + offset.minor
+#     patch = offset.patch
+#
+# We do not know the offsets, so we invert the encoding instead and keep those
+# registered versions that were built from the upstream version we want.
+#
+encode_gap_version(v::VersionNumber) = VersionNumber(100*v.major, 100*v.minor, 100*v.patch)
+
+decode_pkg_version(v::VersionNumber) = (v.major ÷ 100, v.minor ÷ 10000, (v.minor % 10000) ÷ 100)
+
+# GAP package versions are not quite VersionNumbers: they may use `-` as a
+# separator (`2026.05-01`) and may have fewer than three components (`1.4`).
+function parse_pkg_version(s::AbstractString)
+    parts = [something(tryparse(Int, p), -1) for p in split(s, r"[.-]")]
+    any(<(0), parts) && return nothing
+    append!(parts, [0, 0])
+    return (parts[1], parts[2], parts[3])
+end
+
+strip_build(v::VersionNumber) = VersionNumber(v.major, v.minor, v.patch)
+
+"""
+    registered_versions()
+
+Map the name of every registered `GAP*_jll` to its registered versions.
+"""
+function registered_versions()
+    versions = Dict{String,Vector{VersionNumber}}()
+
+    for reg in reachable_registries(), (_, entry) in reg.pkgs
+        startswith(entry.name, "GAP") && endswith(entry.name, JLL_SUFFIX) || continue
+        append!(get!(versions, entry.name, VersionNumber[]),
+                keys(registry_info(entry).version_info))
+    end
+
+    return versions
+end
+
+"""
+    best_pkg_version(candidates, upstream)
+
+The newest registered JLL version built from the upstream package version
+`upstream`, or `nothing` if there is none.
+"""
+function best_pkg_version(candidates::Vector{VersionNumber}, upstream)
+    matching = filter(v -> decode_pkg_version(v) == upstream, candidates)
+    return isempty(matching) ? nothing : strip_build(maximum(matching))
+end
+
+"""
+    proposed_compat(project, pkginfos, gap_version)
+
+Compute the new `[compat]` entries. Returns the proposals as a name => version
+string dict, a list of advisory notes, and a list of problems: entries that
+should have been updated but could not be, i.e. builds that are still missing
+from the registry.
+"""
+function proposed_compat(project, pkginfos, gap_version)
+    available = registered_versions()
+    deps = filter(startswith("GAP"), collect(keys(project["deps"])))
+    proposals = Dict{String,String}()
+    notes = String[]
+    problems = String[]
+
+    # upstream version of each GAP package, keyed like the JLL names
+    upstream = Dict(PKG_PREFIX * lowercase(info["PackageName"]) * JLL_SUFFIX => info["Version"]
+                    for info in values(pkginfos))
+
+    if gap_version !== nothing
+        encoded = encode_gap_version(gap_version)
+        for name in ("GAP_jll", "GAP_lib_jll")
+            if encoded in strip_build.(get(available, name, VersionNumber[]))
+                proposals[name] = "~$(encoded)"
+            else
+                push!(problems, "$name: $encoded is not registered (build pending?)")
+            end
+        end
+    else
+        push!(notes, "GAP_jll, GAP_lib_jll: no GAP version given, use --gap-version=X.Y.Z")
+    end
+
+    for name in sort(deps)
+        startswith(name, PKG_PREFIX) || continue
+
+        # JuliaInterface follows this repository's version, not a GAP package
+        wanted = name == JULIAINTERFACE ? project["version"] : get(upstream, name, nothing)
+        if wanted === nothing
+            push!(notes, "$name: no longer distributed with GAP, remove it by hand")
+            continue
+        end
+
+        parsed = parse_pkg_version(replace(wanted, "-DEV" => ""))
+        if parsed === nothing
+            push!(notes, "$name: cannot parse upstream version '$wanted'")
+            continue
+        end
+
+        best = best_pkg_version(get(available, name, VersionNumber[]), parsed)
+        if best === nothing
+            # a JuliaInterface JLL only exists once this repo has been released,
+            # so a missing one is expected while developing
+            list = name == JULIAINTERFACE ? notes : problems
+            push!(list, "$name: no registered build for upstream $wanted (build pending?)")
+            continue
+        end
+
+        proposals[name] = (name == JULIAINTERFACE ? "=" : "~") * string(best)
+    end
+
+    # packages that gained a JLL but which GAP.jl does not depend on yet; whether
+    # a package needs one is a human decision, as is the matching import in
+    # src/GAP_pkg.jl
+    for name in sort(collect(keys(upstream)))
+        (name in deps || !haskey(available, name)) && continue
+        push!(notes, "$name: registered but not a dependency, consider adding it")
+    end
+
+    return proposals, notes, problems
+end
+
+"""
+    apply_compat(project_toml, proposals)
+
+Rewrite the matching lines of the `[compat]` section in place. Returns the
+number of changed lines. Deliberately line based: a TOML round trip would
+reformat the whole file.
+"""
+function apply_compat(project_toml, proposals)
+    lines = readlines(project_toml)
+    in_compat = false
+    changed = 0
+
+    for (i, line) in enumerate(lines)
+        if startswith(line, "[")
+            in_compat = line == "[compat]"
+            continue
+        end
+        in_compat || continue
+
+        m = match(r"^(\S+) = \"", line)
+        m === nothing && continue
+        haskey(proposals, m[1]) || continue
+
+        new_line = "$(m[1]) = \"$(proposals[m[1]])\""
+        new_line == line && continue
+
+        lines[i] = new_line
+        changed += 1
+    end
+
+    write(project_toml, join(lines, "\n") * "\n")
+
+    return changed
+end
+
+function main(args)
+    write_changes = "--write" in args
+    "--update-registry" in args && Pkg.Registry.update()
+
+    gap_version = nothing
+    for arg in args
+        m = match(r"^--gap-version=(.*)$", arg)
+        m !== nothing && (gap_version = VersionNumber(m[1]))
+    end
+
+    desc = only(filter(!startswith("--"), args))
+    startswith(desc, "4.") && gap_version === nothing && (gap_version = VersionNumber(desc))
+
+    pkginfos = GZip.open(JSON.parse, resolve_pkginfos_path(desc), "r")
+    project_toml = joinpath(dirname(@__DIR__), "Project.toml")
+    project = Pkg.TOML.parsefile(project_toml)
+
+    proposals, notes, problems = proposed_compat(project, pkginfos, gap_version)
+
+    for name in sort(collect(keys(proposals)))
+        old = get(project["compat"], name, "")
+        marker = old == proposals[name] ? "  " : "->"
+        println("$marker $(rpad(name, 32)) $(rpad(old, 24)) $(proposals[name])")
+    end
+
+    for note in vcat(notes, problems)
+        @warn note
+    end
+
+    if !write_changes
+        println("\nDry run, pass --write to apply.")
+        return 0
+    end
+
+    changed = apply_compat(project_toml, proposals)
+    println("\nUpdated $changed entries in $project_toml")
+
+    return isempty(problems) ? 0 : 1
+end
+
+exit(main(ARGS))


### PR DESCRIPTION
Bumping the ~30 GAP*_jll bounds in Project.toml after a GAP release was a manual step with no tooling. The new `etc/update_jll_versions.jl` reads the release's `package-infos.json`, then pins each JLL to the newest registered build of exactly that upstream package version.

Taking the registry's newest version instead would be wrong: a `GAP_pkg_X_jll` must be built from the same version of package X that `Artifacts.toml` ships, because `setup_overrides` grafts the JLL's binaries onto the artifact's source tree.

Prepared with AI assistance (Claude Opus 5).