### PR TITLE
Add CI job building GAP with VALIDATE_MARKING

### DIFF
--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   test:
-    name: Julia ${{ matrix.julia-version }} - GAP ${{ matrix.gap-version }} - ${{ matrix.os }}
+    name: Julia ${{ matrix.julia-version }} - GAP ${{ matrix.gap-version }} - ${{ matrix.os }}${{ matrix.validate-marking && ' - VALIDATE_MARKING' || '' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     continue-on-error: ${{ matrix.julia-version == 'nightly' }}
@@ -37,6 +37,8 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
+        validate-marking:
+          - false
         include:
           # Add a few macOS jobs (the number we can run in parallel is limited)
           - gap-version: 'master'
@@ -45,6 +47,12 @@ jobs:
           - gap-version: 'stable-4.16'
             julia-version: '1'
             os: macOS-latest
+          # build the Julia GC integration with VALIDATE_MARKING, to detect
+          # invalid references during GC marking (see issue #1364)
+          - gap-version: 'master'
+            julia-version: '1'
+            os: ubuntu-latest
+            validate-marking: true
 
     steps:
       - uses: actions/checkout@v7
@@ -92,7 +100,7 @@ jobs:
           make -j`nproc`
       - name: "Override bundled GAP"
         run: |
-          julia --project etc/setup_override_dir.jl /tmp/GAPROOT /tmp/gap_jll_override
+          julia --project etc/setup_override_dir.jl /tmp/GAPROOT /tmp/gap_jll_override ${{ matrix.validate-marking && '--validate-marking' || '' }}
       - name: "Run tests"
         run: |
            julia --project etc/run_with_override.jl /tmp/gap_jll_override --depwarn=error -e "using Pkg; Pkg.test(\"GAP\")"

--- a/etc/setup_override_dir.jl
+++ b/etc/setup_override_dir.jl
@@ -22,6 +22,7 @@ run_configure = true
 overwrite_allow = false
 verbose = false
 debugmode = false
+validate_marking = false
 left_ARGS = String[]
 while !isempty(ARGS)
    arg = popfirst!(ARGS)
@@ -33,6 +34,8 @@ while !isempty(ARGS)
       global verbose = true
    elseif arg == "--debug"
       global debugmode = true
+   elseif arg == "--validate-marking"
+      global validate_marking = true
    else
       push!(left_ARGS, arg)
    end
@@ -88,7 +91,12 @@ if run_configure
 
    juliabin = joinpath(Sys.BINDIR, Base.julia_exename())
 
-   extraargs = ["CPPFLAGS=-DUSE_GAP_INSIDE_JULIA=1"]
+   cppflags = "-DUSE_GAP_INSIDE_JULIA=1"
+   if validate_marking
+      # abort if the GC marking code encounters an invalid reference
+      cppflags *= " -DVALIDATE_MARKING"
+   end
+   extraargs = ["CPPFLAGS=" * cppflags]
 
    if debugmode
       # compile GAP in debug mode (enables many additional assertions in the kernel)


### PR DESCRIPTION
Add a `--validate-marking` flag to `etc/setup_override_dir.jl` that compiles the override GAP with `-DVALIDATE_MARKING`, and a job in the "CI with GAP" workflow using it against GAP master, so regressions in the GC marking code abort the tests instead of going unnoticed.

The job needs gap-system/gap#6525 (which fixes the stale validation criteria in `src/julia_gc.c`) to land in GAP master first; until then it will fail, hence draft.

Part of #1364.

AI disclosure: prepared with the assistance of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
