### PR TITLE
Add regression tests for task stack scanning by the GC

### DIFF
--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -86,9 +86,12 @@ jobs:
           echo "${shimdir}" >> "${GITHUB_PATH}"
       - name: "Build GAP"
         run: |
+          # absolute path: the patches are applied from inside the GAP
+          # checkout below, where a relative path would not be found and the
+          # patches would silently be skipped
+          patchdir=${GITHUB_WORKSPACE}/.github/workflows/GAP_patches/${{ matrix.gap-version }}
           mv GAPROOT /tmp/GAPROOT
           cd /tmp/GAPROOT
-          patchdir=.github/workflows/GAP_patches/${{ matrix.gap-version }}
           if [ -d $patchdir ]; then
             for f in $patchdir/*.patch; do
               echo "Applying patch ${f}"

--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           mv GAPROOT /tmp/GAPROOT
           cd /tmp/GAPROOT
-          patchdir=${GITHUB_WORKSPACE}/.github/workflows/GAP_patches/${{ matrix.gap-version }}
+          patchdir=.github/workflows/GAP_patches/${{ matrix.gap-version }}
           if [ -d $patchdir ]; then
             for f in $patchdir/*.patch; do
               echo "Applying patch ${f}"

--- a/.github/workflows/gap.yml
+++ b/.github/workflows/gap.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           mv GAPROOT /tmp/GAPROOT
           cd /tmp/GAPROOT
-          patchdir=.github/workflows/GAP_patches/${{ matrix.gap-version }}
+          patchdir=${GITHUB_WORKSPACE}/.github/workflows/GAP_patches/${{ matrix.gap-version }}
           if [ -d $patchdir ]; then
             for f in $patchdir/*.patch; do
               echo "Applying patch ${f}"

--- a/test/gc.jl
+++ b/test/gc.jl
@@ -1,0 +1,75 @@
+#############################################################################
+##
+##  This file is part of GAP.jl, a bidirectional interface between Julia and
+##  the GAP computer algebra system.
+##
+##  Copyright of GAP.jl and its parts belongs to its developers.
+##  Please refer to its README.md file for details.
+##
+##  SPDX-License-Identifier: LGPL-3.0-or-later
+##
+
+# Regression tests for conservative scanning of task stacks by the GAP
+# garbage collector integration; see test/gc_common.jl for the technique.
+
+include("gc_common.jl")
+
+@testset "GC and task stacks" begin
+    victim = GCTestHelpers.make_gap_victim("Julia.Main.GCTestHelpers.jwait(jch)")
+
+    # run one victim iteration per call of `gc`, which is invoked while the
+    # victim task is parked inside take!
+    next_id = Ref(0)
+    function run_victim(n, gc)
+        off = next_id[]
+        next_id[] += n
+        GCTestHelpers.ensure_canaries(off + n)
+        ch = Channel{Int}()
+        res = Ref(-1)
+        t = @task (res[] = victim(ch, n, off))
+        bind(ch, t)   # a failing victim closes the channel instead of hanging us
+        schedule(t)
+        yield()
+        keepalive = GapObj[]
+        for i in 1:n
+            GCTestHelpers.pad!(keepalive, i)
+            gc()
+            put!(ch, 0)
+            yield()
+        end
+        wait(t)
+        return res[]
+    end
+
+    # automatic collections (the only kind that historically took the buggy
+    # code path)
+    @test run_victim(60, GCTestHelpers.churn_until_auto_gc) == 0
+
+    # explicit incremental collections
+    @test run_victim(30, () -> GC.gc(false)) == 0
+
+    # a task on a second thread that never task-switches while holding a bag
+    # only in a C stack temporary; needs a multi-threaded subprocess, and
+    # --gcthreads=2 additionally exercises the task scanner callback on
+    # parallel GC mark threads
+    script = joinpath(@__DIR__, "gc_threads_script.jl")
+    function run_threads_script()
+        cmd = `$(Base.julia_cmd()) -t2 --gcthreads=2 --project=$(Base.active_project()) $(script)`
+        mktemp() do path, out
+            p = run(pipeline(cmd; stdout = out, stderr = out); wait = false)
+            if timedwait(() -> !process_running(p), 300) == :timed_out
+                kill(p)
+                wait(p)
+            end
+            close(out)
+            return success(p), read(path, String)
+        end
+    end
+    ok, output = run_threads_script()
+    if !ok
+        # retry once, e.g. after a timeout from an unlucky scheduling
+        ok, output = run_threads_script()
+    end
+    ok || println(output)
+    @test ok
+end

--- a/test/gc_common.jl
+++ b/test/gc_common.jl
@@ -1,0 +1,106 @@
+#############################################################################
+##
+##  This file is part of GAP.jl, a bidirectional interface between Julia and
+##  the GAP computer algebra system.
+##
+##  Copyright of GAP.jl and its parts belongs to its developers.
+##  Please refer to its README.md file for details.
+##
+##  SPDX-License-Identifier: LGPL-3.0-or-later
+##
+
+# Shared machinery of the task stack scanning regression tests in test/gc.jl
+# and test/gc_threads_script.jl, see
+# https://github.com/oscar-system/GAP.jl/issues/1032 and
+# https://github.com/oscar-system/GAP.jl/issues/1224.
+#
+# Technique: a GAP function evaluates `pair(make_canary(off + i), <block>)`.
+# While the second argument runs Julia code, the wrapper bag of the canary
+# object created for the first argument is referenced only from a C stack
+# frame of the task running GAP (the argument temporary of the GAP kernel's
+# function call evaluation). If the GC fails to scan that task's stack, the
+# bag and with it the canary are collected while still live; the canary's
+# finalizer records this, keyed by a per-canary id (a shared flag would give
+# false positives from the natural death of the previous iteration's canary).
+
+module GCTestHelpers
+
+using GAP
+
+# one slot per canary id; written only by that canary's finalizer, so no
+# locking is needed (finalizers must not block on a lock anyway). Ids are
+# never reused and the vector never shrinks, as canaries of an earlier test
+# may be finalized while a later one runs.
+const freed = Bool[]
+
+ensure_canaries(n) = length(freed) < n && append!(freed, falses(n - length(freed)))
+
+function make_canary(id)
+    c = Ref(Int(id))
+    finalizer(_ -> (freed[Int(id)] = true), c)
+    return c
+end
+
+canary_was_freed(id) = freed[Int(id)]
+
+pair(a, b) = 0
+
+# blocker for test/gc.jl: park the task until the driver wakes it
+jwait(ch) = (take!(ch); 0)
+
+# blocker for test/gc_threads_script.jl: busy-wait on another thread
+const spin_state = Threads.Atomic{Int}(0)
+const go = Threads.Atomic{Int}(0)
+function jspin(id)
+    spin_state[] = Int(id)
+    while go[] < Int(id)
+        GC.safepoint()   # participate in stop-the-world, but never task-switch
+    end
+    return 0
+end
+
+# the GAP victim function; `blocker` is GAP code for the blocking second
+# argument, using the locals `jch`, `i` and `off`
+function make_gap_victim(blocker::String)
+    return GAP.evalstr("""
+    function(jch, n, off)
+      local i, s, bad;
+      bad := 0;
+      for i in [1..n] do
+        s := Julia.Main.GCTestHelpers.pair(
+                 Julia.Main.GCTestHelpers.make_canary(off + i),
+                 $(blocker));
+        if Julia.Main.GCTestHelpers.canary_was_freed(off + i) then
+          bad := bad + 1;
+        fi;
+      od;
+      return bad;
+    end;""")
+end
+
+# churn allocations until at least one automatic collection has run. The
+# budget must be generous: only an *automatic* collection takes the code
+# paths under test, an explicit one does not.
+const junk = Any[]
+function churn_until_auto_gc()
+    n0 = Base.gc_num().pause
+    for k in 1:5_000_000
+        Base.gc_num().pause == n0 || break
+        push!(junk, zeros(128))
+        length(junk) > 200_000 && empty!(junk)
+    end
+    empty!(junk)
+    # last resort so the test cannot spin forever
+    Base.gc_num().pause == n0 && GC.gc(false)
+end
+
+# allocate a varying number of GAP objects, kept alive, so that the victim's
+# next wrapper bag gets a fresh master pointer cell rather than accidentally
+# reusing one from a freed predecessor
+function pad!(keepalive, i)
+    for k in 1:(1 + i % 7)
+        push!(keepalive, GapObj("pad $i $k"))
+    end
+end
+
+end

--- a/test/gc_threads_script.jl
+++ b/test/gc_threads_script.jl
@@ -1,0 +1,47 @@
+#############################################################################
+##
+##  This file is part of GAP.jl, a bidirectional interface between Julia and
+##  the GAP computer algebra system.
+##
+##  Copyright of GAP.jl and its parts belongs to its developers.
+##  Please refer to its README.md file for details.
+##
+##  SPDX-License-Identifier: LGPL-3.0-or-later
+##
+
+# Run by test/gc.jl in a subprocess with -t2: a task on a second thread runs
+# GAP and busy-waits inside a Julia call without ever task-switching, while
+# the main thread triggers automatic collections. The task's C stack, which
+# holds the only reference to a bag, must still be scanned. See
+# test/gc_common.jl for the technique.
+
+using GAP
+
+include(joinpath(@__DIR__, "gc_common.jl"))
+
+victim = GCTestHelpers.make_gap_victim("Julia.Main.GCTestHelpers.jspin(off + i)")
+
+@assert Threads.nthreads() >= 2
+
+const N = 40
+GCTestHelpers.ensure_canaries(N)
+res = Ref(-1)
+t = Threads.@spawn (res[] = victim(0, N, 0))
+
+keepalive = GapObj[]
+for i in 1:N
+    while GCTestHelpers.spin_state[] < i
+        istaskdone(t) && break   # don't spin forever if the victim failed
+        yield()
+    end
+    istaskdone(t) && break
+    # the victim is now busy-spinning on the other thread and GAP is not
+    # entered concurrently, so allocating GAP objects from here is fine
+    GCTestHelpers.pad!(keepalive, i)
+    GCTestHelpers.churn_until_auto_gc()
+    GCTestHelpers.go[] = i
+end
+wait(t)
+
+println("canaries freed while live: ", res[], " of ", N)
+exit(res[] == 0 ? 0 : 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ include("packages.jl")
 include("help.jl")
 include("setup.jl")
 include("rand.jl")
+include("gc.jl")
 
 if !(VERSION.major == 1 && VERSION.minor == 10) || Base.JLOptions().code_coverage == 0
   # REPL completion doesn't work in Julia 1.10 when code coverage


### PR DESCRIPTION
A GAP object held only in a C stack frame of a Julia task must survive collections that run while the task is suspended (parked in a Julia call, or busy on another thread). This went wrong when the task stack rescan optimization in GAP's julia_gc.c skipped old tasks, the cause of long-elusive crashes; see #1032, #1224 and gap-system/gap#6525.

The tests hold a canary object solely via a wrapper bag in a GAP kernel argument temporary and detect premature collection through per-canary finalizers, covering automatic and explicit incremental collections and, in a -t2 subprocess, a never-switching task on a second thread. Only automatic collections exercise the historically buggy path, so the driver churns allocations rather than calling GC.gc.

Resolves #996

AI disclosure: tests developed with the assistance of Claude Code.