### PR TITLE
Signal handling: keep Julia's state, make Ctrl-C interrupt GAP

### DIFF
--- a/.github/workflows/CI-distro.yml
+++ b/.github/workflows/CI-distro.yml
@@ -60,6 +60,7 @@ jobs:
           - gap-package: 'atlasrep'                   # random gc-related segfaults during testing
           - gap-package: 'autodoc'                    # tries and fails to build its own documentation, inside the (partially write protected) artifacts dir
           - gap-package: 'ctbllib'                    # random gc-related segfaults during testing
+          - gap-package: 'curlinterface'              # hangs: tests fork an HTTP server via `io`, but the forked child never receives the SIGTERM meant to stop it (julia blocks signals; its signal listener thread does not survive the fork), so a blocking IO_WaitPid never returns
           - gap-package: 'example'                    # no jll
           - gap-package: 'examplesforhomalg'          # `Error, found no GAP executable in PATH`
           - gap-package: 'io'                         # segfaults, most likely due to child process handling
@@ -68,6 +69,7 @@ jobs:
           - gap-package: 'packagemanager'             # many "#I  No sysinfo.gap found" warnings
           - gap-package: 'profiling'                  # segfaults during testing
           - gap-package: 'ringsforhomalg'             # `Error, found no GAP executable in PATH`
+          - gap-package: 'utils'                      # hangs: same forked HTTP test server problem as curlinterface (see above)
           - gap-package: 'xgap'                       # no jll
 
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 ## Version 0.17.6-DEV (released YYYY-MM-DD)
 
+- Ctrl-C now interrupts a running GAP computation (as an `InterruptException`
+  in Julia, or a break loop inside `GAP.prompt()`) instead of being deferred
+  until GAP returns to Julia
+- Restore Julia's `SIGCHLD`, `SIGTSTP` and `SIGWINCH` handling and the
+  terminal attributes after GAP startup and after `GAP.prompt()`
+- Add `GAP.signal_report()` and a manual page on signal handling
+- Exclude the `utils` and `curlinterface` GAP packages from the package
+  distro tests until an io release fixes signal delivery to forked children
 - Speed up `collect` and list comprehensions for GAP lists
 - Avoid boxing immediate integers in wrapped GAP calls (reduces
   allocations and improves performance)

