### PR TITLE
Fix closure boxes and test for them in CI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Speed up `collect` and list comprehensions for GAP lists
 - Avoid boxing immediate integers in wrapped GAP calls (reduces
   allocations and improves performance)
+- Avoid `Core.Box` allocations in closures
 
 ## Version 0.17.5 (released 2026-08-24)
 

--- a/src/exec.jl
+++ b/src/exec.jl
@@ -18,32 +18,24 @@ function GAP_ExecuteProcess(dir::GapObj, prg::GapObj, in::GapInt, out::GapInt, a
     return GAP_ExecuteProcess(String(dir), String(prg), Int(in), Int(out), Vector{String}(args))
 end
 
+# Map a GAP stream id to something `run` accepts as `stdin` / `stdout`.
+# Negative ids mean "no stream".
+function gap_stream_to_julia(id::Int, name::String)
+    id < 0 && return Base.devnull
+    fd = @ccall libgap.SyBufFileno(id::Culong)::Int
+    fd == -1 && error("$name invalid")
+    return RawFD(fd)
+end
+
 function GAP_ExecuteProcess(dir::String, prg::String, fin::Int, fout::Int, args::Vector{String})
     # Note: the GAP kernel function `ExecuteProcess` also handles so-called
     # "window mode", for use in xgap and Gap.app -- we do not emulate this here.
-    if fin < 0
-        fin = Base.devnull
-    else
-        fin = @ccall libgap.SyBufFileno(fin::Culong)::Int
-        if fin == -1
-            error("fin invalid")
-        end
-        fin = RawFD(fin)
-    end
-
-    if fout < 0
-        fout = Base.devnull
-    else
-        fout = @ccall libgap.SyBufFileno(fout::Culong)::Int
-        if fout == -1
-            error("fout invalid")
-        end
-        fout = RawFD(fout)
-    end
+    instream = gap_stream_to_julia(fin, "fin")
+    outstream = gap_stream_to_julia(fout, "fout")
 
     # TODO: verify `dir` is a valid dir?
     cd(dir) do
-        res = run(pipeline(ignorestatus(`$prg $args`), stdin=fin, stdout=fout))
+        res = run(pipeline(ignorestatus(`$prg $args`), stdin=instream, stdout=outstream))
         return res.exitcode == 255 ? GAP.Globals.Fail : res.exitcode
     end
 end

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -225,43 +225,37 @@ function gap_to_julia_internal(
     end
 
     len = length(parameters)
+    last_param = parameters[len]
+    # A last entry `Vararg{S}` or `Vararg{S,N}` means that the trailing
+    # entries of `obj` shall get converted to `S`.
+    is_vararg = last_param isa Core.TypeofVararg
 
-    if parameters[len] isa Core.TypeofVararg
-      # The last entry is `Vararg{S}` or `Vararg{S,N}` for some type `S`,
-      # meaning that the last entries of `obj` shall get converted to `S`.
-      S = parameters[len].T
-      if isdefined(parameters[len], :N)
-        length(obj) == len-1+parameters[len].N ||
-          throw(ArgumentError("length of $obj does not match type $TT"))
-      else
-        length(obj) >= len-1 ||
-          throw(ArgumentError("length of $obj does not match type $TT"))
-      end
+    if !is_vararg
+      length(obj) == len ||
+        throw(ArgumentError("length of $obj does not match type $TT"))
+    elseif isdefined(last_param, :N)
+      length(obj) == len-1+last_param.N ||
+        throw(ArgumentError("length of $obj does not match type $TT"))
+    else
+      length(obj) >= len-1 ||
+        throw(ArgumentError("length of $obj does not match type $TT"))
+    end
 
-      recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
+    recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
 
-      # Switch off recursion if none of the entry types needs recursion.
-      rec = recursive && (_needs_tracking_gap_to_julia(S) || any(X ->_needs_tracking_gap_to_julia(X), parameters[1:(len-1)]))
-      rec_dict = recursion_info_j(TT, obj, rec, recursion_dict)
+    # Switch off recursion if none of the entry types needs recursion.
+    entry_types = is_vararg ? Any[parameters[1:(len-1)]..., last_param.T] : Any[parameters...]
+    rec = recursive && any(_needs_tracking_gap_to_julia, entry_types)
+    rec_dict = recursion_info_j(TT, obj, rec, recursion_dict)
 
+    if is_vararg
+      S = last_param.T
       list = [
         gap_to_julia_internal(parameters[i], obj[i], rec_dict, BoolVal(rec))
         for i = 1:(len-1)
       ]
       append!(list, [gap_to_julia_internal(S, obj[i], rec_dict, BoolVal(rec)) for i in len:length(obj)])
-
     else
-      # The parameters correspond to the entries of `obj`.
-      length(obj) == len ||
-        throw(ArgumentError("length of $obj does not match type $TT"))
-
-      recursive && recursion_dict !== nothing && haskey(recursion_dict, (obj, TT)) && return recursion_dict[(obj, TT)]
-
-      # Switch off recursion if none of the entry types needs recursion.
-      rec = recursive && any(X ->_needs_tracking_gap_to_julia(X), parameters[1:len])
-
-      rec_dict = recursion_info_j(TT, obj, rec, recursion_dict)
-
       list = [
         gap_to_julia_internal(parameters[i], obj[i], rec_dict, BoolVal(rec))
         for i = 1:len

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -168,7 +168,7 @@ macro gapwrap(ex)
     symdict = IdDict{Symbol,Symbol}()
     body = MacroTools.postwalk(body) do x
         MacroTools.@capture(x, GAP.Globals.sym_) || return x
-        new_sym = get!(() -> gensym(sym), symdict, sym)
+        new_sym = get!(symdict, sym, gensym(sym))
         return Expr(:ref, new_sym)
     end
 

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -498,26 +498,26 @@ function test(name::String)
     end
   end
 
-  error_occurred = false
-  called_QuitGap = false
+  # `Ref`s so that the closures below can update them without boxing
+  error_occurred = Ref(false)
+  called_QuitGap = Ref(false)
   function fake_QuitGap(code)
-    called_QuitGap && return # only do something on the first call
-    called_QuitGap = true
+    called_QuitGap[] && return # only do something on the first call
+    called_QuitGap[] = true
     if (code isa Bool && !code) || (code isa Int && code % 256 != 0)
-      error_occurred = true
+      error_occurred[] = true
     end
     return
   end
 
   set_error_handler_disabled(true)
-  result = false
-  try
+  result = try
     with_gap_var(:ERROR_OUTPUT, Globals._JULIAINTERFACE_ORIGINAL_ERROR_OUTPUT) do
       with_gap_var(:QuitGap, fake_QuitGap) do
         with_gap_var(:QUIT_GAP, fake_QuitGap) do
           with_gap_var(:ForceQuitGap, fake_QuitGap) do
             with_gap_var(:FORCE_QUIT_GAP, fake_QuitGap) do
-              result = Globals.TestPackage(GapObj(name))
+              Globals.TestPackage(GapObj(name))
             end
           end
         end
@@ -530,10 +530,10 @@ function test(name::String)
   # Due to the hack above, we run into an error in TestPackage that is usually unreachable.
   # In the case of a `QuitGap` call, we thus don't check for `result == true`.
   if result == Globals.fail
-    called_QuitGap || throw(ArgumentError("GAP's TestPackage failed"))
-    result = true
+    called_QuitGap[] || throw(ArgumentError("GAP's TestPackage failed"))
+    return !error_occurred[]
   end
-  return !error_occurred && result
+  return !error_occurred[] && result
 end
 
 """

--- a/test/ClosureBoxes.jl
+++ b/test/ClosureBoxes.jl
@@ -1,0 +1,13 @@
+# Captured variables that are reassigned force Julia to allocate a `Core.Box`,
+# which defeats type inference. `Test.detect_closure_boxes` exists since
+# Julia 1.14.
+if isdefined(Test, :detect_closure_boxes)
+  @testset "Closure boxes" begin
+    mods = [GAP, Base.get_extension(GAP, :NemoExt)]
+    boxes = Test.detect_closure_boxes(mods...)
+    for (m, vars) in boxes
+      println("Boxed variable(s) ", join(vars, ", "), " in ", m)
+    end
+    @test length(boxes) == 0
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,8 @@ end
 
 using Nemo
 
+include("ClosureBoxes.jl")
+
 include("NemoExt/misc.jl")
 include("NemoExt/gap_to_nemo.jl")
 include("NemoExt/nemo_to_gap.jl")


### PR DESCRIPTION
Julia 1.14 adds `Test.detect_closure_boxes` (JuliaLang/julia#60478), which lists methods whose lowered code allocates `Core.Box`. A box appears when a closure captures a variable that is assigned more than once, and it defeats type inference for that variable.

Running it on GAP and its Nemo extension found four methods:

- `GAP_ExecuteProcess`: `fin`/`fout` were reassigned and then captured by the `cd` closure. A helper now maps a GAP stream id to `devnull` or a `RawFD`.
- Tuple `gap_to_julia_internal`: `rec`/`rec_dict` were assigned in both the vararg and plain branches and captured by comprehensions. They are now computed once above the branch.
- `@gapwrap`: `sym` from `@capture` was captured by the `get!` default closure. Uses the eager `get!(dict, key, default)` form now.
- `Packages.test`: the flags toggled by the fake `QuitGap` are now `Ref`s, and the result is returned through the `do` chain instead of being assigned inside it.

A new test runs the detector on `GAP` and `NemoExt` and requires zero hits. It is skipped on Julia versions without the function, so only the nightly CI jobs cover it until 1.14 is released.

Same approach as Nemocas/AbstractAlgebra.jl#2498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
