### PR TITLE
Speed up `collect` and list comprehensions for GAP lists

### DIFF
--- a/src/adapter.jl
+++ b/src/adapter.jl
@@ -527,6 +527,101 @@ end
 Base.IteratorEltype(::Type{GapObj}) = Base.EltypeUnknown()
 Base.IteratorSize(::Type{GapObj}) = Base.SizeUnknown()
 
+# Optimized `collect` for `GapObj`. The generic `collect` for iterators of
+# unknown size and eltype assembles the result via `Base.grow_to!`, which
+# performs several dynamically dispatched calls per collect. Iterating a
+# `GapObj` always has unknown size and eltype, so nothing is lost by
+# gathering the elements ourselves instead.
+#
+# The element type of the result is determined as by the generic code: it
+# starts out as the type of the first element and is widened via
+# `promote_typejoin` whenever an element does not fit; holes in lists are
+# skipped (as iteration does); and if there is no element at all, the type
+# comes from inference (`ET`, the caller's `Base.@default_eltype`). Note
+# that the `isa` checks let the compiler drop the widening branches when
+# the element type is known and concrete, so that e.g.
+# `[f(x)::T for x in gaplist]` is inferred as `Vector{T}`.
+
+# fast path for GAP lists: the length is known in advance
+function _collect_list(f::F, x::GapObj, len::Int, ::Type{ET}) where {F,ET}
+    for i in 1:len
+        el = ElmList(x, i)  # returns 'nothing' for holes in the list
+        el === nothing && continue
+        y = f(el)
+        v = Vector{typeof(y)}(undef, len)
+        v[1] = y
+        return _collect_list!(f, x, len, v, 1, i+1)
+    end
+    return ET[]  # no bound entries
+end
+
+function _collect_list!(f::F, x::GapObj, len::Int, v::Vector{T}, n::Int, i::Int) where {F,T}
+    while i <= len
+        el = ElmList(x, i)
+        if el !== nothing
+            y = f(el)
+            if !(y isa T)
+                # widen the element type, then carry on where we left off
+                w = Vector{Base.promote_typejoin(T, typeof(y))}(undef, len)
+                copyto!(w, 1, v, 1, n)
+                w[n+1] = y
+                return _collect_list!(f, x, len, w, n+1, i+1)
+            end
+            n += 1
+            v[n] = y
+        end
+        i += 1
+    end
+    resize!(v, n)
+    return v
+end
+
+# for everything else (GAP iterators, collections, generators over these)
+# gather via the iteration protocol
+function _collect_iter(itr, ::Type{ET}) where {ET}
+    y = iterate(itr)
+    y === nothing && return ET[]
+    el = y[1]
+    v = Vector{typeof(el)}()
+    push!(v, el)
+    return _collect_iter!(itr, v, y[2])
+end
+
+function _collect_iter!(itr, v::Vector{T}, state) where {T}
+    y = iterate(itr, state)
+    while y !== nothing
+        el = y[1]
+        if !(el isa T)
+            w = Vector{Base.promote_typejoin(T, typeof(el))}()
+            append!(w, v)
+            push!(w, el)
+            return _collect_iter!(itr, w, y[2])
+        end
+        push!(v, el)
+        y = iterate(itr, y[2])
+    end
+    return v
+end
+
+function Base.collect(x::GapObj)
+    ET = Base.@default_eltype(x)
+    if Wrappers.IsList(x)
+        len = Wrappers.Length(x)
+        len isa Int && return _collect_list(identity, x, len, ET)
+    end
+    return _collect_iter(x, ET)
+end
+
+function Base.collect(g::Base.Generator{GapObj,F}) where {F}
+    x = g.iter
+    ET = Base.@default_eltype(g)
+    if Wrappers.IsList(x)
+        len = Wrappers.Length(x)
+        len isa Int && return _collect_list(g.f, x, len, ET)
+    end
+    return _collect_iter(g, ET)
+end
+
 # copy and deepcopy:
 # The following is just a preliminary solution,
 # in order to avoid Julia crashes when one calls `deepcopy` for a `GapObj`.

--- a/test/adapter.jl
+++ b/test/adapter.jl
@@ -54,6 +54,7 @@
     @test collect(GAP.evalstr("[]")) isa Vector{Any}
     l = GAP.evalstr("[1,,3]")
     @test collect(l) isa Vector{Int}
+    @test collect(l) == [1, 3]
     @test [2 * x for x in l] == [2, 6]
     @test [x for x in GAP.evalstr("[1, 2, 3]")] isa Vector{Int}
 

