### PR TITLE
Speed up converting GAP integers to Nemo

### DIFF
--- a/ext/NemoExt/gap_to_nemo.jl
+++ b/ext/NemoExt/gap_to_nemo.jl
@@ -17,13 +17,11 @@
 ## GAP integer to `ZZRingElem`
 ##
 function ZZRingElem(obj::GapObj)
-  GAP.GAP_IS_INT(obj) || throw(GAP.ConversionError(obj, ZZRingElem))
-  result = GC.@preserve obj ZZRingElem(GAP.ADDR_OBJ(obj), div(GAP.SIZE_OBJ(obj), sizeof(Int)))
-  if obj < 0 
-    return Nemo.neg!(result)
-  else
-    return result
-  end
+  addr, tnum, bagsize = GAP.ADDR_TNUM_SIZE_OBJ(obj)
+  tnum <= GAP.T_INTNEG || throw(GAP.ConversionError(obj, ZZRingElem))
+  result = GC.@preserve obj ZZRingElem(addr, div(bagsize, sizeof(Int)))
+  # the type number already carries the sign, no need to ask GAP for it
+  return tnum == GAP.T_INTNEG ? Nemo.neg!(result) : result
 end
 
 GAP.gap_to_julia_internal(::Type{ZZRingElem}, obj::GapInt, ::GAP.JuliaCacheDict, ::Val{recursive}) where recursive = ZZRingElem(obj)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -55,10 +55,10 @@ end
     for x in [GAP.evalstr("(1,2)"), GAP.evalstr("(1,2)(3,70000)"),
               GAP.evalstr("[1,2,3]"), GAP.evalstr("rec(a := 1)"),
               GAP.evalstr("SymmetricGroup(3)"), GAP.Globals.Print]
-        addr, tnum, size = GAP.ADDR_TNUM_SIZE_OBJ(x)
+        addr, tnum, bagsize = GAP.ADDR_TNUM_SIZE_OBJ(x)
         @test addr == GAP.ADDR_OBJ(x)
         @test tnum == GAP.TNUM_OBJ(x)
-        @test size == GAP.SIZE_OBJ(x)
+        @test bagsize == GAP.SIZE_OBJ(x)
     end
 end
 


### PR DESCRIPTION
`GAP_IS_INT`, `ADDR_OBJ` and `SIZE_OBJ` each chase the master pointer of the bag on their own, and the sign was determined by a comparison carried out in the GAP kernel. Read the bag header once instead, and take the sign from the type number.

The gain shrinks as the number of limbs grows, since the limb copy then dominates.

Before:

    julia> using Chairmarks

    julia> convert_many(x, n) = ZZRingElem[ ZZRingElem(x) for _ in 1:n ];

    julia> x = GAP.evalstr("2^200"); @b convert_many($x, 100000)
    5.505 ms (100003 allocs: 2.292 MiB)

    julia> x = GAP.evalstr("-2^200"); @b convert_many($x, 100000)
    6.495 ms (100003 allocs: 2.292 MiB)

    julia> x = GAP.evalstr("2^20000"); @b convert_many($x, 5000)
    878.500 μs (10003 allocs: 12.254 MiB)

    julia> x = GAP.evalstr("-2^20000"); @b convert_many($x, 5000)
    949.250 μs (10003 allocs: 12.254 MiB)

After:

    julia> using Chairmarks

    julia> convert_many(x, n) = ZZRingElem[ ZZRingElem(x) for _ in 1:n ];

    julia> x = GAP.evalstr("2^200"); @b convert_many($x, 100000)
    4.022 ms (100003 allocs: 2.292 MiB)

    julia> x = GAP.evalstr("-2^200"); @b convert_many($x, 100000)
    4.949 ms (100003 allocs: 2.292 MiB)

    julia> x = GAP.evalstr("2^20000"); @b convert_many($x, 5000)
    824.500 μs (10003 allocs: 12.254 MiB)

    julia> x = GAP.evalstr("-2^20000"); @b convert_many($x, 5000)
    909.125 μs (10003 allocs: 12.254 MiB)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>