--- a/docs/src/signals.md
+++ b/docs/src/signals.md
@@ -1,0 +1,279 @@
+# Signals, interrupts, subprocesses and the terminal
+
+```@meta
+CurrentModule = GAP
+DocTestSetup = :(using GAP)
+```
+
+This page is the reference for how GAP.jl deals with process-wide
+resources that both Julia and GAP want to own: signal dispositions, the
+signal mask, child process reaping, and the terminal. It documents the
+facts about Julia's runtime that an embedded library has to respect, the
+ownership contract GAP.jl enforces, the measures implemented in GAP.jl,
+and what is still pending in GAP, in GAP packages, and upstream in Julia.
+It doubles as guidance for other Julia packages that embed a computer
+algebra system (e.g. Singular.jl, Polymake.jl).
+
+## Why this page exists
+
+GAP was written as a standalone program that owns its process. When it is
+embedded into Julia, three runtimes compete for the same process-wide
+state:
+
+- Julia (and its I/O library libuv),
+- the GAP kernel,
+- GAP packages with kernel extensions: `io` (child processes, its own
+  `SIGCHLD` handler), `Browse` (ncurses, terminal and `SIGTSTP`).
+
+Every incident in the following list is one of these runtimes clobbering
+state that another one relied on:
+
+- Ctrl-C killing Julia with GAP's `you hit Ctrl-C twice` message
+  ([GAP.jl#74](https://github.com/oscar-system/GAP.jl/issues/74),
+  [gap#3256](https://github.com/gap-system/gap/pull/3256));
+- `Process` hanging after `IO_Popen3` was used
+  ([GAP.jl#902](https://github.com/oscar-system/GAP.jl/issues/902)),
+  the crashes that led to disabling the Julia implementation of
+  `ExecuteProcess`
+  ([GAP.jl#905](https://github.com/oscar-system/GAP.jl/issues/905),
+  [#906](https://github.com/oscar-system/GAP.jl/pull/906),
+  [#908](https://github.com/oscar-system/GAP.jl/issues/908)),
+  and the wish to replace GAP's child process functions altogether
+  ([GAP.jl#241](https://github.com/oscar-system/GAP.jl/issues/241),
+  [#1107](https://github.com/oscar-system/GAP.jl/issues/1107));
+- the test suites of the `utils` and `curlInterface` packages hanging
+  forever under GAP.jl because a forked helper process never receives
+  the `SIGTERM` meant to stop it;
+- the io package's own `SIGCHLD` handler losing the race against another
+  reaper, first seen with HPC-GAP
+  ([io#5](https://github.com/gap-packages/io/issues/5),
+  [gap#3380](https://github.com/gap-system/gap/issues/3380));
+- the terminal being garbled after suspending and resuming a Julia
+  session with the `Browse` package loaded
+  ([GAP.jl#741](https://github.com/oscar-system/GAP.jl/issues/741)),
+  and Browse's ncurses initialization emitting stray output
+  ([gap#430](https://github.com/gap-system/gap/issues/430)).
+
+## How Julia handles signals
+
+These facts hold for Julia 1.10 through 1.12 (see `src/signals-unix.c`,
+`src/signal-handling.c` and `src/safepoint.c` in the Julia sources).
+
+**Blocked signals and the listener thread.** At startup Julia blocks
+`SIGINT`, `SIGTERM`, `SIGQUIT` (plus `SIGINFO` on macOS, `SIGUSR1` on
+Linux) on the main thread; all threads created later inherit that mask.
+A dedicated *signal listener* thread consumes these signals, via
+`sigwaitinfo` on Linux and via kqueue on macOS. Because kqueue does not
+dequeue the signals it observes, on macOS the dispositions of `SIGTERM`
+and `SIGQUIT` are set to `SIG_IGN` so that the kernel discards them.
+Consequences:
+
+- A handler installed for one of these signals by a library never runs
+  on a Julia thread — the *mask*, not the disposition, disables it.
+- Children created by a raw `fork()` inherit the blocked mask and the
+  `SIG_IGN` dispositions. Neither Julia nor libuv registers
+  `pthread_atfork` handlers. Unless the forking code resets the signal
+  state itself, such a child cannot be terminated with `SIGTERM`.
+  libuv's own spawn path does reset everything before `exec`.
+
+**Ctrl-C.** When the listener thread receives `SIGINT`, it first
+re-raises the signal on itself with `SIGINT` temporarily unblocked
+(`jl_ignore_sigint`), which dispatches it through the current process
+disposition; only if Julia's own handler ran does it proceed to deliver
+an `InterruptException` — and it delivers it exclusively at a
+*safepoint*, i.e. when Julia code is executing. A long `ccall` into a C
+library is therefore not interruptible; repeated Ctrl-C eventually
+force-throws the exception through the foreign C frames, which is unsafe.
+`Base.disable_sigint` defers delivery, and `jl_gc_safepoint()` is the
+sanctioned way for foreign code to poll for a pending interrupt.
+
+**Fault signals.** `SIGSEGV` and `SIGBUS` (and on Linux `SIGUSR2`) are
+integral to Julia's garbage collector: safepoints are implemented as
+faults on a protected page. Replacing these handlers breaks multithreaded
+Julia. `--handle-signals=no` disables them too and is therefore not an
+option for a process that uses more than one thread.
+
+**Child processes.** Julia spawns processes exclusively through libuv.
+On macOS and the BSDs libuv installs no `SIGCHLD` handler at all and
+watches its children with kqueue; on Linux it installs a process-wide
+`SIGCHLD` handler that merely wakes the event loop. In both cases libuv
+reaps strictly per pid with `waitpid(pid, WNOHANG)`. If another party
+reaped the child first, libuv sees `ECHILD`, concludes that "someone
+stole the waitpid", and silently never completes the `Process` — every
+`wait`/`success`/`run` on it hangs forever. On Linux a foreign `SIGCHLD`
+handler additionally replaces libuv's and stops the loop from ever
+noticing exited children.
+
+**Terminal.** Julia installs no handlers for `SIGTSTP`, `SIGCONT` or
+`SIGWINCH`. The REPL raises `SIGTSTP` itself on Ctrl-Z and polls the
+terminal size on demand.
+
+## The ownership contract
+
+In a process that embeds GAP into Julia:
+
+| Resource | Owner | Everyone else |
+|:---|:---|:---|
+| `SIGSEGV`, `SIGBUS`, `SIGILL`, `SIGFPE`, `SIGTRAP` | Julia (GC safepoints, error reporting) | never touch |
+| `SIGINT` | Julia delivers it; `JuliaInterface` may install a single *chaining* handler | no other handlers, no temporary `SIG_IGN` |
+| `SIGTERM`, `SIGQUIT`, `SIGUSR2`, the signal mask | Julia | never modify |
+| `SIGCHLD` | libuv | reap only your own children, per pid; `waitpid(-1)` is forbidden; no handlers |
+| `fork()` | the forking code | reset mask and dispositions of the termination signals *before* forking and restore them in the parent; children created by `fork`+`exec` inherit both |
+| terminal (raw mode, `SIGTSTP`, `SIGWINCH`) | whoever runs the active REPL | acquire on entry, restore on exit; never at library load time |
+
+The test file `test/signals.jl` asserts the parts of this contract that
+can be checked after `using GAP`.
+
+## What GAP.jl implements
+
+**Startup.** The GAP kernel installs handlers for `SIGCHLD`
+(`ChildStatusChanged` in `src/iostream.c`) and `SIGWINCH`
+(`syWindowChangeIntr` in `src/sysfiles.c`) unconditionally — the
+`handleSignals` argument of `GAP_Initialize` only controls `SIGINT` — and
+loading the `Browse` package initializes ncurses, which installs a
+`SIGTSTP` handler. `GAP.initialize` saves the dispositions of these three
+signals and the terminal attributes before starting GAP and reinstates
+them afterwards. In standalone mode (`gap.sh`), where GAP runs its own
+REPL, nothing is touched.
+
+**`GAP.prompt()`.** The GAP REPL legitimately takes over the terminal.
+`prompt` hands it over and, in a `finally` block, hands it back to Julia
+together with the error-handling state, so an abnormal exit from the GAP
+session cannot leave Julia's REPL in a broken state.
+
+**Diagnostics.** [`signal_report`](@ref) prints the current
+dispositions, attributing every handler to the shared library that owns
+it. Run it whenever Ctrl-C, subprocesses, or the terminal misbehave:
+
+```julia
+julia> GAP.signal_report();
+SIGINT    handler  sigint_handler [libjulia-internal.1.12.7.dylib]  blocked
+SIGQUIT   ignore     blocked
+SIGILL    handler  sigdie_handler [libjulia-internal.1.12.7.dylib]
+...
+```
+
+A `SIGCHLD` line owned by `libgap` or `io`, or a `SIGTSTP`/`SIGWINCH`
+line owned by `libgap` or `ncurses`, means the contract has been
+violated by something that ran after startup.
+
+```@docs
+signal_report
+SignalInfo
+```
+
+## Ctrl-C and interrupts
+
+GAP's own interrupt mechanism is embedder-friendly: the kernel function
+`InterruptExecStat` is a single asynchronous-signal-safe store that makes
+the interpreter raise a `user interrupt` error at the next statement
+boundary. GAP.jl uses it as follows (the *interrupt bridge*):
+
+- `JuliaInterface` installs one chaining `SIGINT` handler and remembers
+  Julia's. Because of the re-raise described above, this handler runs for
+  every Ctrl-C, on Julia's listener thread, without any change to the
+  signal mask.
+- A depth counter records whether GAP code is currently executing. It is
+  maintained around the entry points from Julia into GAP and reset to
+  zero while GAP calls back into Julia, so that the innermost runtime
+  owns Ctrl-C. Maintaining it costs a few nanoseconds per call.
+- If GAP is active, the handler calls `InterruptExecStat`; otherwise it
+  forwards to Julia's handler, and Julia behaves as usual.
+- The resulting GAP `user interrupt` error travels through GAP.jl's
+  normal error bridge and is converted into a Julia `InterruptException`
+  at the boundary, so that generic Julia code handles Ctrl-C uniformly.
+- Inside `GAP.prompt()` Ctrl-C enters GAP's break loop, as in a
+  standalone GAP session. GAP's own `SIGINT` handler, whose
+  double-Ctrl-C path terminates the whole process from inside a signal
+  handler, is not used.
+
+Interrupts arrive at GAP statement boundaries only; a long computation
+inside a single kernel function is not interruptible, as in standalone
+GAP. The design relies on Julia re-dispatching `SIGINT` through the
+process disposition; should a future Julia stop doing that, the bridge
+degrades to the previous behavior (Ctrl-C takes effect when control
+returns to Julia) and never to a crash.
+
+## Child processes and `SIGCHLD`
+
+Three code paths in a GAP.jl session create child processes:
+
+- GAP's `Process`/`Exec` (kernel `ExecuteProcess`). `JuliaInterface`
+  replaces it by a Julia implementation based on `run`, controlled by
+  `GAP.use_orig_ExecuteProcess[]`. The replacement is currently disabled
+  because the io package's reaping steals libuv's children (the hang of
+  GAP.jl#902); it will be enabled by default once an io release that
+  follows the contract is shipped.
+- GAP's pty-based `InputOutputLocalProcess` (kernel `iostream.c`), which
+  reaps its own children per pid but relied on the `SIGCHLD` handler to
+  notice a dead child early. Without the handler, a dead child is noticed
+  when the stream is next used or closed.
+- The io package (`IO_fork`, `IO_Popen*`, `IO_WaitPid`), which installs
+  its own `SIGCHLD` handler and reaps with `waitpid(-1)` whenever its
+  process functions are used. This is the remaining contract violation:
+  after it, Julia's subprocess handling hangs. The fix (embedded and
+  HPC-GAP mode: no handler, per-pid reaping of registered children only)
+  belongs to io 4.10.1 together with the pre-fork signal reset that makes
+  forked children terminable again. Until GAP.jl ships that io version,
+  the `utils` and `curlInterface` packages stay excluded from the package
+  distro tests, and `test/signals.jl` keeps an opt-in test
+  (`GAPJL_TEST_SIGNALS_IO=1`) documenting the breakage.
+
+## Terminal
+
+The GAP kernel enters raw mode only while reading from a terminal, and
+its `SIGTSTP` handling is scoped to raw mode — that is the right handover
+pattern. `SIGWINCH` is installed at startup and will be gated on embedded
+mode in a future GAP release. `Browse` initializes ncurses when it is
+loaded rather than when it first draws on the screen; a patch making that
+initialization lazy, with ncurses's handlers installed only while a
+Browse application is on screen, fixes both GAP.jl#741 and gap#430.
+
+## Guidance for other embedded libraries
+
+A Julia package that embeds a C/C++ library should:
+
+1. Never let the library install handlers for the fault signals. If its
+   initialization does so, save and restore the dispositions with
+   `sigaction` (not `signal`) around the call, as `GAP.initialize` does;
+   the helpers in `src/signals.jl` can be copied.
+2. Configure the library not to handle `SIGINT` at all (like RCall's
+   `R_SignalHandlers = 0`), or install a chaining handler plus a depth
+   counter as described above if interruptible computations are wanted.
+   Wrapping every call in `Base.disable_sigint` (Polymake.jl's approach)
+   is safe but makes Ctrl-C ineffective during the call.
+3. Make sure the library reaps only its own children, per pid, and
+   never installs a `SIGCHLD` handler or calls `waitpid(-1)`.
+4. If the library forks, reset the signal mask and the dispositions of
+   the termination signals before forking (see `FuncIO_fork` in io ≥
+   4.10.1 for a template).
+5. Add a test that prints the equivalent of [`signal_report`](@ref)
+   after loading the library and asserts that the fault signals and
+   `SIGINT` still belong to Julia and that `SIGCHLD` is untouched.
+
+## Compatibility
+
+| Behavior | released GAP + io | with io ≥ 4.10.1 | with the next GAP release |
+|:---|:---|:---|:---|
+| Julia's `run()` after `using GAP` | works | works | works |
+| Julia's `run()` after io process functions | hangs | works | works |
+| `SIGTERM` to children forked by io | ignored | works | works |
+| Ctrl-C during a GAP computation | interrupt bridge (GAP.jl) | same | same, with a public kernel API |
+| Julia implementation of `ExecuteProcess` | disabled | enabled | enabled |
+| `SIGWINCH` handler after startup | restored by GAP.jl | same | not installed by GAP |
+| dead pty child noticed | on next use/close | same | on next use (kernel polls) |
+
+## Open items
+
+- GAP kernel (next release): public `GAP_InterruptExecStat` and a way to
+  tell a user interrupt from an error in the libgap API; gate the
+  `SIGWINCH` handler and the process-exit path of `syAnswerIntr` on
+  embedded mode; replace the `SIGCHLD` handler by polling at the points
+  that consume its information; reset the signal state before forking in
+  `SyExecuteProcess`.
+- io package: 4.10.1 with the pre-fork signal reset and per-pid reaping
+  in embedded/HPC-GAP mode (closes io#5).
+- Browse package: lazy ncurses initialization.
+- Julia: a supported save/restore API for signal handlers
+  ([julia#46076](https://github.com/JuliaLang/julia/issues/46076));
+  GAP.jl depends on the `SIGINT` re-dispatch in `jl_ignore_sigint`.

--- a/docs/src/signals.md
+++ b/docs/src/signals.md
@@ -179,6 +179,11 @@ boundary. GAP.jl uses it as follows (the *interrupt bridge*):
   owns Ctrl-C. Maintaining it costs a few nanoseconds per call.
 - If GAP is active, the handler calls `InterruptExecStat`; otherwise it
   forwards to Julia's handler, and Julia behaves as usual.
+- While GAP waits for input at a prompt (detected through readline's
+  state word, since GAP's command line editor runs GAP code for every
+  key), Ctrl-C is dropped — the behavior of a standalone GAP session.
+  GAP prints the prompt shortly before it enters readline; a Ctrl-C in
+  that tiny window interrupts the next command instead.
 - The resulting GAP `user interrupt` error travels through GAP.jl's
   normal error bridge and is converted into a Julia `InterruptException`
   at the boundary, so that generic Julia code handles Ctrl-C uniformly.

--- a/etc/julia.expect
+++ b/etc/julia.expect
@@ -48,6 +48,27 @@ expect "GAP_jl;\r"
 expect "<Julia module GAP>\r"
 expect "gap> "
 
+# Ctrl-C at an idle GAP prompt must not interrupt the next command
+# (GAP prints the prompt itself before it enters readline; give it a
+# moment, as a human would, so the interrupt hits readline, not the gap)
+sleep 0.5
+send -- "\003"
+sleep 0.5
+send -- "1+1;\r"
+expect "1+1;\r"
+expect "2\r"
+expect "gap> "
+
+# Ctrl-C during a GAP computation enters the break loop
+send -- "while true do od;\r"
+expect "while true do od;\r"
+sleep 1
+send -- "\003"
+expect "brk> "
+send -- "quit;\r"
+expect "quit;\r"
+expect "gap> "
+
 # test returning to Julia prompt
 send -- "quit;\r"
 expect "quit;\r"

--- a/pkg/JuliaInterface/src/JuliaInterface.c
+++ b/pkg/JuliaInterface/src/JuliaInterface.c
@@ -23,6 +23,9 @@
 
 #include <julia_gcext.h>    // Julia header
 
+#include <signal.h>
+#include <string.h>
+
 jl_module_t * gap_module;
 
 static jl_value_t *    JULIA_ERROR_IOBuffer;
@@ -126,6 +129,77 @@ Obj NewJuliaObj(jl_value_t * v)
 void ResetUserHasQUIT(void)
 {
     STATE(UserHasQUIT) = 0;
+}
+
+
+/*
+ * Interrupt bridge (see docs/src/signals.md in GAP.jl).
+ *
+ * Julia blocks SIGINT on all of its threads and consumes it on a listener
+ * thread, which re-raises every SIGINT on itself through the process-wide
+ * disposition before deciding whether to deliver an InterruptException.
+ * Installing a chaining handler thus lets GAP.jl see every Ctrl-C without
+ * touching the signal mask:
+ *
+ *   Ctrl-C --> Julia listener thread --> chained_sigint_handler
+ *                  |                        |
+ *                  |          gap_interrupt_depth > 0 ?
+ *                  |            yes: InterruptExecStat()  (GAP raises
+ *                  |                 "user interrupt" at the next statement)
+ *                  |            no:  Julia's own handler  (Julia delivers an
+ *                  v                 InterruptException as usual)
+ *          jl_sigint_passed set?  -> continue / ignore
+ *
+ * gap_interrupt_depth is maintained by GAP.jl around every entry into GAP
+ * and reset to zero by DoCallJuliaFunc while GAP calls back into Julia.
+ */
+int gap_interrupt_depth = 0;
+
+static struct sigaction julia_sigint_action;
+
+// readline's state word, if GAP uses readline. Its RL_STATE_TERMPREPPED bit
+// is set for the whole duration of a readline() call, i.e. while GAP waits
+// for input at a prompt; GAP's own handler ignores Ctrl-C then (the GAP-level
+// line editor runs GAP statements which must not be interrupted), and so do
+// we. The bit value is fixed by readline's API (readline.h).
+#define RL_STATE_TERMPREPPED 0x0000004
+static volatile unsigned long * rl_state = NULL;
+
+static int gap_is_reading_input(void)
+{
+    return rl_state && (*rl_state & RL_STATE_TERMPREPPED);
+}
+
+static void chained_sigint_handler(int sig, siginfo_t * info, void * context)
+{
+    if (gap_interrupt_depth > 0) {
+        if (!gap_is_reading_input())
+            InterruptExecStat();
+        return;
+    }
+    if (julia_sigint_action.sa_flags & SA_SIGINFO)
+        julia_sigint_action.sa_sigaction(sig, info, context);
+    else if (julia_sigint_action.sa_handler != SIG_DFL &&
+             julia_sigint_action.sa_handler != SIG_IGN)
+        julia_sigint_action.sa_handler(sig);
+}
+
+// <readline_state> is the address of readline's rl_readline_state, or NULL
+// if libgap does not use readline
+void JuliaInterface_InstallSigintHandler(void * readline_state)
+{
+    struct sigaction action;
+
+    rl_state = readline_state;
+
+    sigaction(SIGINT, NULL, &julia_sigint_action);
+
+    memset(&action, 0, sizeof(action));
+    sigemptyset(&action.sa_mask);
+    action.sa_sigaction = chained_sigint_handler;
+    action.sa_flags = SA_SIGINFO | (julia_sigint_action.sa_flags &
+                                    (SA_RESTART | SA_ONSTACK | SA_NODEFER));
+    sigaction(SIGINT, &action, NULL);
 }
 
 

--- a/pkg/JuliaInterface/src/JuliaInterface.h
+++ b/pkg/JuliaInterface/src/JuliaInterface.h
@@ -20,6 +20,14 @@
 // internal helper
 NOINLINE void handle_jl_exception(void);
 
+// Interrupt bridge: > 0 while GAP code is executing (maintained by GAP.jl
+// around every entry into GAP); Ctrl-C then interrupts GAP instead of Julia.
+extern int gap_interrupt_depth;
+
+// Install the chaining SIGINT handler of the interrupt bridge; the argument
+// is the address of readline's rl_readline_state, or NULL.
+void JuliaInterface_InstallSigintHandler(void * readline_state);
+
 // Internal Julia access functions
 
 // GET_JULIA_OBJ(o)

--- a/pkg/JuliaInterface/src/calls.c
+++ b/pkg/JuliaInterface/src/calls.c
@@ -108,6 +108,12 @@ static ALWAYS_INLINE Obj DoCallJuliaFunc(Obj func, const int narg, Obj * a)
     }
 
     jl_value_t * f = (jl_value_t *)GET_JULIA_FUNC(func);
+
+    // While Julia code runs, Ctrl-C belongs to Julia again (see the
+    // interrupt bridge in JuliaInterface.c). jl_call* return normally even
+    // when the Julia code threw, so restoring here covers that exit, too.
+    int saved_interrupt_depth = gap_interrupt_depth;
+    gap_interrupt_depth = 0;
     switch (narg) {
     case 0:
         result = jl_call0(f);
@@ -125,6 +131,7 @@ static ALWAYS_INLINE Obj DoCallJuliaFunc(Obj func, const int narg, Obj * a)
     default:
         result = jl_call(f, (jl_value_t **)a, narg);
     }
+    gap_interrupt_depth = saved_interrupt_depth;
     if (jl_exception_occurred()) {
         handle_jl_exception();
     }

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -128,6 +128,8 @@ function initialize(argv::Vector{String})
     g = cglobal((:gap_module, JuliaInterface_path), Ptr{Cvoid})
     unsafe_store!(g, mptr)
 
+    _install_interrupt_bridge(handle_signals)
+
     # also declare a global GAP variable with the path to JuliaInterface.so
     AssignGlobalVariable("_path_JuliaInterface_so", MakeString(JuliaInterface_path))
 

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -65,6 +65,7 @@ macro include(path)
 end
 
 include("errors.jl")
+include("signals.jl")
 
 # path to JuliaInterface.so
 JuliaInterface_path::String = "" # will be set in __init__()
@@ -97,6 +98,13 @@ function initialize(argv::Vector{String})
     # the C data corresponding to argv needs to live forever
     # as this is kept in the global SyOriginalArgv pointer in GAP
     _saved_argv[] = Base.cconvert(Ptr{Ptr{UInt8}}, argv)
+
+    # In embedded mode Julia keeps ownership of signal handling and of the
+    # terminal; GAP's kernel and autoloaded packages nevertheless install
+    # handlers during startup (see signals.jl), so put Julia's state back
+    # once initialization is complete. In standalone mode GAP runs its own
+    # REPL and needs its handlers.
+    signal_state = handle_signals ? nothing : _save_signal_state(_SIGNALS_OWNED_BY_JULIA)
 
     @ccall libgap.GAP_Initialize(
         length(argv)::Int32,
@@ -184,6 +192,8 @@ function initialize(argv::Vector{String})
     # Redirect error messages, in order not to print them to the screen.
     GAP.@include("../gap/err.g")
     @debug "finished reading gap/err.g"
+
+    _restore_signal_state(signal_state)
 
     return nothing
 end

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -143,7 +143,7 @@ GAP: [  ]
 ```
 """
 function evalstr_ex(cmd::String)
-    res = @ccall libgap.GAP_EvalString(cmd::Cstring)::GapObj
+    res = @gap_active @ccall libgap.GAP_EvalString(cmd::Cstring)::GapObj
     return res
 end
 
@@ -198,7 +198,7 @@ function evalstr(cmd::String)
 
     snapshot = take_or_capture_gap_error_snapshot()
     if any(x::GapObj->x[1] === false, res)
-      throw(snapshot)
+      throw_gap_error(snapshot)
     end
 
     # Successful evalstr calls can still leave warning text in GAP's error
@@ -358,7 +358,7 @@ function call_gap_func(func::GapObj, args...; kwargs...)
 end
 
 function slow_call_gap_func_nokw(func::GapObj, args)
-    @ccall JuliaInterface_path.call_gap_func(func::Any, args::Any)::Ptr{Cvoid}
+    @gap_active @ccall JuliaInterface_path.call_gap_func(func::Any, args::Any)::Ptr{Cvoid}
 end
 
 is_func(func::GapObj) = TNUM_OBJ(func) == T_FUNCTION
@@ -399,14 +399,14 @@ end
 # 0 arguments
 function _call_gap_func(func::GapObj)
     fptr = GET_FUNC_PTR(func, 0)
-    ret = @ccall $fptr(func::GapObj)::Ptr{Cvoid}
+    ret = @gap_active @ccall $fptr(func::GapObj)::Ptr{Cvoid}
     return ret
 end
 
 # 1 argument
 function _call_gap_func(func::GapObj, a1)
     fptr = GET_FUNC_PTR(func, 1)
-    ret = @ccall $fptr(
+    ret = @gap_active @ccall $fptr(
         func::GapObj, 
         _JULIA_TO_GAP(a1)::Ptr{Cvoid},
     )::Ptr{Cvoid}
@@ -416,7 +416,7 @@ end
 # 2 arguments
 function _call_gap_func(func::GapObj, a1, a2)
     fptr = GET_FUNC_PTR(func, 2)
-    ret = @ccall $fptr(
+    ret = @gap_active @ccall $fptr(
         func::GapObj,
         _JULIA_TO_GAP(a1)::Ptr{Cvoid},
         _JULIA_TO_GAP(a2)::Ptr{Cvoid},
@@ -427,7 +427,7 @@ end
 # 3 arguments
 function _call_gap_func(func::GapObj, a1, a2, a3)
     fptr = GET_FUNC_PTR(func, 3)
-    ret = @ccall $fptr(
+    ret = @gap_active @ccall $fptr(
         func::GapObj,
         _JULIA_TO_GAP(a1)::Ptr{Cvoid},
         _JULIA_TO_GAP(a2)::Ptr{Cvoid},
@@ -439,7 +439,7 @@ end
 # 4 arguments
 function _call_gap_func(func::GapObj, a1, a2, a3, a4)
     fptr = GET_FUNC_PTR(func, 4)
-    ret = @ccall $fptr(
+    ret = @gap_active @ccall $fptr(
         func::GapObj,
         _JULIA_TO_GAP(a1)::Ptr{Cvoid},
         _JULIA_TO_GAP(a2)::Ptr{Cvoid},
@@ -452,7 +452,7 @@ end
 # 5 arguments
 function _call_gap_func(func::GapObj, a1, a2, a3, a4, a5)
     fptr = GET_FUNC_PTR(func, 5)
-    ret = @ccall $fptr(
+    ret = @gap_active @ccall $fptr(
         func::GapObj,
         _JULIA_TO_GAP(a1)::Ptr{Cvoid},
         _JULIA_TO_GAP(a2)::Ptr{Cvoid},
@@ -466,7 +466,7 @@ end
 # 6 arguments
 function _call_gap_func(func::GapObj, a1, a2, a3, a4, a5, a6)
     fptr = GET_FUNC_PTR(func, 6)
-    ret = @ccall $fptr(
+    ret = @gap_active @ccall $fptr(
         func::GapObj,
         _JULIA_TO_GAP(a1)::Ptr{Cvoid},
         _JULIA_TO_GAP(a2)::Ptr{Cvoid},

--- a/src/doctestfilters.jl
+++ b/src/doctestfilters.jl
@@ -21,6 +21,7 @@ GAP_docs_pages = [
         "conversion.md",
         "packages.md",
         "other.md",
+        "signals.md",
         "examples.md",
         "internal.md",
         "manualindex.md",

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -302,6 +302,21 @@ function take_or_capture_gap_error_snapshot()
     return snapshot
 end
 
+# GAP reports Ctrl-C as an ordinary error with this message (ExecIntrStat in
+# GAP's src/stats.c). An InterruptException raised in Julia code called from
+# GAP also comes back as a GAP error, carrying the exception's printed form.
+const GAP_USER_INTERRUPT_MESSAGE = "user interrupt"
+
+is_user_interrupt(err::GAPError) =
+    err.message == GAP_USER_INTERRUPT_MESSAGE || occursin("InterruptException", err.message)
+
+# Surface a GAP error in Julia; Ctrl-C becomes the exception generic Julia
+# code expects for it
+function throw_gap_error(err::GAPError)
+    is_user_interrupt(err) && throw(InterruptException())
+    throw(err)
+end
+
 function ThrowObserver(depth::Cint)
     is_error_handler_disabled() && return nothing
 
@@ -312,6 +327,10 @@ function ThrowObserver(depth::Cint)
     # Only the outermost observer turns the GAP failure into a Julia exception.
     if depth <= 0
         snapshot = take_or_capture_gap_error_snapshot()
-        throw(snapshot)
+        # The exception lands in Julia code, where GAP counts as inactive for
+        # the interrupt bridge; if that code was called from GAP, returning
+        # to GAP restores the previous value.
+        _set_gap_depth(Cint(0))
+        throw_gap_error(snapshot)
     end
 end

--- a/src/prompt.jl
+++ b/src/prompt.jl
@@ -20,14 +20,9 @@ This GAP prompt allows to quickly switch between writing Julia and GAP code in
 a session where all data is shared.
 """
 function prompt()
-    # save the current SIGINT handler
-    # (we pass NULL as signal handler; strictly speaking, we should be passing `SIG_DFL`
-    # but it's not clearly how to access this from here, and anyway on the list
-    # of platforms we support, it is NULL)
-    old_sigint = @ccall signal(Base.SIGINT::Cint, C_NULL::Ptr{Cvoid})::Ptr{Cvoid} 
-
-    # install GAP's SIGINT handler
-    @ccall libgap.SyInstallAnswerIntr()::Cvoid
+    # Ctrl-C reaches GAP through the interrupt bridge (see signals.jl) and,
+    # with the break loop enabled below, behaves as in a standalone GAP
+    # session.
 
     # restore GAP's error output
     set_error_handler_disabled(true)
@@ -45,9 +40,6 @@ function prompt()
     finally
         # disable break loop
         Globals.BreakOnError = false
-
-        # restore signal handler
-        @ccall signal(Base.SIGINT::Cint, old_sigint::Ptr{Cvoid})::Ptr{Cvoid}
 
         # Leaving the GAP prompt returns control to ordinary Julia code, so turn
         # GAP.jl's custom error capture back on for subsequent Julia -> GAP calls.

--- a/src/prompt.jl
+++ b/src/prompt.jl
@@ -36,19 +36,24 @@ function prompt()
     # enable break loop
     Globals.BreakOnError = true
 
-    # start GAP repl
-    Globals.SESSION()
+    # GAP's REPL takes over the terminal (raw mode, SIGTSTP/SIGWINCH handlers);
+    # hand it back to Julia afterwards, even if SESSION exits abnormally.
+    try
+        _with_saved_signal_state(_SIGNALS_OWNED_BY_JULIA) do
+            Globals.SESSION()
+        end
+    finally
+        # disable break loop
+        Globals.BreakOnError = false
 
-    # disable break loop
-    Globals.BreakOnError = false
+        # restore signal handler
+        @ccall signal(Base.SIGINT::Cint, old_sigint::Ptr{Cvoid})::Ptr{Cvoid}
 
-    # restore signal handler
-    @ccall signal(Base.SIGINT::Cint, old_sigint::Ptr{Cvoid})::Ptr{Cvoid}
-
-    # Leaving the GAP prompt returns control to ordinary Julia code, so turn
-    # GAP.jl's custom error capture back on for subsequent Julia -> GAP calls.
-    set_error_handler_disabled(false)
-    replace_global!(:ERROR_OUTPUT, Globals._JULIAINTERFACE_ERROR_OUTPUT)
+        # Leaving the GAP prompt returns control to ordinary Julia code, so turn
+        # GAP.jl's custom error capture back on for subsequent Julia -> GAP calls.
+        set_error_handler_disabled(false)
+        replace_global!(:ERROR_OUTPUT, Globals._JULIAINTERFACE_ERROR_OUTPUT)
+    end
 end
 
 # helper function for `gap.sh` scripts created by create_gap_sh()

--- a/src/signals.jl
+++ b/src/signals.jl
@@ -203,6 +203,64 @@ function _with_saved_signal_state(f, signals)
     end
 end
 
+#############################################################################
+##
+## Interrupt bridge (Ctrl-C)
+##
+## JuliaInterface installs a SIGINT handler that chains onto Julia's and
+## consults the counter `gap_interrupt_depth`: if GAP code is executing, it
+## interrupts GAP (which raises a "user interrupt" error, converted into a
+## Julia InterruptException by throw_gap_error); otherwise Julia handles the
+## signal as usual. The counter lives in JuliaInterface.so; every entry from
+## Julia into GAP is wrapped in `@gap_active`, and GAP resets the counter to
+## zero while it calls back into Julia.
+
+const _gap_depth_ptr = Ref{Ptr{Cint}}(C_NULL)
+
+@inline function _adjust_gap_depth(delta::Cint)
+    p = _gap_depth_ptr[]
+    p == C_NULL && return nothing
+    unsafe_store!(p, unsafe_load(p) + delta)
+    return nothing
+end
+
+@inline function _set_gap_depth(value::Cint)
+    p = _gap_depth_ptr[]
+    p == C_NULL && return nothing
+    unsafe_store!(p, value)
+    return nothing
+end
+
+# Evaluate `expr` with GAP marked as active for the interrupt bridge.
+#
+# Deliberately no try/finally: GAP may longjmp across this frame (a GAP
+# error inside a nested Julia -> GAP -> Julia -> GAP call unwinds to GAP's
+# own catch), which would skip popping a Julia exception handler and corrupt
+# the handler chain. The counter stays consistent without it: GAP errors
+# arise while GAP is active, so landing in a GAP catch needs no adjustment,
+# and ThrowObserver resets the counter before throwing into Julia.
+macro gap_active(expr)
+    quote
+        _adjust_gap_depth(Cint(1))
+        local result = $(esc(expr))
+        _adjust_gap_depth(Cint(-1))
+        result
+    end
+end
+
+# Called during initialization once JuliaInterface.so is loaded. In
+# standalone mode (gap.sh) GAP installs its own SIGINT handler instead.
+function _install_interrupt_bridge(standalone::Bool)
+    _gap_depth_ptr[] = cglobal((:gap_interrupt_depth, JuliaInterface_path), Cint)
+    standalone && return nothing
+    # readline's state word lets the handler tell "GAP waits for input at a
+    # prompt" (Ctrl-C is dropped, as in standalone GAP) from "GAP computes"
+    readline_state = Libdl.dlsym(Libdl.dlopen(libgap), :rl_readline_state; throw_error = false)
+    @ccall JuliaInterface_path.JuliaInterface_InstallSigintHandler(
+        something(readline_state, C_NULL)::Ptr{Cvoid})::Cvoid
+    return nothing
+end
+
 # Signals whose handlers GAP or autoloaded packages install at startup even
 # though Julia owns them in an embedded session: SIGCHLD (GAP kernel,
 # iostream.c; io package), SIGTSTP (ncurses, via Browse), SIGWINCH (GAP kernel,

--- a/src/signals.jl
+++ b/src/signals.jl
@@ -1,0 +1,211 @@
+#############################################################################
+##
+##  This file is part of GAP.jl, a bidirectional interface between Julia and
+##  the GAP computer algebra system.
+##
+##  Copyright of GAP.jl and its parts belongs to its developers.
+##  Please refer to its README.md file for details.
+##
+##  SPDX-License-Identifier: LGPL-3.0-or-later
+##
+
+# Signal state inspection and save/restore helpers.
+#
+# Julia, the GAP kernel, and GAP packages (io, Browse/ncurses) all install
+# process-wide signal handlers; see docs/src/signals.md for the ownership
+# contract. The helpers here make the actual state visible (`signal_report`)
+# and let GAP.jl restore Julia's state after code that ignores the contract.
+
+# Signal numbers differ between Linux and the BSD family (macOS).
+# GAP.jl does not support Windows.
+const _SIGNAL_NUMBERS = Sys.islinux() ?
+    Dict(:HUP => 1, :INT => 2, :QUIT => 3, :ILL => 4, :TRAP => 5, :ABRT => 6,
+         :BUS => 7, :FPE => 8, :KILL => 9, :USR1 => 10, :SEGV => 11,
+         :USR2 => 12, :PIPE => 13, :ALRM => 14, :TERM => 15, :CHLD => 17,
+         :CONT => 18, :STOP => 19, :TSTP => 20, :TTIN => 21, :TTOU => 22,
+         :WINCH => 28) :
+    Dict(:HUP => 1, :INT => 2, :QUIT => 3, :ILL => 4, :TRAP => 5, :ABRT => 6,
+         :FPE => 8, :KILL => 9, :BUS => 10, :SEGV => 11, :SYS => 12,
+         :PIPE => 13, :ALRM => 14, :TERM => 15, :STOP => 17, :TSTP => 18,
+         :CONT => 19, :CHLD => 20, :TTIN => 21, :TTOU => 22, :WINCH => 28,
+         :INFO => 29, :USR1 => 30, :USR2 => 31)
+
+_signum(name::Symbol) = _SIGNAL_NUMBERS[name]
+
+# Signals worth reporting, in numeric order; SIGKILL and SIGSTOP cannot be
+# caught and sigaction refuses to even query them on macOS
+const _REPORTED_SIGNALS = sort!(filter(!in((:KILL, :STOP)), collect(keys(_SIGNAL_NUMBERS))); by = _signum)
+
+# Opaque buffers for `struct sigaction`, `sigset_t` and `struct termios`;
+# generously sized so they fit every supported libc.
+const _SIGACTION_BUFSIZE = 256
+const _SIGSET_BUFSIZE = 256
+const _TERMIOS_BUFSIZE = 256
+
+# Values of the `sa_handler` field, and its position (first field on all
+# supported platforms)
+const _SIG_DFL = Ptr{Cvoid}(0)
+const _SIG_IGN = Ptr{Cvoid}(1)
+
+"""
+    SignalInfo
+
+Disposition of one signal in the current process, as returned by
+[`signal_report`](@ref).
+
+Fields: `signal` (number), `name` (e.g. `"SIGCHLD"`), `disposition`
+(`:default`, `:ignore` or `:handler`), `handler` (function pointer),
+`symbol` and `library` (the handler's name and shared library, resolved via
+`dladdr`, or `nothing`), `owner` (`:julia`, `:gap`, `:io`, `:ncurses`,
+`:JuliaInterface`, `:none`, or the library name), and `blocked` (whether the
+signal is blocked in the calling thread's mask).
+"""
+struct SignalInfo
+    signal::Int
+    name::String
+    disposition::Symbol
+    handler::Ptr{Cvoid}
+    symbol::Union{Nothing,String}
+    library::Union{Nothing,String}
+    owner::Symbol
+    blocked::Bool
+end
+
+function _save_sigaction(sig::Integer)
+    buf = zeros(UInt8, _SIGACTION_BUFSIZE)
+    rc = @ccall sigaction(sig::Cint, C_NULL::Ptr{Cvoid}, buf::Ptr{UInt8})::Cint
+    rc == 0 || Base.systemerror("sigaction")
+    return buf
+end
+
+function _restore_sigaction(sig::Integer, buf::Vector{UInt8})
+    rc = @ccall sigaction(sig::Cint, buf::Ptr{UInt8}, C_NULL::Ptr{Cvoid})::Cint
+    rc == 0 || Base.systemerror("sigaction")
+    return nothing
+end
+
+_sigaction_handler(buf::Vector{UInt8}) = Ptr{Cvoid}(reinterpret(UInt, buf[1:sizeof(UInt)])[1])
+
+# Resolve a code address to (symbol, library basename) via dladdr
+function _symbolize(addr::Ptr{Cvoid})
+    # Dl_info: { const char *dli_fname; void *dli_fbase; const char *dli_sname; void *dli_saddr }
+    info = zeros(UInt8, 4 * sizeof(Ptr{Cvoid}))
+    rc = @ccall dladdr(addr::Ptr{Cvoid}, info::Ptr{UInt8})::Cint
+    rc == 0 && return (nothing, nothing)
+    ptrs = reinterpret(Ptr{UInt8}, info)
+    fname = ptrs[1] == C_NULL ? nothing : basename(unsafe_string(ptrs[1]))
+    sname = ptrs[3] == C_NULL ? nothing : unsafe_string(ptrs[3])
+    return (sname, fname)
+end
+
+function _signal_owner(library::Union{Nothing,String})
+    library === nothing && return :unknown
+    occursin("JuliaInterface", library) && return :JuliaInterface
+    occursin("julia", library) && return :julia
+    startswith(library, "libgap") && return :gap
+    occursin("ncurses", library) && return :ncurses
+    (library == "io.so" || startswith(library, "io.")) && return :io
+    return Symbol(library)
+end
+
+function _blocked_signals()
+    set = zeros(UInt8, _SIGSET_BUFSIZE)
+    # `how` is irrelevant when the new set is NULL: this only queries the mask
+    rc = @ccall pthread_sigmask(0::Cint, C_NULL::Ptr{Cvoid}, set::Ptr{UInt8})::Cint
+    rc == 0 || Base.systemerror("pthread_sigmask")
+    return set
+end
+
+_is_blocked(set::Vector{UInt8}, sig::Integer) =
+    (@ccall sigismember(set::Ptr{UInt8}, sig::Cint)::Cint) == 1
+
+function _signal_info(name::Symbol, blocked_set::Vector{UInt8})
+    sig = _signum(name)
+    handler = _sigaction_handler(_save_sigaction(sig))
+    if handler == _SIG_DFL
+        disposition, symbol, library, owner = :default, nothing, nothing, :none
+    elseif handler == _SIG_IGN
+        disposition, symbol, library, owner = :ignore, nothing, nothing, :none
+    else
+        symbol, library = _symbolize(handler)
+        disposition, owner = :handler, _signal_owner(library)
+    end
+    return SignalInfo(sig, "SIG" * String(name), disposition, handler,
+                      symbol, library, owner, _is_blocked(blocked_set, sig))
+end
+
+"""
+    signal_report(io::IO = stdout; all::Bool = false)
+
+Print a table of the process-wide signal dispositions, attributing each
+installed handler to the shared library that owns it, and return the
+underlying `Vector{SignalInfo}`.
+
+By default only signals that are caught, ignored, or blocked are shown;
+`all = true` shows every known signal. This is the first tool to reach for
+when Ctrl-C, subprocesses, or the terminal misbehave in a session using
+GAP.jl; see the manual section on signal handling for the expected state.
+"""
+function signal_report(io::IO = stdout; all::Bool = false)
+    blocked_set = _blocked_signals()
+    infos = [_signal_info(name, blocked_set) for name in _REPORTED_SIGNALS]
+    for info in infos
+        all || info.disposition != :default || info.blocked || continue
+        print(io, rpad(info.name, 10), rpad(String(info.disposition), 9))
+        if info.disposition == :handler
+            print(io, something(info.symbol, "?"), " [", something(info.library, "?"), "]")
+        end
+        info.blocked && print(io, "  blocked")
+        println(io)
+    end
+    return infos
+end
+
+# Terminal attributes of stdin, or `nothing` if stdin is not a terminal
+function _save_termios()
+    (@ccall isatty(0::Cint)::Cint) == 1 || return nothing
+    buf = zeros(UInt8, _TERMIOS_BUFSIZE)
+    rc = @ccall tcgetattr(0::Cint, buf::Ptr{UInt8})::Cint
+    return rc == 0 ? buf : nothing
+end
+
+function _restore_termios(buf::Union{Nothing,Vector{UInt8}})
+    buf === nothing && return nothing
+    TCSANOW = 0
+    @ccall tcsetattr(0::Cint, TCSANOW::Cint, buf::Ptr{UInt8})::Cint
+    return nothing
+end
+
+# Snapshot of the dispositions of `signals` plus the terminal attributes, to
+# be reinstated with `_restore_signal_state` after running code that installs
+# its own handlers (GAP's kernel, io, ncurses)
+function _save_signal_state(signals)
+    actions = [(_signum(name), _save_sigaction(_signum(name))) for name in signals]
+    return (; actions, termios = _save_termios())
+end
+
+_restore_signal_state(::Nothing) = nothing
+
+function _restore_signal_state(state)
+    for (sig, buf) in state.actions
+        _restore_sigaction(sig, buf)
+    end
+    _restore_termios(state.termios)
+    return nothing
+end
+
+function _with_saved_signal_state(f, signals)
+    state = _save_signal_state(signals)
+    try
+        return f()
+    finally
+        _restore_signal_state(state)
+    end
+end
+
+# Signals whose handlers GAP or autoloaded packages install at startup even
+# though Julia owns them in an embedded session: SIGCHLD (GAP kernel,
+# iostream.c; io package), SIGTSTP (ncurses, via Browse), SIGWINCH (GAP kernel,
+# sysfiles.c). Restoring them keeps Julia's subprocess and terminal handling
+# intact; see docs/src/signals.md.
+const _SIGNALS_OWNED_BY_JULIA = (:CHLD, :TSTP, :WINCH)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ using GAP
 include("Aqua.jl")
 
 include("basics.jl")
+include("signals.jl")
 include("errors.jl")
 include("adapter.jl")
 include("convenience.jl")

--- a/test/signals.jl
+++ b/test/signals.jl
@@ -1,0 +1,66 @@
+#############################################################################
+##
+##  This file is part of GAP.jl, a bidirectional interface between Julia and
+##  the GAP computer algebra system.
+##
+##  Copyright of GAP.jl and its parts belongs to its developers.
+##  Please refer to its README.md file for details.
+##
+##  SPDX-License-Identifier: LGPL-3.0-or-later
+##
+
+# These tests pin the signal ownership contract described in
+# docs/src/signals.md. They run early, before any test exercises GAP
+# packages that install handlers of their own.
+
+@testset "signal ownership contract" begin
+    infos = GAP.signal_report(devnull)
+    @test infos isa Vector{GAP.SignalInfo}
+    @test GAP.signal_report(devnull; all = true) isa Vector{GAP.SignalInfo}
+
+    owner(name) = infos[findfirst(info -> info.name == name, infos)].owner
+
+    # Julia's GC safepoints and error reporting depend on its fault handlers
+    for name in ("SIGSEGV", "SIGBUS", "SIGILL", "SIGFPE")
+        @test owner(name) == :julia
+    end
+
+    # Ctrl-C is delivered by Julia; GAP.jl only chains onto it
+    @test owner("SIGINT") in (:julia, :JuliaInterface)
+
+    # SIGCHLD belongs to libuv; neither GAP's `ChildStatusChanged` nor io's
+    # handler may remain installed after startup
+    @test owner("SIGCHLD") ∉ (:gap, :io)
+
+    # The terminal belongs to the Julia REPL while no GAP prompt is active
+    @test owner("SIGTSTP") ∉ (:gap, :ncurses)
+    @test owner("SIGWINCH") ∉ (:gap, :ncurses)
+end
+
+@testset "Julia subprocesses survive GAP initialization" begin
+    # A hang here means GAP or a package reaped Julia's child or replaced
+    # libuv's SIGCHLD handler; the watchdog turns that into a failure.
+    task = @async success(`true`)
+    @test timedwait(() -> istaskdone(task), 60.0) == :ok
+    @test istaskdone(task) && fetch(task)
+end
+
+# The io package still reaps with waitpid(-1) and installs its own SIGCHLD
+# handler whenever its process functions run, which breaks Julia's
+# subprocess handling afterwards. Verified in a subprocess so that the hang
+# cannot poison this test process; opt-in because a broken run costs the
+# whole timeout. Expected to pass once io >= 4.10.1 ships in GAP_pkg_io_jll.
+if get(ENV, "GAPJL_TEST_SIGNALS_IO", "") == "1"
+  @testset "Julia subprocesses after io package usage" begin
+    script = """
+        using GAP
+        GAP.evalstr("LoadPackage(\\"IO\\");; pid := IO_fork();; if pid = 0 then IO_exit(0); fi; IO_WaitPid(pid, true);;")
+        run(`true`)
+    """
+    cmd = `$(Base.julia_cmd()) --project=$(Base.active_project()) -e $script`
+    proc = run(pipeline(cmd; stdout = devnull, stderr = devnull); wait = false)
+    finished = timedwait(() -> process_exited(proc), 120.0) == :ok
+    finished || kill(proc, Base.SIGKILL)
+    @test_broken finished && success(proc)
+  end
+end

--- a/test/signals.jl
+++ b/test/signals.jl
@@ -25,8 +25,8 @@
         @test owner(name) == :julia
     end
 
-    # Ctrl-C is delivered by Julia; GAP.jl only chains onto it
-    @test owner("SIGINT") in (:julia, :JuliaInterface)
+    # Ctrl-C is delivered by Julia; GAP.jl chains onto Julia's handler
+    @test owner("SIGINT") == :JuliaInterface
 
     # SIGCHLD belongs to libuv; neither GAP's `ChildStatusChanged` nor io's
     # handler may remain installed after startup
@@ -43,6 +43,85 @@ end
     task = @async success(`true`)
     @test timedwait(() -> istaskdone(task), 60.0) == :ok
     @test istaskdone(task) && fetch(task)
+end
+
+@testset "interrupt bridge" begin
+    GAP.evalstr("""
+    gapjl_signals_spin := function()
+        local i;
+        i := 0;
+        while true do i := i + 1; od;
+    end;;
+    """)
+
+    # what the SIGINT handler does while GAP code executes
+    @ccall GAP.libgap.InterruptExecStat()::Cvoid
+    @test_throws InterruptException GAP.Globals.gapjl_signals_spin()
+
+    # the bridge's bookkeeping and GAP itself are intact afterwards
+    @test unsafe_load(GAP._gap_depth_ptr[]) == 0
+    @test GAP.evalstr("1 + 1") == 2
+
+    # nested Julia -> GAP -> Julia -> GAP: the innermost runtime owns Ctrl-C
+    depth_inside_julia = Ref{Cint}(-1)
+    probe = () -> (depth_inside_julia[] = unsafe_load(GAP._gap_depth_ptr[]); nothing)
+    GAP.Globals.CallFuncList(GAP.WrapJuliaFunc(probe), GapObj([]))
+    @test depth_inside_julia[] == 0
+    @test unsafe_load(GAP._gap_depth_ptr[]) == 0
+end
+
+# Run `script` in a fresh Julia process, wait for it to print `marker`, send
+# it SIGINT, and return (exited in time, captured output after the marker)
+function interrupt_subprocess(script::String, marker::String)
+    cmd = `$(Base.julia_cmd()) --project=$(Base.active_project()) -e $script`
+    output = Pipe()
+    proc = run(pipeline(cmd; stdout = output, stderr = devnull); wait = false)
+    close(output.in)
+    # GAP may have emitted a carriage return on stdout before the marker
+    @test strip(readline(output)) == marker
+    # let the process get past the code that printed the marker
+    sleep(1)
+    kill(proc, Base.SIGINT)
+    exited = timedwait(() -> process_exited(proc), 60.0) == :ok
+    exited || kill(proc, Base.SIGKILL)
+    return exited, read(output, String)
+end
+
+@testset "SIGINT during a GAP computation" begin
+    script = """
+        using GAP
+        Base.exit_on_sigint(false)
+        # GAP prints the marker via a Julia callback right before it starts
+        # spinning, so GAP is executing when the signal arrives
+        GAP.Globals.gapjl_ready = GAP.WrapJuliaFunc(() -> (println("GAP_RUNNING"); flush(stdout); nothing))
+        try
+            GAP.evalstr("gapjl_ready(); while true do od;")
+        catch err
+            println("caught ", typeof(err))
+            exit(err isa InterruptException ? 0 : 1)
+        end
+        exit(2)
+    """
+    exited, output = interrupt_subprocess(script, "GAP_RUNNING")
+    @test exited
+    @test occursin("caught InterruptException", output)
+end
+
+@testset "SIGINT during Julia code still reaches Julia" begin
+    script = """
+        using GAP
+        Base.exit_on_sigint(false)
+        println("JULIA_RUNNING"); flush(stdout)
+        try
+            while true; sleep(0.05); end
+        catch err
+            println("caught ", typeof(err))
+            exit(err isa InterruptException ? 0 : 1)
+        end
+    """
+    exited, output = interrupt_subprocess(script, "JULIA_RUNNING")
+    @test exited
+    @test occursin("caught InterruptException", output)
 end
 
 # The io package still reaps with waitpid(-1) and installs its own SIGCHLD


### PR DESCRIPTION
GAP, Julia/libuv, and GAP packages (io, Browse/ncurses) each assume they own the process-wide signal state, child reaping, and the terminal. This PR sets an ownership contract for embedded GAP and implements the parts that work with released GAP and io. The contract and the facts about Julia it rests on are in the new manual page `docs/src/signals.md`.

### Startup and `GAP.prompt()`

GAP installs `SIGCHLD` and `SIGWINCH` handlers regardless of the `handleSignals` argument of `GAP_Initialize`, and autoloading Browse makes ncurses install a `SIGTSTP` handler. In an embedded session these belong to Julia (a foreign `SIGCHLD` handler breaks libuv's child handling on Linux; the terminal handlers garble the REPL, #741). `initialize` now saves and restores these dispositions and the terminal attributes (written back only if they changed, since `tcsetattr` from a background job raises `SIGTTOU`); `prompt()` hands the terminal and the error-handling state back in a `finally` block.

### Ctrl-C (#74, gap-system/gap#3256)

Julia's listener thread re-dispatches every `SIGINT` through the process disposition before deciding whether to raise an `InterruptException`. JuliaInterface installs a chaining `SIGINT` handler that uses this: while GAP code executes (tracked by a counter maintained around every entry into GAP and reset while GAP calls back into Julia) it calls GAP's `InterruptExecStat`, otherwise it forwards to Julia's handler. GAP's resulting `user interrupt` error surfaces as a Julia `InterruptException`.

- GAP acts at its next statement. If a call ends before that, e.g. a single kernel function, the interrupt is disarmed and the `InterruptException` is thrown when the call returns, instead of firing in a later, unrelated call.
- In `GAP.prompt()` Ctrl-C enters the break loop; at an idle prompt it is ignored, as in standalone GAP.
- `SyInstallAnswerIntr` is no longer used, so a double Ctrl-C can no longer terminate the Julia process from inside a signal handler.

No signal mask manipulation is involved. A trivial GAP call costs 6.9 ns, against 6.8 ns on master.

### Diagnostics and tests

`GAP.signal_report()` prints the current dispositions with the owning library of every handler. `test/signals.jl` pins the contract, checks that Julia subprocesses still work after GAP startup, and tests the interrupt bridge in-process and via `SIGINT` sent to subprocesses; `etc/julia.expect` gains the prompt scenarios.

### Not in this PR

io up to 4.10.0 reaps with `waitpid(-1)` from its own `SIGCHLD` handler, which hangs Julia's subprocess handling afterwards (#902) and made the `utils`/`curlInterface` distro tests hang (both excluded on master). Fixed by gap-packages/io#137 and gap-packages/io#138; once io 4.10.1 ships in `GAP_pkg_io_jll`, a follow-up can re-enable those tests and the Julia `ExecuteProcess`. Kernel-side wishes and the Browse ncurses initialization are listed under "Known problems" in the manual page.

Open question beyond this PR: if Singular.jl, Polymake.jl etc. copy the chaining handler, the chain depends on load order and on nobody replacing a link. A single dispatcher with registered runtimes would avoid that; GAP.jl's handler could become it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Disclaimer: I have not yet proof-read most of this myself, so it might be full of slop. But I wanted it here so that CI can run, so that others can see it, and so that I don't forget about it (at least not permanently 😂).

---

CC @ChrisJefferson
