### PR TITLE
Miscellaneous fixes, tweaks, cleanup

### DIFF
--- a/etc/update_version.sh
+++ b/etc/update_version.sh
@@ -27,12 +27,17 @@ git diff-index --quiet HEAD -- || error "uncommitted changes detected"
 echo "Setting version to $relvers, released $reldate_iso"
 
 # check that CHANGES.md has correct entry
-if egrep -q "^## Version ${relvers}(-DEV)? " CHANGES.md ; then
+if grep -Eq "^## Version ${relvers}(-DEV)? " CHANGES.md ; then
     perl -pi -e "s;^## Version ${relvers}(-DEV)? \([^)]+\)$;## Version ${relvers} (released ${reldate_iso});" CHANGES.md
-elif [[ ${relvers} = *-DEV ]] ; then
-    perl -pi -e "s;^(# Changes in GAP.jl)$;\1\n\n## Version ${relvers} (released YYYY-MM-DD);" CHANGES.md
 else
-    error "Error, CHANGES.md has no section for version ${relvers}"
+    case "${relvers}" in
+        *-DEV)
+            perl -pi -e "s;^(# Changes in GAP.jl)$;\1\n\n## Version ${relvers} (released YYYY-MM-DD);" CHANGES.md
+            ;;
+        *)
+            error "Error, CHANGES.md has no section for version ${relvers}"
+            ;;
+    esac
 fi
 
 # update version in several files

