### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/.github/workflows/CI-distro.yml
+++ b/.github/workflows/CI-distro.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install pari-gp
-      - name: "Install textlive"  # for gapdoc
+      - name: "Install texlive"  # for gapdoc
         if: matrix.gap-package == 'gapdoc'
         run: |
           sudo apt-get update

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 ## Version 0.17.4 (released 2026-08-11)
 
 - Update the `browse` GAP package from 1.8.22 to 1.8.23
-- Update the `crips` GAP package from 1.4.8 to 1.4.11
+- Update the `crisp` GAP package from 1.4.8 to 1.4.11
 - Update the `irredsol` GAP package from 1.4.4 to 1.4.6
 
 ## Version 0.17.3 (released 2026-08-05)
@@ -110,7 +110,7 @@
   non-recursive conversion.
 - **Breaking:** Do not support the optional `GapCacheDict` argument for
   `GapObj` anymore, because recursive conversion to GAP is handled by
-  `GAP.GapObj_internal` and does not involve cals to `GapObj`.
+  `GAP.GapObj_internal` and does not involve calls to `GapObj`.
   We had always stated in the documentation that users should not enter
   this argument because it gets created automatically in recursive conversions.
 - Add `GAP.@include(filepath)` as a counterpart to julia's `include(filepath)`,
@@ -380,7 +380,7 @@
 
 ## Version 0.9.8 (released 2023-09-11)
 
