### PR TITLE
Version 0.17.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes in GAP.jl
 
-## Version 0.17.6-DEV (released YYYY-MM-DD)
+## Version 0.17.6 (released 2026-09-10)
 
 - Speed up `collect` and list comprehensions for GAP lists
 - Avoid boxing immediate integers in wrapped GAP calls (reduces

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GAP"
 uuid = "c863536a-3901-11e9-33e7-d5cd0df7b904"
-version = "0.17.5"
+version = "0.17.6"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/gap/systemfile.g
+++ b/gap/systemfile.g
@@ -39,7 +39,7 @@ end);
     # early enough for being required by other GAP packages,
     # and such that it is available when user files get read
     # via the GAP command line.
-    deps := [ [ "JuliaInterface", ">=0.17.5" ] ];
+    deps := [ [ "JuliaInterface", ">=0.17.6" ] ];
     if not IsBound(GAPInfo.KernelInfo.ENVIRONMENT.GAP_BARE_DEPS) then
         APPEND_LIST_INTR( deps, GAPInfo.Dependencies.NeededOtherPackages );
     fi;

--- a/pkg/JuliaExperimental/PackageInfo.g
+++ b/pkg/JuliaExperimental/PackageInfo.g
@@ -17,8 +17,8 @@ SetPackageInfo( rec(
 
 PackageName := "JuliaExperimental",
 Subtitle := "Experimental code for the GAP Julia integration",
-Version := "0.17.5",
-Date := "24/08/2026", # dd/mm/yyyy format
+Version := "0.17.6",
+Date := "10/09/2026", # dd/mm/yyyy format
 License := "LGPL-3.0-or-later",
 
 Persons := [

--- a/pkg/JuliaInterface/PackageInfo.g
+++ b/pkg/JuliaInterface/PackageInfo.g
@@ -18,8 +18,8 @@ SetPackageInfo( rec(
 
 PackageName := "JuliaInterface",
 Subtitle := "Interface to Julia",
-Version := "0.17.5",
-Date := "24/08/2026", # dd/mm/yyyy format
+Version := "0.17.6",
+Date := "10/09/2026", # dd/mm/yyyy format
 License := "LGPL-3.0-or-later",
 
 Persons := [


### PR DESCRIPTION
@fingolfin said they wanted to have a GAP.jl-release soon-ish to get all of the recent performance tweaks to users. And since there are no open PRs left (except for https://github.com/oscar-system/GAP.jl/pull/1422 which is ready to be merged), I think we are ready for the release.