### PR TITLE
Make gap.sh honor use_active_project

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,7 @@
 - Avoid boxing immediate integers in wrapped GAP calls (reduces
   allocations and improves performance)
 - Avoid `Core.Box` allocations in closures
-- Fix the `gap.sh` script that GAP.jl generates for building GAP packages
-  to run in the Julia project that was active when it was created, instead
-  of falling back to the default environment
+- Several "behind the scenes" changes that should be invisible for most users
 - Fix non-recursive conversion of GAP records to `Dict{Symbol,T}`: nested
   entries are now treated like those of lists, i.e. no further conversion
   happens once the target type is reached

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
 - Avoid boxing immediate integers in wrapped GAP calls (reduces
   allocations and improves performance)
 - Avoid `Core.Box` allocations in closures
+- Fix the `gap.sh` script that GAP.jl generates for building GAP packages
+  to run in the Julia project that was active when it was created, instead
+  of falling back to the default environment
 
 ## Version 0.17.5 (released 2026-08-24)
 

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -317,6 +317,10 @@ function create_gap_sh(dstdir::String, dstname::String="gap.sh";
         push!(julia_cmd, "--code-coverage=$(code_coverage)")
     end
 
+    # A script for the active project refers to it by path; otherwise the
+    # project sits next to the script and moves with it.
+    project = use_active_project ? "\"$(projectdir)\"" : "\$(dirname \"\$0\")"
+
     gap_sh_path = joinpath(dstdir, dstname)
     write(gap_sh_path,
         """
@@ -333,7 +337,7 @@ function create_gap_sh(dstdir::String, dstname::String="gap.sh";
         else
             READ_STARTUP_FILE="no"
         fi
-        exec $(join(julia_cmd, " ")) --startup-file=\$READ_STARTUP_FILE --project=\$(dirname \"\$0\") -i -- \"\$0\" "\$@"
+        exec $(join(julia_cmd, " ")) --startup-file=\$READ_STARTUP_FILE --project=$(project) -i -- \"\$0\" "\$@"
         =#
 
         # pass command line arguments to GAP.jl via a small hack

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -19,6 +19,12 @@
     else
       @test !occursin("--code-coverage", gap_sh)
     end
+
+    # the script must run in the active project, not in its own directory
+    outfile = joinpath(tmpdir, "active_project.txt")
+    gap_sh_cmd = `$(joinpath(tmpdir, "gap.sh")) -A -b --quitonbreak --norepl -c "FileString(\"$(outfile)\", JuliaToGAP(IsString, Julia.Base.active_project()));"`
+    run(pipeline(gap_sh_cmd; stdout=devnull))
+    @test read(outfile, String) == Base.active_project()
   end
 
   mktempdir() do tmpdir


### PR DESCRIPTION
`create_gap_sh(dir; use_active_project=true)` computed the project directory but the generated script still used `--project=$(dirname "$0")`. As `dir` contains no Project.toml in that case, Julia fell back to the default environment, which need not contain GAP.jl. The script used by PackageManager to build GAP packages is generated this
way.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
