### PR TITLE
Stop recursing in non-recursive record conversion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
 - Avoid boxing immediate integers in wrapped GAP calls (reduces
   allocations and improves performance)
 - Avoid `Core.Box` allocations in closures
+- Fix non-recursive conversion of GAP records to `Dict{Symbol,T}`: nested
+  entries are now treated like those of lists, i.e. no further conversion
+  happens once the target type is reached
 
 ## Version 0.17.5 (released 2026-08-24)
 

--- a/src/gap_to_julia.jl
+++ b/src/gap_to_julia.jl
@@ -301,7 +301,7 @@ function gap_to_julia_internal(
       current_obj = getproperty(obj, key)
       if (rec || !(current_obj isa T)) && !isbitstype(typeof(current_obj))
         ret_val[key] =
-          gap_to_julia_internal(T, current_obj, recursion_dict, Val(true))
+          gap_to_julia_internal(T, current_obj, recursion_dict, BoolVal(rec))
       else
         ret_val[key] = current_obj
       end

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -333,6 +333,14 @@
     @test isa(y[:a], GAP.Obj)
     @test isa(y[:b], GAP.Obj)
     @test y[:a] == y[:c]
+
+    # Non-recursive conversion stops once the target type is reached,
+    # as it does for lists.
+    x = GAP.evalstr("rec( a:= [ [ 1, 2 ] ] )")
+    y = GAP.gap_to_julia(Dict{Symbol,Vector{Any}}, x)
+    @test isa(y[:a][1], GapObj)
+    y = GAP.gap_to_julia(Dict{Symbol,Vector{Any}}, x; recursive = true)
+    @test isa(y[:a][1], Vector)
   end
 
   @testset "Julia Functions" begin


### PR DESCRIPTION
The `Dict{Symbol,T}` method of `gap_to_julia_internal` converted nested entries with `Val(true)` regardless of the `recursive` flag, unlike the list, matrix and set methods. This contradicted the documented rule that non-recursive conversion stops once the target type is reached.

Co-authored-by: Claude Fable 5.1 <noreply@anthropic.com>