### PR TITLE
CI: enable autodoc test

### DIFF
--- a/.github/workflows/CI-distro.yml
+++ b/.github/workflows/CI-distro.yml
@@ -58,7 +58,6 @@ jobs:
         gap-package: ${{fromJSON(needs.generate-matrix.outputs.gap-packages)}}
         exclude:
           - gap-package: 'atlasrep'                   # random gc-related segfaults during testing
-          - gap-package: 'autodoc'                    # tries and fails to build its own documentation, inside the (partially write protected) artifacts dir
           - gap-package: 'ctbllib'                    # random gc-related segfaults during testing
           - gap-package: 'example'                    # no jll
           - gap-package: 'examplesforhomalg'          # `Error, found no GAP executable in PATH`


### PR DESCRIPTION
It shouldn't be writing into its tst dir anymore.