--- a/pkg/JuliaExperimental/PackageInfo.g
+++ b/pkg/JuliaExperimental/PackageInfo.g
@@ -58,9 +58,10 @@ Persons := [
 
 PackageWWWHome := "https://github.com/oscar-system/GAP.jl",
 
-ArchiveURL     := Concatenation( ~.PackageWWWHome, "JuliaExperimental-", ~.Version ),
-README_URL     := Concatenation( ~.PackageWWWHome, "README" ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
+# GAP.jl does not publish separate archives of this package.
+ArchiveURL     := Concatenation( ~.PackageWWWHome, "/JuliaExperimental-", ~.Version ),
+README_URL     := Concatenation( ~.PackageWWWHome, "/raw/v", ~.Version, "/pkg/JuliaExperimental/README.md" ),
+PackageInfoURL := Concatenation( ~.PackageWWWHome, "/raw/v", ~.Version, "/pkg/JuliaExperimental/PackageInfo.g" ),
 
 ArchiveFormats := ".tar.gz",
 

--- a/pkg/JuliaInterface/PackageInfo.g
+++ b/pkg/JuliaInterface/PackageInfo.g
@@ -75,12 +75,13 @@ Persons := [
 ],
 
 SourceRepository := rec( Type := "git", URL := "https://github.com/oscar-system/GAP.jl" ),
-IssueTrackerURL := "https://github.com/oscar-system/GAP.jl",
-PackageWWWHome := "https://github.com/oscar-system/GAP.jl/issues",
+IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
+PackageWWWHome := ~.SourceRepository.URL,
 
-ArchiveURL     := Concatenation( ~.PackageWWWHome, "JuliaInterface-", ~.Version ),
-PackageInfoURL := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
-README_URL     := Concatenation( ~.PackageWWWHome, "README.md" ),
+# GAP.jl does not publish separate archives of this package.
+ArchiveURL     := Concatenation( ~.PackageWWWHome, "/JuliaInterface-", ~.Version ),
+PackageInfoURL := Concatenation( ~.PackageWWWHome, "/raw/v", ~.Version, "/pkg/JuliaInterface/PackageInfo.g" ),
+README_URL     := Concatenation( ~.PackageWWWHome, "/raw/v", ~.Version, "/pkg/JuliaInterface/README.md" ),
 
 ArchiveFormats := ".tar.gz",
 

--- a/pkg/JuliaInterface/tst/testall.g
+++ b/pkg/JuliaInterface/tst/testall.g
@@ -15,37 +15,6 @@ LoadPackage("JuliaInterface");
 dir:=DirectoriesPackageLibrary("JuliaInterface", "tst");
 Assert(0, dir <> fail);
 
-CompareUpToWhitespaceAndMatches:= function( pairs )
-    return function( a, b )
-      local pair;
-
-      a:= ShallowCopy( a );
-      b:= ShallowCopy( b );
-      for pair in pairs do
-        if ForAll( [ a, b ],
-               str -> ForAny( pair,
-                          x -> PositionSublist( str, x ) <> fail ) ) then
-          if pair[1] <> "" then
-            a:= ReplacedString( a, pair[1], "" );
-            b:= ReplacedString( b, pair[1], "" );
-          fi;
-          if pair[2] <> "" then
-            a:= ReplacedString( a, pair[2], "" );
-            b:= ReplacedString( b, pair[2], "" );
-          fi;
-        fi;
-      od;
-
-      return TEST.compareFunctions.uptowhitespace( a, b );
-    end;
-end;
-
-# Several Julia types are shown differently in Julia 1.6.0-DEV
-# and older Julia versions.
-compare:= CompareUpToWhitespaceAndMatches(
-    [ [ "Vector{Any}", "Vector{Any}" ],
-      [ "Maybe you forgot to use an operator such as *, ^, %, / etc. ?", "" ] ] );
-
 TestDirectory(dir, rec(exitGAP := true,
-                       testOptions := rec(compareFunction := compare) ) );
+                       testOptions := rec(compareFunction := "uptowhitespace") ) );
 FORCE_QUIT_GAP(1);

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -193,7 +193,7 @@ julia> Cuchar(val)
 """
 function Base.Cuchar(obj::GapObj)
     GAP_IS_CHAR(obj) && return trunc(Cuchar, Wrappers.INT_CHAR(obj))
-    GAP_IS_INT(obj) && return throw(InexactError(nameof(Cuchar), Cuchar, obj))
+    GAP_IS_INT(obj) && throw(InexactError(nameof(Cuchar), Cuchar, obj))
     throw(ConversionError(obj, Cuchar))
 end
 

--- a/src/doctestfilters.jl
+++ b/src/doctestfilters.jl
@@ -9,25 +9,11 @@
 ##  SPDX-License-Identifier: LGPL-3.0-or-later
 ##
 
-# Define some replacements which are applied in `docs/make.jl` and `test/testmanual.jl`.
-# The idea is that the `jldoctest`ed examples in the source files
-# have the format that fits to the "current" Julia,
-# and that other Julia versions (such as Julia nightly) may show different formats.
-# Each regular expression in `GAP_doctestfilters` gets applied to both the
-# expected output and the output obtained in the actual evaluation,
-# before the comparison of the two values, and matching text gets replaced
-# by the empty string.
-GAP_doctestfilters = Regex[
-    r"BitVector|BitArray\{1\}",
-    r"Dict\{Symbol, Any\}|Dict\{Symbol,Any\}",
-    r"Dict\{Symbol, Vector\{Int64\}\}|Dict\{Symbol,Array\{Int64,1\}\}",
-    r"Dict\{Symbol, Int64\}|Dict\{Symbol,Int64\}",
-    r"Matrix\{Int64\}|Array\{Int64,2\}",
-    r"StepRange\{Int8, Int8\}|StepRange\{Int8,Int8\}",
-    r"Vector\{Any\}|Array\{Any,1\}",
-    r"Vector\{Int64\}|Array\{Int64,1\}",
-    r"Vector\{UInt8\}|Array\{UInt8,1\}",
-]
+# Regular expressions that `docs/make.jl` and `test/doctest.jl` apply to both
+# the expected and the actual output of `jldoctest` blocks before comparing
+# them; matching text is removed on both sides. Use this when some supported
+# Julia version prints a type occurring in the examples differently.
+GAP_doctestfilters = Regex[]
 
 GAP_docs_pages = [
         "index.md",

--- a/test/NemoExt/nemo_to_gap.jl
+++ b/test/NemoExt/nemo_to_gap.jl
@@ -57,13 +57,13 @@ import AbstractAlgebra
 
   @testset "QQFieldElem" begin
     # small (GAP) integer
-    x = ZZRingElem(17)
+    x = QQFieldElem(17)
     val = 17
     @test GapObj(x) == val
     @test GAP.Obj(x) == val
 
     # large GAP integer
-    x = ZZRingElem(2)^65
+    x = QQFieldElem(2)^65
     val = GAP.evalstr("2^65")
     @test GapObj(x) == val
     @test GAP.Obj(x) == val

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -94,6 +94,9 @@
     x = GAP.evalstr("(1,2,3)")
     @test_throws GAP.ConversionError Char(x)
     @test_throws GAP.ConversionError Cuchar(x)
+
+    x = GAP.evalstr("2^100")
+    @test_throws InexactError Cuchar(x)
   end
 
   @testset "Strings" begin


### PR DESCRIPTION
- **Fix URLs in PackageInfo.g of the bundled packages**
- **Drop compatibility code for Julia older than 1.10**
- **Make update_version.sh POSIX sh compliant**
- **Fix copy-paste in QQFieldElem conversion test**
- **Remove redundant return before throw in Cuchar**

Co-authored-by: Claude Fable 5.1 <noreply@anthropic.com>