--- a/test/adapter.jl
+++ b/test/adapter.jl
@@ -45,6 +45,28 @@
 
     # some things cannot be iterated over
     @test_throws ArgumentError collect(GAP.Globals.GAPInfo)
+
+    # `collect` over GAP lists narrows the element type like the generic
+    # iteration based code does
+    @test collect(GAP.evalstr("[SymmetricGroup(3), SymmetricGroup(4)]")) isa Vector{GapObj}
+    @test collect(GAP.evalstr("[1, 2, true]")) isa Vector{Integer}
+    @test collect(GAP.evalstr("[1, SymmetricGroup(3)]")) isa Vector{Any}
+    @test collect(GAP.evalstr("[]")) isa Vector{Any}
+    l = GAP.evalstr("[1,,3]")
+    @test collect(l) isa Vector{Int}
+    @test [2 * x for x in l] == [2, 6]
+    @test [x for x in GAP.evalstr("[1, 2, 3]")] isa Vector{Int}
+
+    # an empty result gets its element type from inference,
+    # just like the generic iteration based code
+    @test [(a::GapObj) for a in GAP.evalstr("[]")] isa Vector{GapObj}
+    @test [2 * (a::Int) for a in GAP.evalstr("[]")] isa Vector{Int}
+
+    # comprehensions with a concrete element type stay inferrable
+    # (Oscar.jl has `@inferred` tests relying on this)
+    f(l::GapObj) = [string(a::GapObj) for a in l]
+    @test @inferred(f(GAP.evalstr("[(1,2), (1,2,3)]"))) isa Vector{String}
+    @test @inferred(f(GAP.evalstr("[]"))) isa Vector{String}
 end
 
 @testset "deepcopy" begin


### PR DESCRIPTION
For iterators of unknown size and eltype, the generic `collect` assembles the result via `Base.grow_to!`, which performs several dynamically dispatched calls per element. Iterating a `GapObj` always has unknown size and eltype, so nothing is lost by gathering the elements ourselves: for GAP lists we can use the known length and fill a vector of that size directly, everything else (GAP iterators and collections) goes through the iteration protocol.

The element type of the result is determined as by the generic code: it starts out as the type of the first element and is widened via `promote_typejoin` whenever an element does not fit, holes in lists are skipped, and if there is no element at all the type comes from inference. As there, the `isa` checks let the compiler drop the widening branches when the element type is concrete, so that a comprehension such as `[f(x)::T for x in gaplist]` is still inferred as `Vector{T}` and yields one also for an empty list; Oscar.jl relies on both.

Benchmarks using `Chairmarks.jl` on Julia 1.12:

    julia> L = GAP.evalstr("List([3..6],SymmetricGroup)");

    julia> v = GapObj(collect(1:10000));

    julia> w = GapObj([GapObj([i]) for i in 1:10000]);

Before:

    julia> @b collect($L)
    1.869 μs (24 allocs: 928 bytes)

    julia> @b [x for x in $L]
    1.847 μs (25 allocs: 944 bytes)

    julia> @b collect($v)
    773.416 μs (49003 allocs: 1.423 MiB)

    julia> @b collect($w)
    630.125 μs (30025 allocs: 1.133 MiB)

After:

    julia> @b collect($L)
    257.505 ns (2 allocs: 96 bytes)

    julia> @b [x for x in $L]
    258.178 ns (2 allocs: 96 bytes)

    julia> @b collect($v)
    71.000 μs (9495 allocs: 228.375 KiB)

    julia> @b collect($w)
    32.458 μs (6 allocs: 80.109 KiB)

On Julia 1.10, where the dispatch overhead of the generic code is smaller, the same benchmarks improve from 475.000 ns, 471.218 ns, 743.625 μs and 637.750 μs to 270.047 ns, 266.667 ns, 69.042 μs and 38.416 μs, respectively.

| benchmark | 1.12 before | 1.12 after | 1.10 before | 1.10 after |
|---|---|---|---|---|
| `collect(L)` — 4 groups | 1.869 µs<br>24 allocs | 257 ns<br>2 allocs | 475 ns<br>15 allocs | 270 ns<br>1 alloc |
| `[x for x in L]` | 1.847 µs<br>25 allocs | 258 ns<br>2 allocs | 471 ns<br>16 allocs | 267 ns<br>1 alloc |
| `collect(v)` — 10k ints | 773 µs<br>49003 allocs | 71 µs<br>9495 allocs | 744 µs | 69 µs |
| `collect(w)` — 10k GapObjs | 630 µs<br>30025 allocs | 32 µs<br>**6 allocs** | 638 µs | 38 µs |


Part of issue #736.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>