-- Allow GAP.Obj(x,true) for recursive conversion (#910. #925)
+- Allow GAP.Obj(x,true) for recursive conversion (#910, #925)
 - Improve documentation on special GAP syntax (#922, #929, #932)
 - Work around a potential crash when GAP launches subprocesses (#906)
 - If the environment variable `GAP_BARE_DEPS` is set, then GAP skips loading
@@ -434,7 +434,7 @@
 ## Version 0.9.1 (released 2022-11-23)
 
 - Added a longer example for using GAP.jl, based around the Rubik's cube
-- Fix some type minor stability issues
+- Fix some minor type stability issues
 
 ## Version 0.9.0 (released 2022-11-01)
 
@@ -489,7 +489,7 @@
   so e.g. typing `Julia.GA` followed by a tab key press is completed to
   `Julia.GAP`, and `Julia.GAP.` then suggests the names of all members
   of the `GAP` module
-- Fix a bug where a warning issues when no C/C++ compiler could be found
+- Fix a bug where a warning issued when no C/C++ compiler could be found
   was accidentally turned into an error that prevented loading GAP.jl.
   Note that installing certain GAP packages still requires a C/C++ compiler.
 
@@ -502,7 +502,7 @@
 
 ## Version 0.7.6 (released 2022-02-07)
 
-- Improve how we show the error messaged triggered by a user trying to
+- Improve how we show the error message triggered by a user trying to
   load GAP.jl on native Windows (which isn't supported)
 - Rewrite `@wrap`, `@gapwrap` and `@gapattribute` to be better compatible
   with future Julia versions.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# TODO: ensure JulieInterface is up-to-date
+# TODO: ensure JuliaInterface is up-to-date
 default:
 	@echo "Use 'make doc' or 'make check' or 'make tags'"
 

--- a/README.maintainer.md
+++ b/README.maintainer.md
@@ -9,7 +9,7 @@ Some information for maintainers of the GAP.jl packages
 
 2. Update the version of the Julia and GAP packages by invoking the script
    `etc/update_version.sh` with the new version as argument. Example:
-   `etc/update_version.sh 0.3.0` (by the way, this is shell script which calls
+   `etc/update_version.sh 0.3.0` (by the way, this is a shell script which calls
    `perl` right now; it would make sense to rewrite it as a Julia script to avoid
    the need for perl).
 
@@ -27,7 +27,7 @@ make the release automatically.
 
 ## Using GAP.jl with a different version of GAP than what `GAP_jll` provides
 
-This can be useful for various reasons e.g.,
+This can be useful for various reasons, e.g.
 
 - you need to test GAP.jl with a newer GAP version, perhaps even its master branch,
 - you need to test with a newer Julia version that breaks binary compatibility,
@@ -38,11 +38,11 @@ For this to work, follow these instructions:
 1. Obtain a copy of the GAP sources, probably from a clone of the GAP git repository.
    Let's say this is in directory `GAPROOT`.
 
-2. Compiled GAP inside GAPROOT once (this is to ensure `build/c_oper1.c` and
+2. Compile GAP inside GAPROOT once (this is to ensure `build/c_oper1.c` and
   `build/c_type1.c` are present).
 
 3. Build GAP with the Julia version of your choice by executing the `etc/setup_override_dir.jl`
-   script. It takes as first argument the GAPROOT, and as second argument the places where
+   script. It takes as first argument the GAPROOT, and as second argument the place where
    the result shall be installed.
 
    To give a concrete example you could invoke
@@ -97,7 +97,7 @@ repository fails in a PR.
    to pick up the new version of `GAP_pkg_juliainterface_jll`.
    > ex: <https://github.com/JuliaRegistries/General/pull/134045>
 
-4. Bump the dependence in `GAP.jl` to whatever version number was used in Step 2.
+4. Bump the dependency in `GAP.jl` to whatever version number was used in Step 2.
    In this PR, the `treehash` CI job should succeed.
    > ex: <https://github.com/oscar-system/GAP.jl/pull/1200>
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ GAP: SymmetricGroup( [ 1 .. 3 ] )
 ```
 
 The Julia types `Int64` and `Bool` are automatically converted to GAP
-objects when passed as arguments to GAP functions. Several others basic
+objects when passed as arguments to GAP functions. Several other basic
 types of objects can be converted using the `GapObj` constructor. For
 example, here we convert a `Vector{Int}` to a GAP list:
 ```julia
@@ -89,7 +89,7 @@ to report any issues you may encounter when using it. You can also submit
 feature requests and general help requests via that tracker.
 
 GAP.jl is being maintained by
-- Thomas Breuer <sam@math.rwth-aachen.de>>
+- Thomas Breuer <sam@math.rwth-aachen.de>
 - Lars Göttgens <goettgens@art.rwth-aachen.de>
 - Max Horn <mhorn@rptu.de>
 
@@ -107,10 +107,10 @@ or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 License for more details.
 
 You should have received a copy of the GNU Lesser General Public License
-along with GAP.jl in form of the file `LICENSE`, or see
+along with GAP.jl in the form of the file `LICENSE`, or see
 <https://www.gnu.org/licenses/lgpl.html>.
 
-Copyright (C) 2017-2025 by its authors, which include:
+Copyright (C) 2017-2026 by its authors, which include:
 - Thomas Breuer
 - Sebastian Gutsche
 - Lars Göttgens

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,7 +29,7 @@ function copy_JuliaInterface_manual()
 
   # clear the destination directory first
   rm(dst_dir; recursive=true, force=true)
-  
+
   mkpath(dst_dir)
   for file in readdir(src_dir; sort=false)
     if endswith(file, ".html") || endswith(file, ".css") || endswith(file, ".js")

--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -15,7 +15,7 @@ and corresponding Julia objects. This is typically done by "type coercion",
 also just called "coercion": to convert a Julia object `x` into a GAP object,
 you may write `GapObj(x)`, see [`GapObj`](@ref). Conversely, if `y` is a GAP
 object, then e.g. `Vector{Int}(y)` will attempt to convert it into a
-`Vector{Int}`. This will success if e.g. `y` is a GAP range or a plain list of
+`Vector{Int}`. This will succeed if e.g. `y` is a GAP range or a plain list of
 integers. See also [Constructor Methods for GAP-to-Julia Conversions](@ref).
 
 For interactive use it may also be convenient to use the function

--- a/docs/src/other.md
+++ b/docs/src/other.md
@@ -31,10 +31,10 @@ in order to support special GAP syntax beyond function calls with arguments.
   `GAP.Globals.Cyc(GAP.Obj(1.41421356); bits=20)` in Julia.
 
 - Access list/matrix entries via [`getindex`](@ref) and [`setindex!`](@ref)
-  respectively the corresponding Julia syntax (described there).
+  or the corresponding Julia syntax (described there).
 
 - Access record components via [`getproperty`](@ref) and [`setproperty!`](@ref)
-  respectively the corresponding Julia syntax (described there).
+  or the corresponding Julia syntax (described there).
 
 - Check for bound record components via [`hasproperty`](@ref).
 

--- a/etc/update_artifacts.jl
+++ b/etc/update_artifacts.jl
@@ -68,7 +68,7 @@ function add_artifacts_for_packages(; pkginfos_path::String = "package-infos.jso
     open(artifacts_toml, "w") do io
         TOML.print(io, artifacts; sorted=true)
     end
-    
+
     return nothing
 end
 

--- a/ext/NemoExt/gap_to_nemo.jl
+++ b/ext/NemoExt/gap_to_nemo.jl
@@ -9,7 +9,7 @@
 ##  SPDX-License-Identifier: LGPL-3.0-or-later
 ##
 
-## conversions of Nemo objects to Oscar objects
+## conversions of GAP objects to Nemo objects
 ## (extends the conversions from GAP.jl's `src/gap_to_julia.jl` and
 ## `src/constructors.jl`, where low level Julia objects are treated)
 

--- a/pkg/JuliaExperimental/README.md
+++ b/pkg/JuliaExperimental/README.md
@@ -1,4 +1,4 @@
-# The GAP package `JuliaExperimental'
+# The GAP package `JuliaExperimental`
 
 JuliaExperimental provides experimental code to test and explore the
 capabilities of the JuliaInterface package, and the general combination of

--- a/pkg/JuliaInterface/README.md
+++ b/pkg/JuliaInterface/README.md
@@ -1,4 +1,4 @@
-# The GAP package `JuliaInterface'
+# The GAP package `JuliaInterface`
 
 JuliaInterface provides an interface to the Julia interpreter.
 

--- a/pkg/JuliaInterface/gap/JuliaInterface.gd
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gd
@@ -394,7 +394,7 @@ DeclareGlobalFunction( "CallJuliaFunctionWithKeywordArguments" );
 #! @EndExampleSession
 #!  Note that in &Julia; any object (not just functions) is potentially callable
 #!  (in fact this is the same as in &GAP;), for example &Julia; types can be
-##  called like functions. This is also fully supported on the GAP side:
+#!  called like functions. This is also fully supported on the &GAP; side:
 #! @BeginExampleSession
 #! gap> smalltype:= Julia.Int32;
 #! <Julia: Int32>

--- a/pkg/JuliaInterface/gap/JuliaInterface.gi
+++ b/pkg/JuliaInterface/gap/JuliaInterface.gi
@@ -69,7 +69,7 @@ InstallMethod( IsBound\.,
     rnam := NameRNam( rnum );
     if IsIdenticalObj(module, Julia) and rnam = "GAP" then
         ## Ensure that the Julia module GAP is always accessible as GAP_jl,
-        ## even while it is still being initialized, and also if it not actually
+        ## even while it is still being initialized, and also if it is not actually
         ## exported to the Julia Main module
         return true;
     fi;

--- a/pkg/JuliaInterface/gap/adapter.gi
+++ b/pkg/JuliaInterface/gap/adapter.gi
@@ -71,7 +71,7 @@ BindGlobal("_JL_RNAM_TO_JULIA_SYMBOL", function(rnam)
     local symbol;
     if ISB_REC(_JL_RNAM_TO_JULIA_SYMBOL_CACHE, rnam) then
         symbol := ELM_REC(_JL_RNAM_TO_JULIA_SYMBOL_CACHE, rnam);
-    else;
+    else
         symbol := Julia.Symbol( NameRNam( rnam ) );
         ASS_REC(_JL_RNAM_TO_JULIA_SYMBOL_CACHE, rnam, symbol);
     fi;

--- a/pkg/JuliaInterface/gap/calls.gi
+++ b/pkg/JuliaInterface/gap/calls.gi
@@ -14,7 +14,7 @@ BindGlobal("_JL_Vector_Any", JuliaType( Julia.Vector, [ Julia.Any ] ));
 BindGlobal("_JL_Dict_Any", JuliaType( Julia.Dict, [ Julia.Symbol, Julia.Any ] ));
 
 ##
-##  We want to use &GAP;'s function call syntax also for certain Julia objects
+##  We want to use GAP's function call syntax also for certain Julia objects
 ##  that are <E>not</E> functions, for example for types such as <C>String</C>.
 ##  Note that also Julia supports this.
 ##

--- a/pkg/JuliaInterface/gap/calls.gi
+++ b/pkg/JuliaInterface/gap/calls.gi
@@ -14,7 +14,7 @@ BindGlobal("_JL_Vector_Any", JuliaType( Julia.Vector, [ Julia.Any ] ));
 BindGlobal("_JL_Dict_Any", JuliaType( Julia.Dict, [ Julia.Symbol, Julia.Any ] ));
 
 ##
-##  We want to use &GAP's function call syntax also for certain Julia objects
+##  We want to use &GAP;'s function call syntax also for certain Julia objects
 ##  that are <E>not</E> functions, for example for types such as <C>String</C>.
 ##  Note that also Julia supports this.
 ##

--- a/pkg/JuliaInterface/gap/convert.gd
+++ b/pkg/JuliaInterface/gap/convert.gd
@@ -96,16 +96,16 @@
 #!  To this end, the interface converts &GAP; immediate integers into
 #!  &Julia; <C>Int64</C> objects, and vice versa.
 #!  However, &GAP; immediate integers on a 64 bit system can only store
-#!  61 bits, so not all <C>Int64</C>objects can be converted into immediate
+#!  61 bits, so not all <C>Int64</C> objects can be converted into immediate
 #!  integers;
 #!  integers exceeding the 61 bits limit are therefore wrapped like any other
 #!  &Julia; object.
 #!  Other &Julia; integer types, like <C>UInt64</C>, <C>Int32</C>,
 #!  are also wrapped by default,
-#!  in order to ensure that conversion round trips do not arbitrary change
+#!  in order to ensure that conversion round trips do not arbitrarily change
 #!  object types.
 #!  <P/>
-#!  All automatic conversions and wrappings are handled on the C functions
+#!  All automatic conversions and wrappings are handled by the C functions
 #!  <C>julia_gap</C> and <C>gap_julia</C>
 #!  in <Package>JuliaInterface</Package>.
 #!  <!-- What is meant by this:
@@ -253,7 +253,7 @@
 #!  </Item>
 #!  <Item>
 #!    <C>IsList</C> to
-#!    <C>Vector{Union{Any,Nothing}}</C> (default),
+#!    <C>Vector{Any}</C> (default),
 #!    <C>Vector{T}</C>,
 #!    <C>Matrix{T}</C>,
 #!    or <C>T &lt;: Tuple</C>,
@@ -284,7 +284,7 @@
 #!  indicating recursive conversion of nested objects.
 #!  The chosen method depends on the &Julia; type of the first argument.
 #!
-#!  The function <Ref Constr="JuliaToGAP" Label="for IsObject, IsObject"/>.
+#!  The function <Ref Constr="JuliaToGAP" Label="for IsObject, IsObject"/>
 #!  takes two or three arguments,
 #!  a &GAP; filter and an object to be converted,
 #!  and optionally the value <K>true</K> indicating recursive conversion
@@ -360,7 +360,7 @@
 #!      <Item>records</Item>
 #!    </Row>
 #!    <Row>
-#!      <Item><C>UnitRange{T}</C>, <C>StepRange{T}</C></Item>
+#!      <Item><C>UnitRange{T}</C>, <C>StepRange{T,S}</C></Item>
 #!      <Item><C>IsRange</C></Item>
 #!      <Item>ranges</Item>
 #!    </Row>
@@ -415,7 +415,7 @@
 #! @Arguments filt, juliaobj[, recursive]
 #! @Returns a &GAP; object in the filter <A>filt</A>
 #! @Description
-#!  Let <A>juliaobj</A> be a Julia object in
+#!  Let <A>juliaobj</A> be a &Julia; object
 #!  for which a conversion to &GAP; is provided,
 #!  in the sense of Section <Ref Sect="Section_Conversion_rules"/>,
 #!  such that the corresponding &GAP; object is in the filter <A>filt</A>.

--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -134,7 +134,7 @@ function initialize(argv::Vector{String})
     f = @cfunction(ThrowObserver, Cvoid, (Cint, ))
     @ccall libgap.RegisterThrowObserver(f::Ptr{Cvoid})::Cvoid
 
-    # detect if GAP quit early (e.g due `-h` or `-c` command line arguments)
+    # detect if GAP quit early (e.g. due to `-h` or `-c` command line arguments)
     # TODO: restrict this to "standalone" mode?
     # HACK: GAP resp. libgap currently offers no good way to detect this
     # (perhaps this could be a return value for GAP_Initialize?),
@@ -204,7 +204,7 @@ function __init__()
     global JuliaInterface_path = Setup.locate_JuliaInterface_so()
 
     roots = [
-            # GAP root for the the actual GAP library, from GAP_lib_jll
+            # GAP root for the actual GAP library, from GAP_lib_jll
             abspath(GAP_lib_jll.find_artifact_dir(), "share", "gap"),
             # GAP root into which PackageManager installs packages by default
             Packages.gap_packages_rootdir(),

--- a/src/GAP_pkg.jl
+++ b/src/GAP_pkg.jl
@@ -78,7 +78,7 @@ function setup_overrides()
         pkg = pkg[9:end-4]
 
         # Crude heuristic: if the JLL has a `bin` directory then we assume it
-        # contains executables the packages uses; otherwise assume it contains
+        # contains executables the package uses; otherwise assume it contains
         # a kernel extension `lib/gap/BLAH.so`.
         #
         # This fails if a package has both executables and a kernel extension.

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -109,7 +109,7 @@ with the following meaning.
   and `false` otherwise.
 - If the first entry is `true`, then the second entry is bound to the
   result of the statement if there was one, and unbound otherwise.
-- The third entry is unbound if an error occured,
+- The third entry is unbound if an error occurred,
   `true` if the statement ends in a double semicolon,
   and `false` otherwise.
 - The fourth entry currently is always unbound.
@@ -177,7 +177,7 @@ and the return values of the command(s).
 
 In general we recommend to avoid using `evalstr`, but it sometimes can
 be a useful escape hatch to access GAP functionality that is otherwise
-impossible to difficult to reach. But in most typical scenarios it
+impossible or difficult to reach. But in most typical scenarios it
 should not be necessary to use it at all.
 
 Instead, use `GapObj` or `GAP.Obj` for constructing GAP objects
@@ -407,7 +407,7 @@ end
 function _call_gap_func(func::GapObj, a1)
     fptr = GET_FUNC_PTR(func, 1)
     ret = @ccall $fptr(
-        func::GapObj, 
+        func::GapObj,
         _JULIA_TO_GAP(a1)::Ptr{Cvoid},
     )::Ptr{Cvoid}
     return ret

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -101,7 +101,7 @@ ERROR: InexactError: Int64(15511210043330985984000000)
 
 Return the rational converted from
 the [GAP integer](GAP_ref(ref:Integers)) or
-the [GAP rational](GAP_ref(ref:Rationals)) `obj`,
+the [GAP rational](GAP_ref(ref:Rationals)) `obj`.
 
 # Examples
 ```jldoctest

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -87,8 +87,8 @@ function recursion_info_g(::Type{T}, obj, ret_val, ::Val{recursive}, recursion_d
     else
         rec_dict = recursion_dict
     end
-    
-   if rec_dict !== nothing
+
+    if rec_dict !== nothing
         # We assume that `obj` is not yet cached.
         rec_dict[obj] = ret_val
     end

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -377,7 +377,7 @@ end
 Try to convert the object `x` to a Julia object of type `type`.
 If `x` is a `GapObj` then the conversion rules are defined in
 [the manual of the GAP package JuliaInterface](assets/html/JuliaInterface/chap0_mj.html).
-If `x` is another `GAP.Obj` (for example a `Int64`) then the result is
+If `x` is another `GAP.Obj` (for example an `Int64`) then the result is
 defined in Julia by `type`.
 
 For GAP lists and records, it makes sense to either convert also the subobjects

--- a/src/julia_to_gap.jl
+++ b/src/julia_to_gap.jl
@@ -127,7 +127,7 @@ GAP.@install GapObj(x::Bool) = x    # Default for actual GAP objects is to do no
 ## We do not want to track conversion for any concrete integer types.
 @install GapObj(x::Integer) = x in -1<<60:(1<<60-1) ? Int64(x) : GapObj(BigInt(x))
 
-## Small integers types always fit into GAP immediate integers, and thus are
+## Small integer types always fit into GAP immediate integers, and thus are
 ## represented by Int64 on the Julia side.
 GAP.@install GapObj(x::Int64) = x
 GAP.@install GapObj(x::Int32) = Int64(x)

--- a/src/lowlevel.jl
+++ b/src/lowlevel.jl
@@ -74,7 +74,7 @@ size, reading the bag header only once.
 Calling `ADDR_OBJ`, `TNUM_OBJ` and `SIZE_OBJ` separately chases the same two
 pointers again for each of them. LLVM merges those accesses in simple cases,
 but not once the caller is inlined into a loop such as the one in
-`collect_to!`; a caller that needs more than one of the three values is three
+`_collect_list!`; a caller that needs more than one of the three values is three
 times slower there.
 """
 function ADDR_TNUM_SIZE_OBJ(obj::GapObj)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -39,7 +39,7 @@ via `@gap(SymmetricGroup)`, then calls that function with the argument `3`.
 Due to Julia's way of handing over arguments into the code of macros,
 not all expressions representing valid GAP code can be processed.
 For example, the GAP syntax of permutations consisting of more than one cycle
-cause problems, as well as the GAP syntax of non-dense lists.
+causes problems, as well as the GAP syntax of non-dense lists.
 
 ```
 julia> @gap (1,2,3)
@@ -305,7 +305,7 @@ macro gapattribute(ex)
         """
             $($settername)(x, v)
 
-        Set the value for `$($julianame)(x)` to `v` if it has't been
+        Set the value for `$($julianame)(x)` to `v` if it hasn't been
         set already.
         """
         GAP.@gapwrap $settername($juliaarg,v) = GAP.Globals.$gapsetter($gaparg,v)::Nothing
@@ -453,7 +453,7 @@ When applied to a unary method definition for the function `GapObj`,
 with argument of type `T`,
 this macro installs instead a three argument method for
 `GAP.GapObj_internal`, with second argument of type
-`GAP.GapCacheDict` and third argument of type `Bool`.
+`GAP.GapCacheDict` and third argument of type `Val{recursive}`.
 
 This way, the intended `GapObj(x::T)` method becomes available,
 and additionally its code is applicable in recursive calls,
@@ -495,7 +495,7 @@ macro install(ex)
     # assemble the method definition again
     ex = MacroTools.combinedef(def_dict)
 
-    # install the `needs_conversion_tracking` method that returns `false`
+    # install the `_needs_tracking_julia_to_gap` method that returns `false`
     x = def_dict[:args][1]
     if x isa Symbol || !(x.head == :(::) && length(x.args) == 2)
       error("argument of GapObj needs a type annotation")

--- a/src/packages.jl
+++ b/src/packages.jl
@@ -256,7 +256,7 @@ In all other cases the newest released version of the package will get
 installed.
 
 Return `true` if the installation is successful or if
-(a version compatible with `version`) of the package was already installed,
+a version of the package compatible with `version` was already installed,
 and `false` otherwise.
 
 The function uses [the function `InstallPackage` from GAP's package

--- a/src/prompt.jl
+++ b/src/prompt.jl
@@ -16,15 +16,15 @@ Start a GAP prompt where you can enter GAP commands as in a regular GAP
 session. This prompt can be left as any GAP prompt by either entering `quit;`
 or pressing ctrl-D, which returns to the Julia prompt.
 
-This GAP prompt allows to quickly switch between writing Julia and GAP code in
+This GAP prompt allows one to quickly switch between writing Julia and GAP code in
 a session where all data is shared.
 """
 function prompt()
     # save the current SIGINT handler
     # (we pass NULL as signal handler; strictly speaking, we should be passing `SIG_DFL`
-    # but it's not clearly how to access this from here, and anyway on the list
+    # but it's not clear how to access this from here, and anyway on the list
     # of platforms we support, it is NULL)
-    old_sigint = @ccall signal(Base.SIGINT::Cint, C_NULL::Ptr{Cvoid})::Ptr{Cvoid} 
+    old_sigint = @ccall signal(Base.SIGINT::Cint, C_NULL::Ptr{Cvoid})::Ptr{Cvoid}
 
     # install GAP's SIGINT handler
     @ccall libgap.SyInstallAnswerIntr()::Cvoid
@@ -66,7 +66,7 @@ function run_session()
 
     # Reset the GAP kernel variable `UserHasQUIT` so that GAP's exit handlers
     # can run. This is necessary if the user passed a file on the command line
-    # that has a `QUIT` statements, thus ending GAP during ProcessInitFiles,
+    # that has a `QUIT` statement, thus ending GAP during ProcessInitFiles,
     # hence before the first SESSION.
     #
     # Note that in this case, even our manual call to SESSION above actually

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -154,7 +154,7 @@ function create_sysinfo_gap_and_gac(dir::String)
     sysinfo["GAP"] = joinpath(dir, "bin", "gap.sh")
     sysinfo["GAC"] = joinpath(dir, "gac")
 
-    # the following sysinfo entries are intentional left as they are:
+    # the following sysinfo entries are intentionally left as they are:
     # - GAParch
     # - GAC_CFLAGS
     # - GAC_LDFLAGS
@@ -193,9 +193,9 @@ function build_JuliaInterface(builddir::String)
     @info "Compiling JuliaInterface ..."
 
     # run code in julia-config.jl to determine compiler and linker flags for Julia;
-    # remove apostrophes, they mess up quoting when used in shell code(although
+    # remove apostrophes, they mess up quoting when used in shell code (although
     # they are fine inside of Makefiles); this could cause problems if any
-    # paths involve spaces, but then we likely will haves problem in other
+    # paths involve spaces, but then we likely will have problems in other
     # places; in any case, if anybody ever cares about this, we can work on
     # finding a better solution.
     JULIA_CFLAGS = filter(c -> c != '\'', cflags())
@@ -301,7 +301,7 @@ function create_gap_sh(dstdir::String, dstname::String="gap.sh";
         @info "Generating custom Julia project ..."
         gaproot_gapjl = abspath(@__DIR__, "..")
         # workaround: pre-populate Project.toml, otherwise the `run` command
-        # afterwards complaints about Pkg not being in the environment.
+        # afterwards complains about Pkg not being in the environment.
         write(joinpath(projectdir, "Project.toml"),
                 """
                 [deps]
@@ -321,7 +321,7 @@ function create_gap_sh(dstdir::String, dstname::String="gap.sh";
     write(gap_sh_path,
         """
         #!/bin/sh
-        # This is a a Julia script which also is a valid bash script; if executed by
+        # This is a Julia script which also is a valid bash script; if executed by
         # bash, it will execute itself by invoking `julia`. Of course this only works
         # right if `julia` exists in the PATH and is the "correct" julia executable.
         # But you can always instead load this file as if it was a .jl file via any

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -131,7 +131,7 @@ create_type(T::Type, paras::Vector) = T{paras...}
 ## convenience function
 
 function Base.functionloc(f::GapObj)
-    GAP.Globals.IsFunction(f) || throw(ArgumentError("`f` must be GAP function"))
+    GAP.Globals.IsFunction(f) || throw(ArgumentError("`f` must be a GAP function"))
     file = GAP.Globals.FilenameFunc(f)::GapObj
     if file == GAP.Globals.fail
         error("could not determine file of GAP function definition")

--- a/test/NemoExt/nemo_to_gap.jl
+++ b/test/NemoExt/nemo_to_gap.jl
@@ -140,7 +140,7 @@ import AbstractAlgebra
     F, z = cyclotomic_field(5)
     e5 = GAP.Globals.E(5)
     @test GAP.Obj(z^2+z+1) == e5^2 + e5 + 1
-    
+
     # not supported conversions
     R, x = polynomial_ring(QQ, :x; cached=false)
     F, z = number_field(x^2 + 5)
@@ -150,7 +150,7 @@ import AbstractAlgebra
   @testset "matrices over a cyclotomic field" begin
     F, z = cyclotomic_field(5)
     @test GAP.Obj(matrix(F, 2, 2, [z^0, z, z^2, z^3])) == GAP.evalstr("[ [ 1, E(5) ], [ E(5)^2, E(5)^3 ] ]")
-    
+
     # not supported conversions
     R, x = polynomial_ring(QQ, :x; cached=false)
     F, z = number_field(x^2 + 5)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -185,7 +185,7 @@ end
 end
 
 @testset "gapcalls border cases" begin
-    # check argument validation of internal helprs
+    # check argument validation of internal helpers
     @test_throws MethodError GAP.slow_call_gap_func_nokw(1,1)
     @test_throws ErrorException GAP.slow_call_gap_func_nokw(GAP.Globals.SymmetricGroup,1)
     @test GAP.slow_call_gap_func_nokw(GAP.Globals.SymmetricGroup,(1,)) isa Ptr


### PR DESCRIPTION
Also correct stale references to renamed functions and files, a `##` comment line in JuliaInterface.gd that hid part of a sentence from the generated manual, and outdated type names in convert.gd.

Co-authored-by: Claude Fable 5.1 <noreply@anthropic.com>